### PR TITLE
Add aarch64 machine slave to build flang with clang-8

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1526,6 +1526,22 @@ def _get_flang_builders():
          ),
          'category' : 'flang'},
 
+        {'name': "flang-aarch64-ubuntu-clang",
+         'slavenames':["flang-aarch64-ubuntu-clang-build"],
+         'builddir':"flang-aarch64-ubuntu-clang",
+         'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                        clean=True,
+                        depends_on_projects=['llvm','mlir','clang','flang'],
+                        extra_configure_args=[
+                            "-DLLVM_TARGETS_TO_BUILD=AArch64",
+                            "-DCMAKE_C_COMPILER=/usr/bin/clang-8",
+                            "-DCMAKE_CXX_COMPILER=/usr/bin/clang++-8",
+                            "-DLLVM_INSTALL_UTILS=ON",
+                            "-DCMAKE_CXX_STANDARD=17",
+                        ],
+         ),
+         'category' : 'flang'},
+
         {'name': "flang-x86_64-linux",
          'slavenames':["nersc-flang"],
          'builddir':"flang-x86_64-linux",

--- a/buildbot/osuosl/master/config/slaves.py
+++ b/buildbot/osuosl/master/config/slaves.py
@@ -237,5 +237,6 @@ def get_build_slaves():
         create_slave("polly-x86_64-fdcserver", properties={'jobs': 8, 'loadaverage': 8}, max_builds=1),
 
         create_slave("flang-aarch64-ubuntu-build"),
+        create_slave("flang-aarch64-ubuntu-clang-build"),
         create_slave("nersc-flang"),
         ]


### PR DESCRIPTION
This patch adds another slave to build flang. It uses clang-8 and clang++-8
Signed-off-by: Caroline Concatto <caroline.concatto@arm.com>