### PR TITLE
Set up Vulkan compute in mlir-nvidia docker

### DIFF
--- a/buildbot/google/docker/buildbot-mlir-nvidia/Dockerfile
+++ b/buildbot/google/docker/buildbot-mlir-nvidia/Dockerfile
@@ -33,6 +33,15 @@ RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/nul
     apt-get update ;\
     apt-get install -y cmake
 
+# Get the Vulkan SDK from LunarG. The CUDA meta package already pulls in NVIDIA
+# Vulkan ICD.
+RUN wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc 2>/dev/null | \
+       apt-key add - ;\
+    wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.2.141-bionic.list \
+       http://packages.lunarg.com/vulkan/1.2.141/lunarg-vulkan-1.2.141-bionic.list;\
+    apt-get update ;\
+    apt-get install -y vulkan-sdk
+
 # install (old) build bot version
 # this version of build bot requires python2!
 RUN pip install buildbot-slave==0.8.11

--- a/buildbot/google/docker/buildbot-mlir-nvidia/run.sh
+++ b/buildbot/google/docker/buildbot-mlir-nvidia/run.sh
@@ -22,7 +22,9 @@ WORKER_PASSWORD=$(cat /secrets/token)
   lsb_release -d | cut -f 2- ; \
   clang --version | head -n1 ; \
   ld.lld-8 --version ; \
-  cmake --version | head -n1 
+  cmake --version | head -n1  \
+  vulkaninfo 2>/dev/null | grep "Vulkan Instance" \
+  vulkaninfo 2>/dev/null | grep "apiVersion" | cut -d= -f2 | awk '{printf "NVIDIA Vulkan ICD Version: " $2 "\n"}'
 ) > ${WORKER_NAME}/info/host 
 
 # It looks like GKE sometimes deploys the container before the NVIDIA drivers 


### PR DESCRIPTION
This commit changes the mlir-nvidia docker to additionally install
Vulkan SDK. NVIDIA's Vulkan ICD is already installed as part of
the CUDA meta package.

Also enables running Vulkan tests in mlir-nvidia build workers.