### PR TITLE
Support compatibility with buildbot 2.10.

### DIFF
--- a/zorg/buildbot/commands/LitTestCommand.py
+++ b/zorg/buildbot/commands/LitTestCommand.py
@@ -4,7 +4,7 @@ from os.path import basename
 from buildbot.process.results import SUCCESS
 from buildbot.process.results import FAILURE
 
-from buildbot.steps.shell import Test
+from buildbot.steps.shell import TestNewStyle
 
 from buildbot.process.logobserver import LogLineObserver
 
@@ -140,7 +140,7 @@ class LitLogObserver(LogLineObserver):
         self.resultCounts[code] = self.resultCounts.get(code, 0) + 1
         return
 
-class LitTestCommand(Test):
+class LitTestCommand(TestNewStyle):
   resultNames = {'FAIL':'unexpected failures',
                  'PASS':'expected passes',
                  'XFAIL':'expected failures',
@@ -159,8 +159,6 @@ class LitTestCommand(Test):
     super().__init__(*args, **kwargs)
     self.maxLogs = int(max_logs)
     self.logObserver = LitLogObserver(self.maxLogs, parseSummaryOnly)
-    self.addFactoryArguments(max_logs=max_logs)
-    self.addFactoryArguments(parseSummaryOnly=parseSummaryOnly)
     self.addLogObserver('stdio', self.logObserver)
 
   def evaluateCommand(self, cmd):
@@ -175,7 +173,7 @@ class LitTestCommand(Test):
     return SUCCESS
 
   def describe(self, done=False):
-    description = Test.describe(self, done) or list()
+    description = TestNewStyle.describe(self, done) or list()
     for name, count in self.logObserver.resultCounts.items():
         if name in self.resultNames:
             description.append('{0} {1}'.format(count, self.resultNames[name]))


### PR DESCRIPTION
This removes the deprecation warning and also removes now
non-existing method addFactoryArguments (they were not doing
anything anyway for some time).