### PR TITLE
[libc++] Remove build bots that are handled on BuildKite now

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1327,41 +1327,6 @@ all = [
 
 # Libc++ builders.
 
-    {'name': 'libcxx-libcxxabi-x86_64-linux-debian',
-    'tags'  : ["libcxx"],
-    'workernames': ['gribozavr4'],
-    'builddir': 'libcxx-libcxxabi-x86_64-linux-debian',
-    'factory': LibcxxAndAbiBuilder.getLibcxxAndAbiBuilder(
-                    env={'CC': 'clang', 'CXX': 'clang++'},
-                    lit_extra_args=['--shuffle'],
-                    check_libcxx_abilist=True)},
-
-    {'name' : 'libcxx-libcxxabi-x86_64-linux-debian-noexceptions',
-    'tags'  : ["libcxx"],
-    'workernames' : ['gribozavr4'],
-    'builddir': 'libcxx-libcxxabi-x86_64-linux-debian-noexceptions',
-    'factory' : LibcxxAndAbiBuilder.getLibcxxAndAbiBuilder(
-                    env={'CC': 'clang', 'CXX': 'clang++'},
-                    use_cache='Generic-noexceptions.cmake',
-                    lit_extra_args=['--shuffle'])},
-
-    {'name' : 'libcxx-libcxxabi-libunwind-x86_64-linux-debian',
-    'tags'  : ["libcxx"],
-    'workernames' : ['gribozavr4'],
-    'builddir': 'libcxx-libcxxabi-libunwind-x86_64-linux-debian',
-    'factory' : LibcxxAndAbiBuilder.getLibcxxAndAbiBuilder(
-             env={'CC': 'clang', 'CXX': 'clang++'},
-             cmake_extra_opts={'LIBCXXABI_USE_LLVM_UNWINDER': 'ON'},
-             lit_extra_args=['--shuffle'])},
-
-    {'name' : 'libcxx-libcxxabi-singlethreaded-x86_64-linux-debian',
-    'tags'  : ["libcxx"],
-    'workernames' : ['gribozavr4'],
-    'builddir': 'libcxx-libcxxabi-singlethreaded-x86_64-linux-debian',
-    'factory' : LibcxxAndAbiBuilder.getLibcxxAndAbiBuilder(
-                    env={'CC': 'clang', 'CXX': 'clang++'},
-                    use_cache='Generic-singlethreaded.cmake')},
-
     {'name' : 'libcxx-libcxxabi-libunwind-ppc-aix',
     'tags'  : ["libcxx"],
     'workernames' : ['aix-ppc-libcxx'],
@@ -1613,7 +1578,7 @@ all = [
                         'LD': 'lld'
                     })},
 
-# Builders responsible building Sphinix documentation.
+# Builders responsible building Sphinx documentation.
 
     {'name' : "llvm-sphinx-docs",
     'tags'  : ["llvm", "doc"],


### PR DESCRIPTION
Those builders have been failing for months because they use a version
of Clang that we don't actively support anymore. Furthermore, all those
configurations (single-threaded, no exceptions, with LLVM's unwinder)
are being tested on BuildKite.

At this point, I think those builders are only adding noise and using
resources that could be repurposed to other tasks, so I think it is
reasonable to remove them.