### PR TITLE
[lldb] Actually let the matrix bot test something

### DIFF
--- a/zorg/jenkins/monorepo_build.py
+++ b/zorg/jenkins/monorepo_build.py
@@ -566,8 +566,7 @@ def lldb_cmake_builder(target, variant=None):
         # if we have a host compiler available.
         if conf.CC():
             cmake_cmd.extend([
-                '-DLLDB_TEST_C_COMPILER=' + conf.CC(),
-                '-DLLDB_TEST_CXX_COMPILER=' + conf.CC() + "++"
+                '-DLLDB_TEST_COMPILER=' + conf.CC(),
             ])
 
     if conf.compiler_flags:
@@ -578,8 +577,7 @@ def lldb_cmake_builder(target, variant=None):
 
     if conf.lldbtestcompiler():
         cmake_cmd.extend([
-            '-DLLDB_TEST_C_COMPILER=' + conf.lldbtestcompiler(),
-            '-DLLDB_TEST_CXX_COMPILER=' + conf.lldbtestcompiler() + "++"
+            '-DLLDB_TEST_COMPILER=' + conf.lldbtestcompiler(),
         ])
 
     cmake_cmd.extend(conf.cmake_flags)


### PR DESCRIPTION
Since https://reviews.llvm.org/D69401 landed the bot has been setting unused
CMake variables for specifying test compilers which meant this bot hasn't
been testing anything since 2019. Reenabling the tests so that we can start
fixing the failing tests.