### PR TITLE
Add BOLT buildbot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -21,6 +21,7 @@ from zorg.buildbot.builders import LLDPerformanceTestsuite
 from zorg.buildbot.builders import FuchsiaBuilder
 from zorg.buildbot.builders import XToolchainBuilder
 from zorg.buildbot.builders import TestSuiteBuilder
+from zorg.buildbot.builders import BOLTBuilder
 
 from zorg.buildbot.builders import HtmlDocsBuilder
 from zorg.buildbot.builders import DoxygenDocsBuilder
@@ -2291,5 +2292,22 @@ all += [
              "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=ARC",
          ])},
 
+
+    # BOLT builder managed by Meta
+    {'name': "bolt-x86_64-ubuntu",
+    'tags': ["bolt"],
+    'collapseRequests': False,
+    'workernames':["bolt-worker2"],
+    'builddir': "bolt-x86_64-ubuntu-bolttests",
+    'factory' : BOLTBuilder.getBOLTCmakeBuildFactory(
+                    clean=True,
+                    bolttests=True,
+                    extra_configure_args=[
+                        '-DLLVM_ENABLE_PROJECTS=clang;lld;bolt',
+                        '-DLLVM_TARGETS_TO_BUILD=X86;AArch64',
+                        "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
+                        "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
+                        ],
+                    )},
 
 ]

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -273,4 +273,7 @@ def get_all():
         # OpenMP on AMDGPU, Ubuntu 18.04.5, Intel(R) Xeon(R) Gold 5218 @ 2.30GHz with 64GB Memory, 1 Vega20 GPU with 16GB Memory
         create_worker("omp-vega20-0", properties={'jobs': 32}, max_builds=1),
         create_worker("omp-vega20-1", properties={'jobs': 32}, max_builds=1),
+
+        # BOLT worker
+        create_worker("bolt-worker2"),
         ]

--- a/zorg/buildbot/builders/BOLTBuilder.py
+++ b/zorg/buildbot/builders/BOLTBuilder.py
@@ -1,0 +1,69 @@
+from buildbot.plugins import steps
+from zorg.buildbot.commands.CmakeCommand import CmakeCommand
+from zorg.buildbot.builders.UnifiedTreeBuilder import getLLVMBuildFactoryAndSourcecodeSteps, addCmakeSteps, addNinjaSteps
+from zorg.buildbot.process.factory import LLVMBuildFactory
+
+def getBOLTCmakeBuildFactory(
+           clean = False,
+           bolttests = False,
+           extra_configure_args = None,
+           env = None,
+           **kwargs):
+
+    if env is None:
+        env = dict()
+
+    bolttests_dir = "bolt-tests"
+
+    cleanBuildRequested = lambda step: clean or step.build.getProperty("clean", default=step.build.getProperty("clean_obj"))
+
+    checks = ['check-bolt']
+    extra_steps = []
+
+    f = getLLVMBuildFactoryAndSourcecodeSteps(
+            depends_on_projects=['clang', 'lld', 'bolt'],
+            **kwargs) # Pass through all the extra arguments.
+
+    if bolttests:
+        checks += ['check-large-bolt']
+        extra_configure_args += [
+            '-DLLVM_EXTERNAL_PROJECTS=bolttests',
+            '-DLLVM_EXTERNAL_BOLTTESTS_SOURCE_DIR=' + LLVMBuildFactory.pathRelativeTo(bolttests_dir, f.monorepo_dir),
+            ]
+        f.addSteps([
+            steps.RemoveDirectory(name="BOLT tests: clean",
+                dir=bolttests_dir,
+                haltOnFailure=True,
+                warnOnFailure=True,
+                doStepIf=cleanBuildRequested),
+
+            steps.Git(name="BOLT tests: checkout",
+                description="fetching",
+                descriptionDone="fetch",
+                descriptionSuffix="BOLT Tests",
+                repourl='https://github.com/rafaelauler/bolt-tests.git',
+                workdir=bolttests_dir,
+                alwaysUseLatest=True),
+            ])
+
+    # Some options are required for this build no matter what.
+    CmakeCommand.applyRequiredOptions(extra_configure_args, [
+        ('-G',                      'Ninja'),
+        ])
+
+    addCmakeSteps(
+        f,
+        cleanBuildRequested=cleanBuildRequested,
+        extra_configure_args=extra_configure_args,
+        obj_dir=None,
+        env=env,
+        **kwargs)
+
+    addNinjaSteps(
+           f,
+           targets = ['llvm-bolt'],
+           checks=checks,
+           env=env,
+           **kwargs)
+
+    return f


### PR DESCRIPTION
Add BOLT build worker and custom builder to zorg.

Builder is expected to check out binary tests from another repo, currently at https://github.com/rafaelauler/bolt-tests. 
The plan is to transfer the repository over to llvm organization in the future.

With that requirement, BOLT builder has to define an intermediate checkout step between `getLLVMBuildFactoryAndSourcecodeSteps` and `addCmakeSteps`/`addNinjaSteps`. 
Otherwise, it's based on `UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory`.

The configuration is tested with a [temporary build master](http://157.230.108.44:8011/#/builders/3/builds/2811), which points to the [current BOLT repo](https://github.com/facebookincubator/bolt) instead of the monorepo.

This PR should only be merged once BOLT is pushed to the monorepo. 
Current plan is end of this week: https://lists.llvm.org/pipermail/llvm-dev/2021-December/154290.html