### PR TITLE
Remove fedora builder and worker

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2089,36 +2089,6 @@ all += [
                     script="ve-linux.py",
                     depends_on_projects=['llvm', 'clang', 'compiler-rt', 'libcxx'])},
 
-# Latest stable fedora running on Red Hat internal OpenShift cluster (PSI).
-
-    {'name' : 'x86_64-fedora-clang',
-    'tags'  : ['mlir'],
-    'collapseRequests': False,
-    'workernames': ['fedora-llvm-x86_64'],
-    'builddir': 'x86_64-fedora-clang',
-    'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
-                    clean=True,
-                    depends_on_projects=['llvm', 'clang', 'clang-tools-extra', 'compiler-rt', 'lld', 'mlir'],
-                    checks=['check-all'],
-                    extra_configure_args=[
-                        '-DCMAKE_BUILD_TYPE=Release',
-                        '-DCMAKE_C_COMPILER=/usr/bin/gcc',
-                        '-DCMAKE_CXX_COMPILER=/usr/bin/g++',
-                        '-DLLVM_ENABLE_ASSERTIONS=On',
-                        '-DLLVM_BUILD_EXAMPLES=On',
-                        "-DLLVM_LIT_ARGS=-v --xunit-xml-output test-results.xml",
-                        '-DLLVM_CCACHE_BUILD=On',
-                        '-DLLVM_CCACHE_DIR=/ccache',
-                        '-DLLVM_CCACHE_MAXSIZE=20G',
-                        '-DLLVM_TARGETS_TO_BUILD=X86',
-                        '-DCMAKE_EXPORT_COMPILE_COMMANDS=1',
-                        '-DLLVM_BUILD_LLVM_DYLIB=On',
-                        '-DLLVM_LINK_LLVM_DYLIB=On',
-                        '-DCLANG_LINK_CLANG_DYLIB=On',
-                        '-DBUILD_SHARED_LIBS=Off',
-                        '-DLLVM_ENABLE_LLD=ON',
-                    ])},
-
     # Build the LLVM dylib .so with all backends and link tools to it
     {'name' : 'llvm-x86_64-debian-dylib',
     'tags'  : ['llvm'],

--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -170,13 +170,6 @@ all = [
     reporters.MailNotifier(
         fromaddr = "llvm.buildmaster@lab.llvm.org",
         sendToInterestedUsers = False,
-        extraRecipients = ["kkleine@redhat.com"],
-        subject = "Build %(builder)s Failure",
-        mode = "failing",
-        builders = ["fedora-llvm-x86_64", "x86_64-fedora-clang"]),
-    reporters.MailNotifier(
-        fromaddr = "llvm.buildmaster@lab.llvm.org",
-        sendToInterestedUsers = False,
         extraRecipients = ["labath@google.com"],
         subject = "Build %(builder)s Failure",
         mode = "failing",

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -158,9 +158,6 @@ def get_all():
         create_worker("fuchsia-debian-64-us-central1-a-1", properties={'jobs': 64}, max_builds=1),
         create_worker("fuchsia-debian-64-us-central1-b-1", properties={'jobs': 64}, max_builds=1),
 
-        # Fedora latest stable, arch=x86_64, running on RedHat internal OpenShift PSI cluster
-        create_worker("fedora-llvm-x86_64", properties={'jobs': 64}, max_builds=1),
-
         # Debian x86_64 Buster Xeon(R) Gold 6154 CPU @ 3.00GHz, 192GB RAM
         create_worker("lldb-x86_64-debian", properties={'jobs': 72}, max_builds=1),
 


### PR DESCRIPTION
This patch removes this builder:

 * x86_64-fedora-clang

and this worker:

 * fedora-llvm-x86_64

This builder and worker haven't been maintained by me for a while and
I initially installed them with the intend to support them much longer.
But this was only the beginning of my journey with LLVM CI...