### PR TITLE
[libc++] Stop building libc++ alongside Clang on GreenDragon bots

### DIFF
--- a/zorg/jenkins/build.py
+++ b/zorg/jenkins/build.py
@@ -395,9 +395,6 @@ def clang_builder(target):
                                    '-DLLVM_INCLUDE_TESTS=On',
                                    '-DCLANG_INCLUDE_TESTS=On',
                                    '-DLLVM_INCLUDE_UTILS=On',
-                                   '-DLIBCXX_INSTALL_HEADERS=On',
-                                   '-DLIBCXX_OVERRIDE_DARWIN_INSTALL=On',
-                                   '-DLIBCXX_INSTALL_LIBRARY=Off',
                                    '-DCMAKE_MACOSX_RPATH=On',
                                    ]
 

--- a/zorg/jenkins/jobs/jobs/clang-san-iossim
+++ b/zorg/jenkins/jobs/jobs/clang-san-iossim
@@ -41,11 +41,7 @@ pipeline {
                     rm -rf clang-install *.tar.gz
                     python llvm-zorg/zorg/jenkins/monorepo_build.py cmake build \
                       --assertions --cmake-type=RelWithDebInfo \
-                      --projects="clang;clang-tools-extra;compiler-rt;libcxx" \
-                      --cmake-flag='-DLIBCXX_ENABLE_SHARED=OFF' \
-                      --cmake-flag='-DLIBCXX_ENABLE_STATIC=OFF' \
-                      --cmake-flag='-DLIBCXX_INCLUDE_TESTS=OFF' \
-                      --cmake-flag='-DLIBCXX_ENABLE_EXPERIMENTAL_LIBRARY=OFF'
+                      --projects="clang;clang-tools-extra;compiler-rt"
                     '''
                 }
             }

--- a/zorg/jenkins/jobs/jobs/clang-stage1-RA
+++ b/zorg/jenkins/jobs/jobs/clang-stage1-RA
@@ -49,11 +49,7 @@ pipeline {
                     rm -rf clang-build clang-install *.tar.gz
                     python llvm-zorg/zorg/jenkins/monorepo_build.py cmake build \
                       --assertions --cmake-type=RelWithDebInfo \
-                      --projects="clang;clang-tools-extra;compiler-rt;libcxx" \
-                      --cmake-flag='-DLIBCXX_ENABLE_SHARED=OFF'\
-                      --cmake-flag='-DLIBCXX_ENABLE_STATIC=OFF' \
-                      --cmake-flag='-DLIBCXX_INCLUDE_TESTS=OFF' \
-                      --cmake-flag='-DLIBCXX_ENABLE_EXPERIMENTAL_LIBRARY=OFF'
+                      --projects="clang;clang-tools-extra;compiler-rt"
                     '''
                 }
             }

--- a/zorg/jenkins/jobs/jobs/clang-stage2-Rthinlto
+++ b/zorg/jenkins/jobs/jobs/clang-stage2-Rthinlto
@@ -45,11 +45,7 @@ pipeline {
 
                     python llvm-zorg/zorg/jenkins/monorepo_build.py fetch
                     python llvm-zorg/zorg/jenkins/monorepo_build.py clang build \
-                      --thinlto --projects="clang;compiler-rt;libcxx" \
-                      --cmake-flag="-DLIBCXX_ENABLE_SHARED=OFF" \
-                      --cmake-flag="-DLIBCXX_ENABLE_STATIC=OFF" \
-                      --cmake-flag="-DLIBCXX_INCLUDE_TESTS=OFF" \
-                      --cmake-flag="-DLIBCXX_ENABLE_EXPERIMENTAL_LIBRARY=OFF" \
+                      --thinlto --projects="clang;compiler-rt" \
                       --cmake-flag="-DCMAKE_DSYMUTIL=$WORKSPACE/host-compiler/bin/dsymutil"
                     '''
                 }

--- a/zorg/jenkins/monorepo_build.py
+++ b/zorg/jenkins/monorepo_build.py
@@ -430,9 +430,6 @@ def clang_builder(target):
                                    '-DLLVM_INCLUDE_TESTS=On',
                                    '-DCLANG_INCLUDE_TESTS=On',
                                    '-DLLVM_INCLUDE_UTILS=On',
-                                   '-DLIBCXX_INSTALL_HEADERS=On',
-                                   '-DLIBCXX_OVERRIDE_DARWIN_INSTALL=On',
-                                   '-DLIBCXX_INSTALL_LIBRARY=Off',
                                    '-DCMAKE_MACOSX_RPATH=On',
                                    ]
 


### PR DESCRIPTION
The libc++ headers used to be shipped alongside the Clang toolchain
on Apple platforms, so it made sense to build libc++ at the same time
as Clang in our CI. However, for a couple of years now, Clang and libc++
are entirely separate projects w.r.t. how they are shipped on Apple
platforms, and it doesn't make sense to build libc++ at the same time
as Clang anymore. Libc++ has its own CI infrastructure.