### PR TITLE
[green dragon] Remove libc++ from monorepo builds

### DIFF
--- a/test/jenkins/test_monorepo_build.py
+++ b/test/jenkins/test_monorepo_build.py
@@ -5,7 +5,7 @@
 # RUN: export BUILD_NUMBER=321
 # RUN: export BRANCH=main
 # Tell monorepo_build.py to just print commands instead of running.
-# RUN: mkdir -p %t.SANDBOX/host-compiler/lib %t.SANDBOX/host-compiler/bin %t.SANDBOX/llvm-project/llvm %t.SANDBOX/llvm-project/clang %t.SANDBOX/llvm-project/libcxx %t.SANDBOX/llvm-project/compiler-rt %t.SANDBOX/llvm-project/debuginfo-tests %t.SANDBOX/llvm-project/clang-tools-extra %t.SANDBOX/llvm-project/lldb
+# RUN: mkdir -p %t.SANDBOX/host-compiler/lib %t.SANDBOX/host-compiler/bin %t.SANDBOX/llvm-project/llvm %t.SANDBOX/llvm-project/clang %t.SANDBOX/llvm-project/compiler-rt %t.SANDBOX/llvm-project/debuginfo-tests %t.SANDBOX/llvm-project/clang-tools-extra %t.SANDBOX/llvm-project/lldb
 # RUN: touch %t.SANDBOX/host-compiler/bin/clang
 # RUN: python %{src_root}/zorg/jenkins/monorepo_build.py clang all > %t.log
 # RUN: FileCheck --check-prefix CHECK-SIMPLE < %t.log %s
@@ -20,7 +20,7 @@
 # CHECK-SIMPLE: '/usr/local/bin/cmake' '-G' 'Ninja' '-C'
 # CHECK-SIMPLE: '-DLLVM_ENABLE_ASSERTIONS:BOOL=FALSE'
 # CHECK-SIMPLE: '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
-# CHECK-SIMPLE: '-DLLVM_ENABLE_PROJECTS=clang;clang-tools-extra;compiler-rt;libcxx'
+# CHECK-SIMPLE: '-DLLVM_ENABLE_PROJECTS=clang;clang-tools-extra;compiler-rt'
 # CHECK-SIMPLE: '-DCMAKE_MAKE_PROGRAM=/usr/local/bin/ninja'
 # CHECK-SIMPLE: '-DLLVM_VERSION_PATCH=99'
 # CHECK-SIMPLE: '-DLLVM_VERSION_SUFFIX=""'

--- a/zorg/jenkins/monorepo_build.py
+++ b/zorg/jenkins/monorepo_build.py
@@ -1064,7 +1064,7 @@ def parse_args():
                         action='store_true', help="Turn on the experimental"
                                                   " GlobalISel CMake flag.")
     parser.add_argument('--projects', dest='llvm_enable_projects',
-                        default="clang;clang-tools-extra;compiler-rt;libcxx",
+                        default="clang;clang-tools-extra;compiler-rt",
                         help="Semicolon seperated list of projects to enable.")
     parser.add_argument('--runtimes', dest='llvm_enable_runtimes',
                         default="",


### PR DESCRIPTION
We don't want to include libc++ in LLVM_ENABLE_PROJECTS anymore, since
it's unsupported and the goal of this script is to test Clang, which
does not include libc++ headers anymore on Apple platforms.