### PR TITLE
[sanitizer] Add check-orc-rt to sanitizer-windows.

### DIFF
--- a/zorg/buildbot/builders/annotated/sanitizer-windows.py
+++ b/zorg/buildbot/builders/annotated/sanitizer-windows.py
@@ -42,7 +42,7 @@ def main(argv):
     ]
     check_targets = ['check-asan', 'check-asan-dynamic', 'check-sanitizer',
                      'check-ubsan', 'check-fuzzer', 'check-cfi',
-                     'check-profile', 'check-builtins']
+                     'check-profile', 'check-builtins', 'check-orc-rt']
 
     # These arguments are a bit misleading, they really mean use cl.exe for
     # stage1 instead of GCC.


### PR DESCRIPTION
With https://reviews.llvm.org/D130479, we have a orc runtime support in MSVC which enables various advacned features in JIT LLVM such as SEH exception frame registration, static initializer collection, or dynamic library api emulation. However, there is no build bot that tests this part of code since noone runs check-orc-rt in msvc bots. I think sanitizer-windows is somewhat off place to run orc runtime tests, but I don't see any else bot suitable either.