### PR TITLE
Use optimized tablegen in clangd builds

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2467,7 +2467,8 @@ all += [
              "-DCMAKE_BUILD_TYPE=Release",
              "-DCLANGD_ENABLE_REMOTE=ON",
              "-DLLVM_ENABLE_ASSERTIONS=ON",
-             "-DGRPC_INSTALL_PATH=/usr/local/lib/grpc"
+             "-DGRPC_INSTALL_PATH=/usr/local/lib/grpc",
+             "-DLLVM_OPTIMIZED_TABLEGEN=ON"
          ])},
 
     # Build in C++20 configuration.


### PR DESCRIPTION
A recent [change](https://github.com/llvm/llvm-project/commit/50d96f59d0966bdda6b3ac4f8964ed572435b847) to llvm-tablegen made it unusable under tsan. our bot would OOM all builds ever since. this flag should enable us to build tblgen in native setup, without tsan.