### PR TITLE
Add builders for premerge-like configurations

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2792,4 +2792,45 @@ all += [
                     env={
                         'CCACHE_DIR' : WithProperties("%(builddir)s/ccache-db"),
                     })},
+
+    # Builders similar to used in Buildkite premerge pipeline.
+    # Please keep in sync with llvm-project/.ci configurations.
+
+    # See https://github.com/llvm/llvm-project/blob/main/.ci/monolithic-windows.sh.
+    {'name' : "premerge-monolithic-windows",
+    'tags'  : ["premerge"],
+    'collapseRequests': True,
+    'workernames' : ["premerge-windows-1"],
+    'builddir': "premerge-monolithic-windows",
+    'factory' : UnifiedTreeBuilder.getCmakeWithNinjaWithMSVCBuildFactory(
+                    vs="autodetect",
+                    depends_on_projects=["clang-tools-extra", "clang", "flang", "libclc", "lld", "llvm", "mlir", "polly", "pstl"],
+                    checks=["check-all"],
+                    extra_configure_args=[
+                        "-DCMAKE_BUILD_TYPE=Release",
+                        "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_BUILD_EXAMPLES=ON",
+                        "-DCOMPILER_RT_BUILD_LIBFUZZER=OFF",
+                        "-DLLVM_LIT_ARGS=-v",
+                        "-DCOMPILER_RT_BUILD_ORC=OFF",
+                        "-DCMAKE_C_COMPILER_LAUNCHER=sccache",
+                        "-DCMAKE_CXX_COMPILER_LAUNCHER=sccache"])},
+    # See https://github.com/llvm/llvm-project/blob/main/.ci/monolithic-linux.sh.
+    {'name': "premerge-monolithic-linux",
+    'tags'  : ["premerge"],
+    'collapseRequests': False,
+    'workernames': ["premerge-linux-1"],
+    'builddir': "premerge-monolithic-linux",
+    'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                    depends_on_projects=["bolt", "clang", "clang-tools-extra", "compiler-rt", "flang", "libc", "libclc", "lld", "llvm", "mlir", "polly", "pstl"],
+                    extra_configure_args=[
+                      "-DCMAKE_BUILD_TYPE=Release",
+                      "-DLLVM_ENABLE_ASSERTIONS=ON",
+                      "-DLLVM_BUILD_EXAMPLES=ON",
+                      "-DCOMPILER_RT_BUILD_LIBFUZZER=OFF",
+                      "-DLLVM_LIT_ARGS=-v",
+                      "-DLLVM_ENABLE_LLD=ON",
+                      "-DCMAKE_CXX_FLAGS=-gmlt",
+                      "-DBOLT_CLANG_EXE=/usr/bin/clang",
+                      "-DLLVM_CCACHE_BUILD=ON"])},
 ]

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2799,7 +2799,6 @@ all += [
     # See https://github.com/llvm/llvm-project/blob/main/.ci/monolithic-windows.sh.
     {'name' : "premerge-monolithic-windows",
     'tags'  : ["premerge"],
-    'collapseRequests': True,
     'workernames' : ["premerge-windows-1"],
     'builddir': "premerge-monolithic-windows",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaWithMSVCBuildFactory(

--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -383,7 +383,7 @@ def getReporters():
         reporters.MailNotifier(
             fromaddr = "llvm.buildmaster@lab.llvm.org",
             sendToInterestedUsers = False,
-            messageFormatter = LLVMInformativeMailNotifier, # TODO: remove after moving to prod.
+            messageFormatter = LLVMInformativeMailNotifier,
             extraRecipients = ["llvm-premerge-buildbots@google.com"],
             mode = "failing",
             builders = ["premerge-monolithic-windows", "premerge-monolithic-linux"]),

--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -380,4 +380,11 @@ def getReporters():
             subject = "Build %(builder)s Failure",
             mode = "failing",
             builders = ["clang-cmake-x86_64-avx512-linux"]),
+        reporters.MailNotifier(
+            fromaddr = "llvm.buildmaster@lab.llvm.org",
+            sendToInterestedUsers = False,
+            messageFormatter = LLVMInformativeMailNotifier, # TODO: remove after moving to prod.
+            extraRecipients = ["llvm-premerge-buildbots@google.com"],
+            mode = "failing",
+            builders = ["premerge-monolithic-windows", "premerge-monolithic-linux"]),
     ]

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -317,4 +317,11 @@ def get_all():
         create_worker("gc-builder-5", properties={'jobs' : 112},  max_builds=1),
         create_worker("gc-builder-6-win", properties={'jobs' : 112},  max_builds=1),
         create_worker("gc-builder-7-win", properties={'jobs' : 112},  max_builds=1),
+
+        # Linux builder matching Buildkite pre-merge checks configuration.
+        create_worker("premerge-linux-1", max_builds=1, missing_timeout=300,
+                      notify_on_missing="llvm-premerge-buildbots@google.com"),
+        # Windows builder matching Buildkite pre-merge checks configuration.
+        create_worker("premerge-windows-1", max_builds=1, missing_timeout=300,
+                      notify_on_missing="llvm-premerge-buildbots@google.com"),
         ]


### PR DESCRIPTION
As was suggested https://github.com/llvm/llvm-project/issues/56674#issuecomment-1690845357 that adds a configuration that should match build run by GitHub pull requests.

We are going to set up initially one worker per windows / linux architecture. It's unlikely that windows one will be able to catch up with every commit but we will monitor it and decide if e.g. adding one more worker might actually be fast enough to build every change.