### PR TITLE
[jenkins] Coverage bot: Remove cross-project-tests

### DIFF
--- a/zorg/jenkins/jobs/jobs/llvm-coverage
+++ b/zorg/jenkins/jobs/jobs/llvm-coverage
@@ -76,7 +76,7 @@ pipeline {
 
                     python llvm-zorg/zorg/jenkins/monorepo_build.py lldb-cmake build \
                       --assertions \
-                      --projects="clang;lldb;cross-project-tests" \
+                      --projects="clang;lldb" \
                       --runtimes="libcxx;libcxxabi" \
                       --cmake-flag="-DPYTHON_LIBRARY=/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7.dylib" \
                       --cmake-flag="-DPYTHON_INCLUDE_DIR=/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/include/python3.7m" \


### PR DESCRIPTION
Directory coverage is recently enabled in https://reviews.llvm.org/D158703 The following file shows up at the top level because cross-project-tests is also built in the coverage build:
`cross-project-tests/debuginfo-tests/llvm-prettyprinters/gdb/llvm-support.cpp`
This patch removes cross-project-tests from the project list.

Differential Revision: https://reviews.llvm.org/D159469