### PR TITLE
Add two new Sony builders and workers

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -949,6 +949,46 @@ all = [
                         "-DLLVM_PARALLEL_LINK_JOBS=16",
                         "-DLLVM_USE_LINKER=gold"])},
 
+    {'name': "clang-x86_64-linux-abi-test",
+     'tags': ["llvm", "clang", "clang-tools-extra", "compiler-rt", "lld", "cross-project-tests"],
+     'workernames': ["sie-linux-worker2"],
+     'builddir': "abi-test",
+     'factory': ABITestsuitBuilder.getABITestsuitBuildFactory(
+                    depends_on_projects=['llvm','clang','clang-tools-extra','compiler-rt','lld','cross-project-tests'],
+                    extra_configure_args=[
+                        "-DCMAKE_C_COMPILER=gcc",
+                        "-DCMAKE_CXX_COMPILER=g++",
+                        "-DCMAKE_BUILD_TYPE=Release",
+                        "-DCLANG_ENABLE_CLANGD=OFF",
+                        "-DLLVM_BUILD_RUNTIME=ON",
+                        "-DLLVM_BUILD_TESTS=ON",
+                        "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_INCLUDE_EXAMPLES=OFF",
+                        "-DLLVM_LIT_ARGS=--verbose -j48",
+                        "-DLLVM_PARALLEL_LINK_JOBS=16",
+                        "-DLLVM_USE_LINKER=gold",
+                        "-DLLVM_ENABLE_WERROR=OFF"])},
+
+    {'name': "llvm-new-debug-iterators",
+    'tags'  : ["llvm", "clang", "clang-tools-extra", "compiler-rt", "lld", "cross-project-tests"],
+    'workernames': ["sie-linux-worker3"],
+    'builddir': "debug-iterators",
+    'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                    depends_on_projects=['llvm','clang','clang-tools-extra','compiler-rt','lld','cross-project-tests'],
+                    extra_configure_args=[
+                        "-DCMAKE_C_COMPILER=gcc",
+                        "-DCMAKE_CXX_COMPILER=g++",
+                        "-DCMAKE_BUILD_TYPE=Release",
+                        "-DCLANG_ENABLE_CLANGD=OFF",
+                        "-DLLVM_BUILD_RUNTIME=ON",
+                        "-DLLVM_BUILD_TESTS=ON",
+                        "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_EXPERIMENTAL_DEBUGINFO_ITERATORS=ON",
+                        "-DLLVM_INCLUDE_EXAMPLES=OFF",
+                        "-DLLVM_LIT_ARGS=--verbose -j48",
+                        "-DLLVM_PARALLEL_LINK_JOBS=16",
+                        "-DLLVM_USE_LINKER=gold"])},
+
 # Polly builders.
 
     {'name' : "polly-arm-linux",

--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -244,7 +244,9 @@ def getReporters():
                         "llvm-clang-x86_64-gcc-ubuntu",
                         "llvm-clang-x86_64-gcc-ubuntu-release",
                         "cross-project-tests-sie-ubuntu",
-                        "cross-project-tests-sie-ubuntu-dwarf5"]),
+                        "cross-project-tests-sie-ubuntu-dwarf5",
+                        "clang-x86_64-linux-abi-test",
+                        "llvm-new-debug-iterators"]),
         reporters.MailNotifier(
             fromaddr = "llvm.buildmaster@lab.llvm.org",
             sendToInterestedUsers = False,

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -283,6 +283,9 @@ def get_all():
         create_worker("doug-worker-1b", properties={'jobs': 10}, max_builds=1),
         # Ubuntu 18.04 in docker container on Ryzen 4800U
         create_worker("doug-worker-2a", properties={'jobs': 22}, max_builds=1),
+        # Configuration TBD
+        create_worker("sie-linux-worker2", properties={'jobs': 32}, max_builds=1),
+        create_worker("sie-linux-worker3", properties={'jobs': 32}, max_builds=1),
 
         # Windows Server 2019 on AWS, x86_64 PS4 target
         create_worker("sie-win-worker", properties={'jobs': 64}, max_builds=1),


### PR DESCRIPTION
Add two new builders clang-x86_64-linux-abi-test and llvm-new-debug-iterators,
two new workers sie-linux-worker2 and sie-linux-worker3 as well as setup notifications for their failures.

I'm not sure what configuration we will use for the machines yet and wanted to get them into the staging server so that I can see what the timings are like and what state things are in at the moment before I commit to a configuration.