### PR TITLE
Remove mlir windows bot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1395,24 +1395,6 @@ all += [
                         'CXX': 'g++-7',
                     })},
 
-    {'name' : "mlir-windows",
-    'tags'  : ["mlir"],
-    'workernames' : ["win-mlir-buildbot"],
-    'builddir': "mlir-x64-windows-ninja",
-    'factory' : UnifiedTreeBuilder.getCmakeWithNinjaWithMSVCBuildFactory(
-                    clean=True,
-                    targets = ['check-mlir-build-only'],
-                    checks = ['check-mlir'],
-                    depends_on_projects=['llvm','mlir'],
-                    vs="autodetect",
-                    extra_configure_args=[
-                        "-DLLVM_BUILD_EXAMPLES=ON",
-                        "-DLLVM_ENABLE_PROJECTS=mlir",
-                        "-DMLIR_ENABLE_BINDINGS_PYTHON=ON",
-                        "-DLLVM_ENABLE_WERROR=ON",
-                        "-DLLVM_TARGETS_TO_BUILD='host;NVPTX;AMDGPU'",
-                    ])},
-
     {'name' : 'ppc64le-mlir-rhel-clang',
     'tags'  : ["mlir", "ppc", "ppc64le"],
     'collapseRequests' : False,

--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -144,13 +144,6 @@ def getReporters():
         reporters.MailNotifier(
             fromaddr = "llvm.buildmaster@lab.llvm.org",
             sendToInterestedUsers = False,
-            extraRecipients = ["aifxbuildbotdri@microsoft.com", "namcvica@microsoft.com"],
-            subject = "Build %(builder)s Failure",
-            mode = "failing",
-            builders = ["mlir-windows"]),
-        reporters.MailNotifier(
-            fromaddr = "llvm.buildmaster@lab.llvm.org",
-            sendToInterestedUsers = False,
             extraRecipients = ["gongsu@us.ibm.com", "alexe@us.ibm.com"],
             subject = "Build %(builder)s Failure",
             mode = "failing",
@@ -267,7 +260,6 @@ def getReporters():
             subject = "MLIR Build Failure: %(builder)s",
             mode = "failing",
             builders = ["mlir-nvidia",
-                        "mlir-windows",
                         "ppc64le-mlir-rhel-clang"]),
         reporters.MailNotifier(
             fromaddr="llvm.buildmaster@lab.llvm.org",

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -47,9 +47,6 @@ def get_all():
         create_worker("linaro-armv8-windows-msvc-04", properties={'jobs' : 8}, max_builds=1),
         create_worker("linaro-armv8-windows-msvc-05", properties={'jobs' : 8}, max_builds=1),
 
-        # Windows Server 2016 Intel(R) Xeon(R) CPU @ 2.60GHz, 16 Core(s), 128 GB of RAM
-        create_worker("win-mlir-buildbot", properties={'jobs' : 64}, max_builds=1),
-
         # Linux s390x Ubuntu Focal, IBM z13 (5GHz), 64GB of RAM
         create_worker("onnx-mlir-nowarn-linux-s390x", properties={'jobs' : 4}, max_builds=1),
 


### PR DESCRIPTION
We are retiring the mlir windows bot. This removes it from zorg.