### PR TITLE
[Android] Remove unneeded -stdlib and -I flags for C++

### DIFF
--- a/zorg/buildbot/builders/sanitizers/buildbot_android_functions.sh
+++ b/zorg/buildbot/builders/sanitizers/buildbot_android_functions.sh
@@ -53,7 +53,6 @@ function configure_android { # ARCH triple
   local ANDROID_LIBRARY_OUTPUT_DIR=$(ls -d $ROOT/llvm_build64/lib/clang/* | tail -1)
   local ANDROID_EXEC_OUTPUT_DIR=$ROOT/llvm_build64/bin
   local ANDROID_FLAGS="--target=${_triple}${ANDROID_API} --sysroot=$ANDROID_TOOLCHAIN/sysroot --gcc-toolchain=$ANDROID_TOOLCHAIN  -B$ANDROID_TOOLCHAIN"
-  local ANDROID_CXX_FLAGS="$ANDROID_FLAGS -stdlib=libc++ -I/$ANDROID_TOOLCHAIN/sysroot/usr/include/c++/v1"
 
   local CLANG_PATH=$ROOT/llvm_build64/bin/clang
   local CLANGXX_PATH=$ROOT/llvm_build64/bin/clang++
@@ -72,7 +71,7 @@ function configure_android { # ARCH triple
     -DCMAKE_CXX_COMPILER=$CLANGXX_PATH \
     -DCMAKE_ASM_FLAGS="$ANDROID_FLAGS" \
     -DCMAKE_C_FLAGS="$ANDROID_FLAGS" \
-    -DCMAKE_CXX_FLAGS="$ANDROID_CXX_FLAGS" \
+    -DCMAKE_CXX_FLAGS="$ANDROID_FLAGS" \
     -DLLVM_BINUTILS_INCDIR=/usr/include \
     -DCMAKE_EXE_LINKER_FLAGS="-pie" \
     -DCMAKE_SKIP_RPATH=ON \
@@ -92,7 +91,7 @@ function configure_android { # ARCH triple
     -DCOMPILER_RT_ENABLE_WERROR=ON \
     -DCMAKE_ASM_FLAGS="$ANDROID_FLAGS" \
     -DCMAKE_C_FLAGS="$ANDROID_FLAGS" \
-    -DCMAKE_CXX_FLAGS="$ANDROID_CXX_FLAGS" \
+    -DCMAKE_CXX_FLAGS="$ANDROID_FLAGS" \
     -DSANITIZER_CXX_ABI="libcxxabi" \
     -DCOMPILER_RT_TEST_COMPILER_CFLAGS="$ANDROID_FLAGS" \
     -DCOMPILER_RT_DEFAULT_TARGET_TRIPLE=$_triple \


### PR DESCRIPTION
A recent Clang driver will assume -stdlib=libc++ automatically for Android and will also automatically add $SYSROOT/usr/include/c++/v1 to the include search path.

This explicit -I path breaks libFuzzer when it builds and links its own copy of libc++ because there are two different libc++ copies on the include path.