### PR TITLE
[BOLT] Align bolt-aarch64-ubuntu-clang with bolt-x86_64-ubuntu-clang

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2521,18 +2521,24 @@ all += [
     'builddir': "bolt-aarch64-ubuntu-clang",
     'factory' : BOLTBuilder.getBOLTCmakeBuildFactory(
                     bolttests=False,
-                    depends_on_projects=['bolt', 'clang', 'llvm'],
+                    clean=True,
+                    depends_on_projects=['bolt', 'clang', 'lld', 'llvm'],
                     caches=[
                         'clang/cmake/caches/BOLT.cmake',
+                        'clang/cmake/caches/BOLT-PGO.cmake',
                     ],
                     targets=['clang-bolt'],
+                    checks=['stage2-clang-bolt'],
                     extra_configure_args=[
-                        "-DCMAKE_C_COMPILER=clang",
-                        "-DCMAKE_CXX_COMPILER=clang++",
+                        "-DCMAKE_C_COMPILER=gcc",
+                        "-DCMAKE_CXX_COMPILER=g++",
                         "-DLLVM_APPEND_VC_REV=OFF",
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
-                        "-DLLVM_USE_LINKER=lld",
+                        "-DLLVM_ENABLE_LLD=ON",
+                        "-DBOOTSTRAP_LLVM_ENABLE_LLD=ON",
+                        "-DBOOTSTRAP_BOOTSTRAP_LLVM_ENABLE_LLD=ON",
+                        "-DPGO_INSTRUMENT_LTO=Thin",
                         ],
                     )},
 


### PR DESCRIPTION
- Enable `clean=True` to force build dir cleanup (avoiding processing
  BOLTed clang).
- Use gcc/g++ for 1st stage clang binary to extend testing.
- Enable BOLT-PGO.cmake cache to test optimizing PGO+LTO clang.
- Track lld commits.
