### PR TITLE
Enable ccache for LLVM builds in Fuchsia builder

### DIFF
--- a/zorg/buildbot/builders/annotated/fuchsia-linux.py
+++ b/zorg/buildbot/builders/annotated/fuchsia-linux.py
@@ -26,7 +26,7 @@ def step(step_name, halt_on_fail=False):
         util.report('@@@STEP_EXCEPTION@@@')
 
 
-def run_command(cmd, directory='.'):
+def run_command(cmd, directory=os.getcwd()):
     util.report_run_cmd(cmd, cwd=directory)
 
 

--- a/zorg/buildbot/builders/annotated/fuchsia-linux.py
+++ b/zorg/buildbot/builders/annotated/fuchsia-linux.py
@@ -54,6 +54,7 @@ def main(argv):
             '-B', build_dir,
             '-G', 'Ninja',
             '-D', 'BOOTSTRAP_LLVM_ENABLE_LTO=OFF',
+            '-D', 'LLVM_CCACHE_BUILD=ON',
             '-D', 'LLVM_ENABLE_LTO=OFF',
             '-D', f'FUCHSIA_SDK={args.sdk_dir}',
             '-C', f'{source_dir}/clang/cmake/caches/Fuchsia.cmake',


### PR DESCRIPTION
- Change fuchsia annotated builder to use getcwd() instead of "."
- Enable ccache when building LLVM.
