### PR TITLE
Remove sivachandra and add ndesaulniers in libc notification list

### DIFF
--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -185,7 +185,7 @@ def getReporters():
             fromaddr = "llvm.buildmaster@lab.llvm.org",
             sendToInterestedUsers = False,
             extraRecipients = ["lntue@google.com", "michaelrj@google.com",
-                            "sivachandra@google.com"],
+                            "ndesaulniers@google.com"],
             subject = "Build %(builder)s Failure",
             mode = "failing",
             builders = ["libc-x86_64-debian", "libc-x86_64_debian-dbg",


### PR DESCRIPTION
Sivachandra has moved on from the libc project and ndesaulniers has joined. This patch ensures the notifications are going to the right place.