### PR TITLE
Upgrade to Clang 17.0.6 in the C++20 buildbot

### DIFF
--- a/buildbot/google/docker/buildbot-cpp20/Dockerfile
+++ b/buildbot/google/docker/buildbot-cpp20/Dockerfile
@@ -18,15 +18,16 @@ RUN apt-get update && \
         cmake ninja-build  \
         ccache \
         python3 python3-pip python3-psutil && \
-    # Install clang-15 to make the minimal C++20 support in the toolchain.
-    echo "deb http://apt.llvm.org/unstable/ llvm-toolchain-15 main" >> /etc/apt/sources.list.d/llvm-15.list && \
+    # Install clang-17 to make the minimal C++20 support in the toolchain.
+    echo "deb http://apt.llvm.org/unstable/ llvm-toolchain-17 main" >> /etc/apt/sources.list.d/llvm-17.list && \
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key >> /etc/apt/trusted.gpg.d/llvm.asc && \
     apt-get update && \
-    apt-get install -y clang-15 lld-15 && \
+    apt-get install -y clang-17 lld-17 && \
     apt-get clean
 
-# Install build bot (server was at 2.8.5-dev at time of writing).
-RUN pip3 install buildbot-worker==2.8.4
+# Install build bot (server was at 2.8.4 at time of writing).
+# We need --break-system-packages to install globally.
+RUN pip3 install --break-system-packages buildbot-worker==2.8.4
 
 # Workaround permissions issues when writing to named volumes
 # https://github.com/docker/compose/issues/3270#issuecomment-206214034
@@ -62,9 +63,9 @@ ENV WORKER_NAME="clang-debian-cpp20"
 ENV BUILDBOT_PORT="9994"
 
 # Configure LLVM tools.
-ENV CC=clang-15
-ENV CXX=clang++-15
-ENV LD=ld.lld-15
+ENV CC=clang-17
+ENV CXX=clang++-17
+ENV LD=ld.lld-17
 
 # Run startup script.
 CMD /home/buildbot/run.sh


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/pull/72348 for some context on why we need this upgrade.