### PR TITLE
Accept new requests on SVE builders only if idle

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -442,6 +442,7 @@ all = [
     'tags'  : ["clang"],
     'workernames' : ["linaro-g3-01", "linaro-g3-02", "linaro-g3-03", "linaro-g3-04"],
     'builddir': "clang-aarch64-sve-vla",
+    'max_simultaneous_builds' : 1,
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=False,
                     checkout_flang=True,
@@ -465,6 +466,7 @@ all = [
     'tags'  : ["clang"],
     'workernames' : ["linaro-g3-01", "linaro-g3-02", "linaro-g3-03", "linaro-g3-04"],
     'builddir': "clang-aarch64-sve-vla-2stage",
+    'max_simultaneous_builds' : 1,
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=False,
                     checkout_flang=True,
@@ -490,6 +492,7 @@ all = [
     'tags'  : ["clang"],
     'workernames' : ["linaro-g3-01", "linaro-g3-02", "linaro-g3-03", "linaro-g3-04"],
     'builddir': "clang-aarch64-sve-vls",
+    'max_simultaneous_builds' : 1,
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=False,
                     checkout_flang=True,
@@ -513,6 +516,7 @@ all = [
     'tags'  : ["clang"],
     'workernames' : ["linaro-g3-01", "linaro-g3-02", "linaro-g3-03", "linaro-g3-04"],
     'builddir': "clang-aarch64-sve-vls-2stage",
+    'max_simultaneous_builds' : 1,
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=False,
                     checkout_flang=True,

--- a/buildbot/osuosl/master/master.cfg
+++ b/buildbot/osuosl/master/master.cfg
@@ -62,16 +62,16 @@ c['collapseRequests'] = buildrequest.collapseRequests
 from buildbot.plugins import util
 
 def nextSVEBuild(builder, reqs):
-  if bool(builder.building):
-    return False
-  return min(reqs, key=lambda req: req.submittedAt)
+    if bool(builder.building):
+        return False
+    return min(reqs, key=lambda req: req.submittedAt)
 
 builders = []
 for b in config.builders.all:
-  nextBuild = None
-  if b['name'].startswith("clang-aarch64-sve-"):
-    nextBuild = nextSVEBuild
-  builders.append(util.BuilderConfig(**b, nextBuild=nextBuild))
+    nextBuild = None
+    if b['name'].startswith("clang-aarch64-sve-"):
+        nextBuild = nextSVEBuild
+    builders.append(util.BuilderConfig(**b, nextBuild=nextBuild))
 c['builders'] = builders
 
 for rb in config.release_builders.all:

--- a/buildbot/osuosl/master/master.cfg
+++ b/buildbot/osuosl/master/master.cfg
@@ -61,25 +61,34 @@ c['collapseRequests'] = buildrequest.collapseRequests
 
 from buildbot.plugins import util
 
-def nextSVEBuild(builder, reqs):
-    if bool(builder.building):
-        return False
-    return min(reqs, key=lambda req: req.submittedAt)
+class SimultaneousBuildLimiter:
+    def __init__(self, max_simultaneous_builds):
+        assert isinstance(max_simultaneous_builds, int), \
+            "max_simultaneous_builds must be int"
+        self.max_simultaneous_builds = max_simultaneous_builds
 
-builders = []
-for b in config.builders.all:
-    nextBuild = None
-    if b['name'].startswith("clang-aarch64-sve-"):
-        nextBuild = nextSVEBuild
-    builders.append(util.BuilderConfig(**b, nextBuild=nextBuild))
-c['builders'] = builders
+    def __call__(self, builder, reqs):
+        if len(builder.building) >= self.max_simultaneous_builds:
+            return False
+        return min(reqs, key=lambda req: req.submittedAt)
+
+def getBuilderConfig(builder):
+    if 'max_simultaneous_builds' in builder:
+        builder['nextBuild'] = \
+            SimultaneousBuildLimiter(builder['max_simultaneous_builds'])
+        del builder['max_simultaneous_builds']
+    return util.BuilderConfig(**builder)
+
+c['builders'] = builders = [
+    getBuilderConfig(b) for b in config.builders.all
+]
 
 for rb in config.release_builders.all:
     # Make sure a release builder has the "release" tag.
     tags = rb.get('tags', [])
     if 'release' not in tags:
         rb['tags'] = tags + ['release']
-    builders.append(util.BuilderConfig(**rb))
+    builders.append(getBuilderConfig(rb))
 
 ####### SCHEDULERS
 

--- a/buildbot/osuosl/master/master.cfg
+++ b/buildbot/osuosl/master/master.cfg
@@ -61,9 +61,18 @@ c['collapseRequests'] = buildrequest.collapseRequests
 
 from buildbot.plugins import util
 
-c['builders'] = builders = [
-  util.BuilderConfig(**b) for b in config.builders.all
-]
+def nextSVEBuild(builder, reqs):
+  if bool(builder.building):
+    return False
+  return min(reqs, key=lambda req: req.submittedAt)
+
+builders = []
+for b in config.builders.all:
+  nextBuild = None
+  if b['name'].startswith("clang-aarch64-sve-"):
+    nextBuild = nextSVEBuild
+  builders.append(util.BuilderConfig(**b, nextBuild=nextBuild))
+c['builders'] = builders
 
 for rb in config.release_builders.all:
     # Make sure a release builder has the "release" tag.


### PR DESCRIPTION
Some of Linaro's SVE builders are suffering from starvation,
because there is currently no way to limit how many builds a given
builder can start simultaneously. As there are 4 SVE builders that
may use any of the 4 G3 workers, sometimes some builders use
multiple workers while others end up with none available. This is
aggravated by the fact that the same builders may use more than one
worker for several times in a row, causing other builders to starve
(clang-aarch64-sve-vls, for instance, has been idle for over 3
days once).

The buildbot documentation (2.5.2.8. Prioritizing Builders) says
that builds are started in the builder with the oldest pending
request, but it seems this is not working, possibly because the
collapse requests feature ends up resetting submittedAt time.

While there is a way to limit how many builds a single worker can
run, there is currently no way to limit how many builds a builder
can be running on a pool of workers.

As shown below, this PR aims to enable us to prevent Builder A from
building on Worker 1 and Worker 2 at the same time. Starving B of
resources.

```
Builder A -->|------------|
           | | Worker 1   |
           | |------------|
           |
Builder B -->|------------|
             | Worker 2   |
             |------------|
```

This is accomplished by introducing the max_simultaneous_builds
setting for builders. Its value specifies the maximum number of
builds that a builder can have simultaneously. This limit is
enforced using nextBuild, from BuilderConfig. With it, it was
possible to limit Linaro's SVE builders to only one build at a time.