### PR TITLE
Update the builder configurations on as-builder-4(-rel) worker hosts.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -125,7 +125,7 @@ all = [
     {'name' : "llvm-clang-x86_64-expensive-checks-ubuntu",
     'tags'  : ["llvm", "expensive-checks"],
     'workernames' : ["as-builder-4"],
-    'builddir': "llvm-clang-x86_64-expensive-checks-ubuntu",
+    'builddir': "expensive-checks",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     depends_on_projects=["llvm", "lld"],
                     clean=True,
@@ -1337,7 +1337,7 @@ all = [
     'tags'  : ["lld"],
     'collapseRequests': False,
     'workernames' : ["as-builder-4"],
-    'builddir' : "lld-x86_64-ubuntu-fast",
+    'builddir' : "lld-x86_64",
     'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     depends_on_projects=['llvm', 'lld'],
                     clean=True,

--- a/buildbot/osuosl/master/config/release_builders.py
+++ b/buildbot/osuosl/master/config/release_builders.py
@@ -64,9 +64,6 @@ all = [
                         "-DLLVM_LIT_ARGS=-vv --time-tests"],
                     env={
                         'CCACHE_DIR' : WithProperties("%(builddir)s/ccache-db"),
-                        # TMP/TEMP within the build dir (to utilize a ramdisk).
-                        'TMP'        : WithProperties("%(builddir)s/build"),
-                        'TEMP'       : WithProperties("%(builddir)s/build"),
                     })},
 
     {'name' : "llvm-clang-x86_64-expensive-checks-win-release",
@@ -205,9 +202,6 @@ all = [
                         '-DLLVM_ENABLE_WERROR=OFF'],
                     env={
                         'CCACHE_DIR' : WithProperties("%(builddir)s/ccache-db"),
-                        # TMP/TEMP within the build dir (to utilize a ramdisk).
-                        'TMP'        : WithProperties("%(builddir)s/build"),
-                        'TEMP'       : WithProperties("%(builddir)s/build"),
                     })},
 
 # LTO and ThinLTO builders.


### PR DESCRIPTION
* reduce a build path for the builders to avoid failures for the unix socket related tests (the expensive check builders).
* remove TMP/TEMP substitution for the release builders (we don't use a ramdisk for these builders).

We start getting the failures for the unix socket related tests when overriding TMP/TEMP env variables with the longer path on the Linux hosts, The tests create an unique path for the sockets based on TMP + uniqie name + socket name. The test gets failed when a total length of this path overflows a limit in 108 characters.