### PR TITLE
[libc][AMDGPU] Enable parallel tests for libc on AMDGPU

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1812,7 +1812,6 @@ all += [
                             "-DLIBC_GPU_BUILD=ON",
                             "-DLIBC_GPU_ARCHITECTURES=gfx906",
                             "-DLIBC_GPU_TEST_ARCHITECTURE=gfx906",
-                            "-DLIBC_GPU_TEST_JOBS=1",
                             ],
                         install=True,
                         testsuite=False,


### PR DESCRIPTION
It appears that https://github.com/llvm/llvm-project/pull/70695 fixed an issue that prevented libc unit tests to be run in parallel.