### PR TITLE
[OpenMP][Flang] Adds experimental OpenMP bot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1824,6 +1824,32 @@ all += [
                         add_lit_checks=["check-clang", "check-llvm", "check-lld", "check-libc"]
                     )},
 
+    {'name' : "openmp-offload-amdgpu-clang-flang",
+    'tags'  : ["openmp,flang"],
+    'workernames' : ["rocm-worker-hw-01"],
+    'builddir': "openmp-offload-amdgpu-clang-flang",
+    'factory' : OpenMPBuilder.getOpenMPCMakeBuildFactory(
+                        clean=True,
+                        enable_runtimes=['openmp'],
+                        depends_on_projects=['llvm','clang','lld','openmp','flang'],
+                        extraCmakeArgs=[
+                            "-DCMAKE_BUILD_TYPE=Release",
+                            "-DCLANG_DEFAULT_LINKER=lld",
+                            "-DLLVM_TARGETS_TO_BUILD=X86;AMDGPU",
+                            "-DLLVM_ENABLE_ASSERTIONS=ON",
+                            "-DLLVM_ENABLE_RUNTIMES=openmp",
+                            "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
+                            "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
+                            ],
+                        install=True,
+                        testsuite=False,
+                        testsuite_sollvevv=False,
+                        extraTestsuiteCmakeArgs=[
+                            "-DTEST_SUITE_SOLLVEVV_OFFLOADING_CFLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
+                            "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
+                        ],
+                    )},
+
 
 # Whole-toolchain builders.
 

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -298,6 +298,9 @@ def get_all():
         create_worker("omp-vega20-0", properties={'jobs': 32}, max_builds=1),
         create_worker("omp-vega20-1", properties={'jobs': 32}, max_builds=1),
 
+        # Flang OpenMP on AMDGPU, Ubuntu 22.04.3, AMD(R) EPYC 9354 @ 2.5GHz with 512GB Memory, 1 MI210 GPU with 64GB Memory
+        create_worker("rocm-worker-hw-01", properties={'jobs': 64}, max_builds=1),
+
         # AMD ROCm support, Ubuntu 18.04.6, AMD Ryzen @ 1.5 GHz, MI200 GPU
         create_worker("mi200-buildbot", max_builds=1),
 


### PR DESCRIPTION
This bot adds clang and flang frontends to the OpenMP runtime on AMDGPUs. Given the current state of flang, this can still be seen quite experimental.
Also, this relies on a new worker that is not yet connected.