### PR TITLE
Update the 'flang-runtime-cuda-gcc' builder configuration.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2787,7 +2787,6 @@ all += [
                     src_to_build_dir="flang/runtime",
                     targets=["FortranRuntime"],
                     extra_configure_args=[
-                        "-DLLVM_CCACHE_BUILD=ON",
                         "-DCMAKE_BUILD_TYPE=Release",
                         "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
@@ -2797,7 +2796,10 @@ all += [
                         "-DCMAKE_CXX_COMPILER=/usr/bin/g++",
                         "-DCMAKE_C_COMPILER=/usr/bin/gcc",
                         "-DCMAKE_CUDA_HOST_COMPILER=/usr/bin/g++",
-                        "-DCMAKE_CUDA_ARCHITECTURES='50;60;70;80'",
+                        "-DCMAKE_CUDA_ARCHITECTURES=80",
+                        "-DCMAKE_CUDA_COMPILER_LAUNCHER=ccache",
+                        "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
+                        "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                     ],
                     env={
                         'CCACHE_DIR' : WithProperties("%(builddir)s/ccache-db"),


### PR DESCRIPTION
We start getting the build timeout errors for the `flang-runtime-cuda-gcc` builder ([build](https://lab.llvm.org/buildbot/#/builders/267/builds/636)) after PR https://github.com/llvm/llvm-project/pull/76486. The reason is that some of added files take around or more than 1200 seconds (20 minutes, default timeout) to compile without any console output.

The most slowly built files:
* findloc.cpp, ~43min
* matmul.cpp, ~20min
* extrema.cpp, ~16min
* matmul-transpose.cpp, ~14min

All of those were compiled by `nvcc` for four GPU arch targets.

To fix the timeout error and reduce interferences with the other builders on the worker I have updated the builder configuration to compile only for the single GPU arch target. It reduces a compilation time for `findloc.cpp` file to 12 minutes. It reduces a full rebuild time (without code caching) to 15-16 minutes apprx. We should be good for now with these updated compile timings.

(Note: all timings are for *[as-builder-7](https://lab.llvm.org/buildbot/#/workers/181)* host configuration)

We can get back with few architectures when the builder will get moved to the dedicated worker host.

A playing with an optimization level does not speed up the build.

Also these changes fix the `ccache` settings for CUDA compilers.