### PR TITLE
Fix fuchsia annotated build path

### DIFF
--- a/zorg/buildbot/builders/annotated/fuchsia-linux.py
+++ b/zorg/buildbot/builders/annotated/fuchsia-linux.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import subprocess
 import sys
+import tempdir
 import traceback
 import util
 
@@ -41,12 +42,8 @@ def main(argv):
     buildbot_revision = os.environ.get('BUILDBOT_REVISION', 'origin/main')
 
     cwd = os.getcwd()
-    build_dir = os.path.join(cwd, '..', 'llvm-build')
+    build_dir = tempfile.mkdtemp('', 'llvm-build-', cwd)
     source_dir = os.path.join(cwd, '..', 'llvm-project')
-
-    if buildbot_clobber:
-        with step('clean', halt_on_fail=True):
-            util.clean_dir(build_dir)
 
     with step('configure', halt_on_fail=True):
         cmake_args = [

--- a/zorg/buildbot/builders/annotated/fuchsia-linux.py
+++ b/zorg/buildbot/builders/annotated/fuchsia-linux.py
@@ -41,7 +41,6 @@ def main(argv):
     buildbot_revision = os.environ.get('BUILDBOT_REVISION', 'origin/main')
 
     cwd = os.getcwd()
-    build_dir = cwd
     build_dir = os.path.join(cwd, '..', 'llvm-build')
     source_dir = os.path.join(cwd, '..', 'llvm-project')
 

--- a/zorg/buildbot/builders/annotated/fuchsia-linux.py
+++ b/zorg/buildbot/builders/annotated/fuchsia-linux.py
@@ -42,6 +42,7 @@ def main(argv):
 
     cwd = os.getcwd()
     build_dir = cwd
+    build_dir = os.path.join(cwd, '..', 'llvm-build')
     source_dir = os.path.join(cwd, '..', 'llvm-project')
 
     if buildbot_clobber:


### PR DESCRIPTION
The fuchsia build dir is set to the current working directory. 
This change moves build dir  to be a sibling of the llvm-project source directory so it can be safely cleaned for each build.
