### PR TITLE
[LibC][AMDGPU] Enable 8-way parallel AMDGPU tests

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1812,6 +1812,7 @@ all += [
                             "-DLIBC_GPU_BUILD=ON",
                             "-DLIBC_GPU_ARCHITECTURES=gfx906",
                             "-DLIBC_GPU_TEST_ARCHITECTURE=gfx906",
+                            "-DLIBC_GPU_TEST_JOBS=8",
                             ],
                         install=True,
                         testsuite=False,


### PR DESCRIPTION
This enables an actual 8-way parallel testing of libc for GPU on AMDGPU. We limit the number of concurrent executions since we have some anecdotal evidence that highly-parallel execution can still provoke some issues. I think we should test some parallel execution though and we did not see hangs on other systems with low numbers of parallel jobs.