### PR TITLE
Remove BOLT_CLANG_EXE from premerge builder

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3013,6 +3013,5 @@ all += [
                       "-DLLVM_LIT_ARGS=-v",
                       "-DLLVM_ENABLE_LLD=ON",
                       "-DCMAKE_CXX_FLAGS=-gmlt",
-                      "-DBOLT_CLANG_EXE=/usr/bin/clang",
                       "-DLLVM_CCACHE_BUILD=ON"])},
 ]


### PR DESCRIPTION
The option doesn't make sense as clang is being built and BOLT tests can
use trunk clang instead.
