### PR TITLE
Update 'llvm-clang-x86_64-win-fast' builder.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -88,15 +88,21 @@ all = [
                     depends_on_projects=['llvm', 'clang'],
                     clean=True,
                     checks=[
-                    "check-llvm-unit",
-                    "check-clang-unit"],
+                        "check-llvm-unit",
+                        "check-clang-unit"
+                    ],
                     extra_configure_args=[
+                        "-DLLVM_CCACHE_BUILD=ON",
                         "-DLLVM_ENABLE_WERROR=OFF",
                         "-DLLVM_TARGETS_TO_BUILD=ARM",
                         "-DLLVM_DEFAULT_TARGET_TRIPLE=armv7-unknown-linux-eabihf",
                         "-DLLVM_ENABLE_ASSERTIONS=OFF",
                         "-DLLVM_OPTIMIZED_TABLEGEN=OFF",
-                        "-DLLVM_LIT_ARGS=-v --threads=32"])},
+                        "-DLLVM_LIT_ARGS=-v --threads=32",
+                    ],
+                    env={
+                        'CCACHE_DIR' : WithProperties("%(builddir)s/ccache-db"),
+                    })},
 
     {'name': "llvm-clang-x86_64-sie-ubuntu-fast",
     'tags'  : ["clang", "llvm", "clang-tools-extra", "lld", "cross-project-tests"],


### PR DESCRIPTION
Enable 'ccache' cached builds.