### PR TITLE
[LLDB] Remove builder class jobs option, only use worker's jobs property if present

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1323,8 +1323,7 @@ all = [
                     extra_cmake_args=[
                         '-DLLVM_ENABLE_ASSERTIONS=True',
                         '-DLLVM_LIT_ARGS=-v',
-                        '-DLLVM_USE_LINKER=lld'],
-                    jobs=None)},
+                        '-DLLVM_USE_LINKER=lld'])},
 
     {'name' : "lldb-arm-ubuntu",
     'tags'  : ["lldb"],
@@ -1336,8 +1335,7 @@ all = [
                     extra_cmake_args=[
                         '-DLLVM_ENABLE_ASSERTIONS=True',
                         '-DLLVM_LIT_ARGS=-vj 4',
-                        '-DLLVM_USE_LINKER=gold'],
-                    jobs=None)},
+                        '-DLLVM_USE_LINKER=gold'])},
 
     {'name' : "lldb-aarch64-windows",
     'tags'  : ["lldb"],
@@ -1352,8 +1350,7 @@ all = [
                         '-DLLVM_LIT_ARGS=-v',
                         # Hardware breakpoints and watchpoints are not yet supported,
                         # https://github.com/llvm/llvm-project/issues/80665.
-                        '-DLLDB_TEST_USER_ARGS=--skip-category=watchpoint'],
-                    jobs=None)},
+                        '-DLLDB_TEST_USER_ARGS=--skip-category=watchpoint'])},
 
 # LLD builders.
 

--- a/zorg/buildbot/builders/LLDBBuilder.py
+++ b/zorg/buildbot/builders/LLDBBuilder.py
@@ -11,10 +11,6 @@ from zorg.buildbot.process.factory import LLVMBuildFactory
 # CMake builds
 def getLLDBCMakeBuildFactory(
             clean=False,
-            # None means use the "jobs" property of the worker, if it has one.
-            # If this argument is not None, it should be set to the number of
-            # jobs to use.
-            jobs=None,
 
             # Source directory containing a built python
             python_source_dir=None,
@@ -52,15 +48,12 @@ def getLLDBCMakeBuildFactory(
     test_cmd = ['ninja','check-lldb']
     lit_args = '-v'
 
-    if jobs:
-        jobs_option = ["-j{}".format(jobs)]
-    else:
-        # Use the worker property if option was not explicitly specified.
-        jobs_option = [
-            # If jobs exists, add -j. If not, add nothing.
-            WithProperties("%(jobs:+-j)s"),
-            # If jobs exists, add its value. If not, add nothing.
-            WithProperties("%(jobs:-)s")]
+    # If the worker has specified a number of jobs, use it.
+    jobs_option = [
+        # If jobs exists, add -j. If not, add nothing.
+        WithProperties("%(jobs:+-j)s"),
+        # If jobs exists, add its value. If not, add nothing.
+        WithProperties("%(jobs:-)s")]
 
     build_cmd.extend(jobs_option)
     install_cmd.extend(jobs_option)

--- a/zorg/buildbot/builders/LLDBBuilder.py
+++ b/zorg/buildbot/builders/LLDBBuilder.py
@@ -12,7 +12,8 @@ from zorg.buildbot.process.factory import LLVMBuildFactory
 def getLLDBCMakeBuildFactory(
             clean=False,
             # None means use the "jobs" property of the worker, if it has one.
-            # If it is set, it should be set to the number of jobs to use.
+            # If this argument is not None, it should be set to the number of
+            # jobs to use.
             jobs=None,
 
             # Source directory containing a built python


### PR DESCRIPTION
Previously the builder class argument "jobs" defaulted to a string to use with `WithProperties`. This assumed that every worker has a "jobs" property, which is no longer true after changes to Linaro's workers.

The behaviour of `WithProperties` is detailed here: https://github.com/buildbot/buildbot/blob/6e7218792bc324584af980bd1abb4d8b6a5055b8/master/docs/manual/configuration/properties.rst#withproperties

As no builder was using the `jobs=` argument I have removed it and adapted code from `NinjaCommand` to add `-j<jobs>` only if the property exists.

Meaning that Linaro's workers that do not have a "jobs" property will not be limited. `lldb-x86_64-debian` will have a `-j` because its worker specifies `'jobs': 72`.

According to Buildbot docs, `WithProperties` should be replaced with `Iterpolate`, but I think doing so here would only complicate this change.