### PR TITLE
Switch sparc64-linux to single-stage builds

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -775,21 +775,6 @@ all = [
                                       '-DLLVM_PARALLEL_LINK_JOBS=4',
                                       '-DLLVM_TARGETS_TO_BUILD=Sparc'])},
 
-    {'name' : "clang-sparc64-linux-multistage",
-    'tags'  : ["clang"],
-    'workernames' : ["debian-stadler-sparc64"],
-    'builddir': "clang-sparc64-linux-multistage",
-    'factory' : ClangBuilder.getClangCMakeBuildFactory(
-                    clean=False,
-                    checkout_lld=False,
-                    enable_runtimes=None,
-                    useTwoStage=True,
-                    stage1_config='Release',
-                    stage2_config='Release',
-                    extra_cmake_args=['-DLLVM_ENABLE_ASSERTIONS=ON',
-                                      '-DLLVM_PARALLEL_LINK_JOBS=4',
-                                      '-DLLVM_TARGETS_TO_BUILD=Sparc'])},
-
     ## LoongArch64 Clang+LLVM build check-all + test-suite
     {'name' : 'clang-loongarch64-linux',
     'tags'  : ['clang'],

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -760,6 +760,21 @@ all = [
                         "-DLLVM_CCACHE_BUILD=ON",
                         "-DLLVM_ENABLE_ASSERTIONS=ON"])},
 
+    {'name' : 'clang-sparc64-linux',
+    'tags'  : ['clang'],
+    'workernames' : ['debian-stadler-sparc64'],
+    'builddir': 'clang-sparc64-linux',
+    'factory' : ClangBuilder.getClangCMakeBuildFactory(
+                    clean=False,
+                    runTestSuite=True,
+                    checkout_clang_tools_extra=False,
+                    checkout_compiler_rt=False,
+                    checkout_lld=False,
+                    testsuite_flags=['--threads=32', '--build-threads=32'],
+                    extra_cmake_args=['-DLLVM_ENABLE_PROJECTS=clang',
+                                      '-DLLVM_PARALLEL_LINK_JOBS=4',
+                                      '-DLLVM_TARGETS_TO_BUILD=Sparc'])},
+
     {'name' : "clang-sparc64-linux-multistage",
     'tags'  : ["clang"],
     'workernames' : ["debian-stadler-sparc64"],


### PR DESCRIPTION
As more than 400 tests are currently failing for the Sparc target, it makes little sense to test two-stage builds until these issues have all been sorted out. Thus, switch sparc64 builds on Linux to single stage.