### PR TITLE
[Clang] Move LoongArch from LLVM_EXPERIMENTAL_TARGETS_TO_BUILD to LLVM_TARGETS_TO_BUILD

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -787,8 +787,7 @@ all = [
                     checkout_compiler_rt=False,
                     checkout_lld=False,
                     testsuite_flags=['--threads=32', '--build-threads=32'],
-                    extra_cmake_args=['-DLLVM_TARGETS_TO_BUILD=',
-                                      '-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=LoongArch',
+                    extra_cmake_args=['-DLLVM_TARGETS_TO_BUILD=LoongArch',
                                       '-DLLVM_ENABLE_PROJECTS=clang'])},
 
     {'name' : "clang-hexagon-elf",


### PR DESCRIPTION
As LoongArch has already been in the LLVM_ALL_TARGETS instead of LLVM_ALL_EXPERIMENTAL_TARGETS list in the llvm-project, this patch will match cmake config to it on LoongArch builder.