### PR TITLE
[flang] Remove pgmath linker flag for test suite

### DIFF
--- a/zorg/buildbot/builders/ClangBuilder.py
+++ b/zorg/buildbot/builders/ClangBuilder.py
@@ -518,8 +518,6 @@ def _getClangCMakeBuildFactory(
             if checkout_flang:
                 fortran_flags = [
                         '--cmake-define=TEST_SUITE_FORTRAN:STRING=ON',
-                        '--cmake-define=CMAKE_Fortran_FLAGS:STRING=' +
-                            '-lpgmath',
                         util.Interpolate(
                             '--cmake-define=CMAKE_Fortran_COMPILER=' +
                             '%(prop:builddir)s/'+compiler_path+'/bin/'+fc)]


### PR DESCRIPTION
After https://reviews.llvm.org/D140236 (and other changes I'm sure), flang doesn't need pgmath to link executables.

Seems good to be testing based on that, plus it will clean up a bunch of warnings from Linaro's bots:
flang-new: warning: -lpgmath: 'linker' input unused [-Wunused-command-line-argument]

That end up polluting the emails we send on a failed build.