### PR TITLE
[LLVMPoller] Fix an exception in case of changing files in the root

### DIFF
--- a/zorg/buildbot/changes/llvmgitpoller.py
+++ b/zorg/buildbot/changes/llvmgitpoller.py
@@ -70,7 +70,7 @@ class LLVMPoller(changes.GitPoller):
                 continue
 
             pieces = path.split('/')
-            project = pieces[0] if len(pieces) > 1 else None
+            project = pieces[0] if len(pieces) > 1 else 'root'
 
             #log.msg("LLVMPoller: _transform_path: processing path %s: project: %s" % (path, project))
             # Collect file path for each detected projects.

--- a/zorg/buildbot/changes/llvmgitpoller.py
+++ b/zorg/buildbot/changes/llvmgitpoller.py
@@ -70,7 +70,7 @@ class LLVMPoller(changes.GitPoller):
                 continue
 
             pieces = path.split('/')
-            project = pieces[0] if len(pieces) > 1 else 'root'
+            project = pieces[0] if len(pieces) > 1 else 'llvm-project'
 
             #log.msg("LLVMPoller: _transform_path: processing path %s: project: %s" % (path, project))
             # Collect file path for each detected projects.


### PR DESCRIPTION
`project=None` will cause the following exception
```
File "/zorg/buildbot/changes/llvmgitpoller.py", line 188, in _process_changes
    project=",".join(projects) if projects else "llvm-project",
builtins.TypeError: sequence item 0: expected str instance, NoneType found
```
Use a dummy str instead.