### PR TITLE
[LLVMPoller] Fix invalid repository while creating a new change

### DIFF
--- a/zorg/buildbot/changes/llvmgitpoller.py
+++ b/zorg/buildbot/changes/llvmgitpoller.py
@@ -187,6 +187,6 @@ class LLVMPoller(changes.GitPoller):
                        category=self.category, ## TODO: Figure out if we could support tags here
                        project=",".join(projects) if projects else "llvm-project",
                        # Always promote an external github url of the LLVM project with the changes.
-                       repository=self.repourl,
+                       repository=self.repourl if self.repourl.startswith('https://github.com') else self._repourl,
                        src='git', # Must be one of the buildbot.process.users.srcs
                        properties=properties)

--- a/zorg/buildbot/changes/llvmgitpoller.py
+++ b/zorg/buildbot/changes/llvmgitpoller.py
@@ -187,6 +187,6 @@ class LLVMPoller(changes.GitPoller):
                        category=self.category, ## TODO: Figure out if we could support tags here
                        project=",".join(projects) if projects else "llvm-project",
                        # Always promote an external github url of the LLVM project with the changes.
-                       repository=self._repourl,
+                       repository=self.repourl,
                        src='git', # Must be one of the buildbot.process.users.srcs
                        properties=properties)


### PR DESCRIPTION
LLVMPoller can be configured to use other `repourl` for test/debug purpose. But LLVMPoller always provides `https://github.com/llvm/llvm-project` as the repository while creating a new change. Then `GitHubStatusPush._extract_github_info()` extracts invalid `repo_owner` and `repo_name`. This patch fixes the issue described above.