### PR TITLE
[HIP] Add libunwind to LLVM_ENABLE_RUNTIMES

### DIFF
--- a/zorg/buildbot/builders/annotated/hip-build.sh
+++ b/zorg/buildbot/builders/annotated/hip-build.sh
@@ -78,7 +78,7 @@ cmake -G Ninja \
   -DCMAKE_VERBOSE_MAKEFILE=1 \
   -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" \
   -DLLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra;compiler-rt" \
-  -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \
+  -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
   -DLIBCXX_ENABLE_SHARED=OFF \
   -DLIBCXX_ENABLE_STATIC=ON \
   -DLIBCXX_INSTALL_LIBRARY=OFF \


### PR DESCRIPTION
It seems that this is needed now.

Should fix the current state of the clang-hip-builder.
https://lab.llvm.org/buildbot/#/builders/165/builds/48048