### PR TITLE
Add 2 new mac workers/builders as well as reallocate resources on some existing workers.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1003,6 +1003,42 @@ all = [
                         "-DLLVM_PARALLEL_LINK_JOBS=16",
                         "-DLLVM_USE_LINKER=gold"])},
 
+    {'name': "llvm-clang-x86_64-darwin",
+    'tags'  : ["llvm", "clang", "clang-tools-extra", "lld", "cross-project-tests"],
+    'workernames': ["doug-worker-3"],
+    'builddir': "x86_64-darwin",
+    'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                    clean=True,
+                    depends_on_projects=['llvm','clang','clang-tools-extra','lld','cross-project-tests'],
+                    extra_configure_args=[
+                        "-DCMAKE_C_COMPILER=clang",
+                        "-DCMAKE_CXX_COMPILER=clang++",
+                        "-DCMAKE_BUILD_TYPE=Release",
+                        "-DLLVM_BUILD_TESTS=ON",
+                        "-DLLVM_CCACHE_BUILD=ON",
+                        "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_INCLUDE_EXAMPLES=OFF"
+                        "-DLLVM_LIT_ARGS=--verbose",
+                        "-DLLVM_TARGETS_TO_BUILD=X86"])},
+
+    {'name': "llvm-clang-aarch64-darwin",
+    'tags'  : ["llvm", "clang", "clang-tools-extra", "lld", "cross-project-tests"],
+    'workernames': ["doug-worker-4"],
+    'builddir': "aarch64-darwin",
+    'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                    clean=True,
+                    depends_on_projects=['llvm','clang','clang-tools-extra','lld','cross-project-tests'],
+                    extra_configure_args=[
+                        "-DCMAKE_C_COMPILER=clang",
+                        "-DCMAKE_CXX_COMPILER=clang++",
+                        "-DCMAKE_BUILD_TYPE=Release",
+                        "-DLLVM_BUILD_TESTS=ON",
+                        "-DLLVM_CCACHE_BUILD=ON",
+                        "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_INCLUDE_EXAMPLES=OFF",
+                        "-DLLVM_LIT_ARGS=--verbose",
+                        "-DLLVM_TARGETS_TO_BUILD=AArch64"])},
+
 # Polly builders.
 
     {'name' : "polly-arm-linux",

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -278,17 +278,22 @@ def get_all():
         create_worker("sie-linux-worker", properties={'jobs': 40}, max_builds=1),
         # 2012 Mac Mini host, 16GB memory:
         #   - Ubuntu 18.04 in docker container
-        create_worker("doug-worker-1a", properties={'jobs': 10}, max_builds=1),
+        create_worker("doug-worker-1a", properties={'jobs': 8}, max_builds=1),
         #   - Ubuntu 22.04 in docker container
-        create_worker("doug-worker-1b", properties={'jobs': 10}, max_builds=1),
+        create_worker("doug-worker-1b", properties={'jobs': 8}, max_builds=1),
         # Ubuntu 18.04 in docker container on Ryzen 4800U
-        create_worker("doug-worker-2a", properties={'jobs': 22}, max_builds=1),
-        # Configuration TBD
+        create_worker("doug-worker-2a", properties={'jobs': 16}, max_builds=1),
+        # Ubuntu 20.04 on AWS, AMD EPYC 7R13 shared
         create_worker("sie-linux-worker2", properties={'jobs': 32}, max_builds=1),
         create_worker("sie-linux-worker3", properties={'jobs': 32}, max_builds=1),
 
         # Windows Server 2019 on AWS, x86_64 PS4 target
         create_worker("sie-win-worker", properties={'jobs': 64}, max_builds=1),
+
+        # Mac target, Intel Core i7-8700B, 64GB
+        create_worker("doug-worker-3", properties={'jobs': 12}, max_builds=1),
+        # Mac target, Apple M1, 16GB
+        create_worker("doug-worker-4", properties={'jobs': 8}, max_builds=1),
 
         # XCore target, Ubuntu 20.04 x64 host
         create_worker("xcore-ubuntu20-x64", properties={'jobs': 4}, max_builds=1),


### PR DESCRIPTION
Adding two new mac builders since I will soon have some spare machines lying around idle and we don't seem to have much mac coverage on the main buildbot.

Also reduced the number of parallel threads used by a few other workers that were sharing another machine's distributed compilation resources (that machine will be redeployed as one of the new mac workers).