### PR TITLE
Use a single stage build for Fuchsia toolchain

### DIFF
--- a/zorg/buildbot/builders/annotated/fuchsia-linux-staging.py
+++ b/zorg/buildbot/builders/annotated/fuchsia-linux-staging.py
@@ -55,21 +55,20 @@ def main(argv):
             '-S', f'{source_dir}/llvm',
             '-B', build_dir,
             '-G', 'Ninja',
-            '-D', 'BOOTSTRAP_LLVM_ENABLE_LTO=OFF',
             '-D', 'LLVM_CCACHE_BUILD=ON',
             '-D', 'LLVM_ENABLE_LTO=OFF',
             '-D', f'FUCHSIA_SDK={args.sdk_dir}',
-            '-C', f'{source_dir}/clang/cmake/caches/Fuchsia.cmake',
+            '-C', f'{source_dir}/clang/cmake/caches/Fuchsia-stage2.cmake',
         ]
 
         run_command(['cmake'] + cmake_args)
 
     with step('build'):
-        run_command(['ninja', '-C', build_dir, 'stage2-toolchain-distribution'])
+        run_command(['ninja', '-C', build_dir, 'toolchain-distribution'])
 
     with step('check'):
         run_command(['ninja', '-C', build_dir] +
-                    [f'stage2-check-{p}' for p in ('llvm', 'clang', 'lld')])
+                    [f'check-{p}' for p in ('llvm', 'clang', 'lld')])
 
     return 0
 


### PR DESCRIPTION
This patch updates the configuration for the Fuchsia staging builder to
use a single stage build to reduce the build time.
