### PR TITLE
Stop building Fuchsia runtime variants on Fuchsia staging bots

### DIFF
--- a/zorg/buildbot/builders/annotated/fuchsia-linux-staging.py
+++ b/zorg/buildbot/builders/annotated/fuchsia-linux-staging.py
@@ -58,6 +58,7 @@ def main(argv):
             '-D', 'LLVM_CCACHE_BUILD=ON',
             '-D', 'LLVM_ENABLE_LTO=OFF',
             '-D', f'FUCHSIA_SDK={args.sdk_dir}',
+            '-D', 'LLVM_RUNTIME_MULTILIBS=',
             '-C', f'{source_dir}/clang/cmake/caches/Fuchsia-stage2.cmake',
         ]
 


### PR DESCRIPTION
We don't need the runtime variants on build bots. This patch disable it
so the build time can be further reduced.
