### PR TITLE
[OpenMP] Disabling SDMA transfers AMDGPU offload bots

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1826,6 +1826,9 @@ all += [
                             "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                             "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
                             ],
+                        env={
+                            'HSA_ENABLE_SDMA':'0',
+                            },
                         install=True,
                         testsuite=False,
                         testsuite_sollvevv=False,
@@ -1885,6 +1888,9 @@ all += [
                             "-DLIBC_GPU_TEST_ARCHITECTURE=gfx906",
                             "-DLIBC_GPU_TEST_JOBS=8",
                             ],
+                        env={
+                            'HSA_ENABLE_SDMA':'0',
+                            },
                         install=True,
                         testsuite=False,
                         testsuite_sollvevv=False,
@@ -1912,6 +1918,9 @@ all += [
                             "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                             "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
                             ],
+                        env={
+                            'HSA_ENABLE_SDMA':'0',
+                            },
                         install=True,
                         testsuite=False,
                         testsuite_sollvevv=False,


### PR DESCRIPTION
This disables host/device and device/host transfers via the SDMA engines for the OpenMP Offload AMDGPU buildbots.
The motivation is a known issue of a potentially missed synchronization tracked via https://github.com/ROCm/ROCm/issues/2616.

This change was rolled-out to one of the staging bots previously via https://github.com/llvm/llvm-zorg/pull/114 and seemed to remove the flakiness we were observing.