### PR TITLE
[lldb] Use NinjaCommand instead of manually building options

### DIFF
--- a/zorg/buildbot/builders/LLDBBuilder.py
+++ b/zorg/buildbot/builders/LLDBBuilder.py
@@ -4,6 +4,7 @@ from buildbot.process.properties import WithProperties, Property
 from buildbot.plugins import steps
 
 from zorg.buildbot.commands.CmakeCommand import CmakeCommand
+from zorg.buildbot.commands.NinjaCommand import NinjaCommand
 from zorg.buildbot.builders.Util import getVisualStudioEnvironment
 from zorg.buildbot.builders.Util import extractVSEnvironment
 from zorg.buildbot.process.factory import LLVMBuildFactory
@@ -43,22 +44,6 @@ def getLLDBCMakeBuildFactory(
 
     f.addGetSourcecodeSteps()
 
-    build_cmd=['ninja']
-    install_cmd = ['ninja','install']
-    test_cmd = ['ninja','check-lldb']
-    lit_args = '-v'
-
-    # If the worker has specified a number of jobs, use it.
-    jobs_option = [
-        # If jobs exists, add -j. If not, add nothing.
-        WithProperties("%(jobs:+-j)s"),
-        # If jobs exists, add its value. If not, add nothing.
-        WithProperties("%(jobs:-)s")]
-
-    build_cmd.extend(jobs_option)
-    install_cmd.extend(jobs_option)
-    test_cmd.extend(jobs_option)
-
     ############# CLEANING
     cleanBuildRequested = lambda step: clean or step.build.getProperty("clean", default=step.build.getProperty("clean_obj"))
     f.addStep(steps.RemoveDirectory(name='clean '+build_dir,
@@ -72,7 +57,7 @@ def getLLDBCMakeBuildFactory(
     cmake_options = [
         "-G", "Ninja",
         "-DCMAKE_BUILD_TYPE=" + config,
-        "-DLLVM_LIT_ARGS='%s'" % lit_args,
+        "-DLLVM_LIT_ARGS='-v'",
         "-DCMAKE_INSTALL_PREFIX=../install",
         "-DLLVM_ENABLE_PROJECTS=%s" % ";".join(f.depends_on_projects),
         ]
@@ -89,16 +74,15 @@ def getLLDBCMakeBuildFactory(
                            env=env,
                            workdir=build_dir))
 
-    f.addStep(WarningCountingShellCommand(name='build',
-                          command=build_cmd,
+    f.addStep(NinjaCommand(name='build',
                           haltOnFailure=True,
                           description='ninja build',
                           workdir=build_dir,
                           env=env))
 
     ignoreInstallFail = bool(install != 'ignoreFail')
-    f.addStep(ShellCommand(name='install',
-                          command=install_cmd,
+    f.addStep(NinjaCommand(targets=['install'],
+                          name='install',
                           flunkOnFailure=ignoreInstallFail,
                           description='ninja install',
                           workdir=build_dir,
@@ -106,11 +90,11 @@ def getLLDBCMakeBuildFactory(
                           env=env))
 
     ignoreTestFail = bool(test != 'ignoreFail')
-    f.addStep(ShellCommand(name='test',
-                          command=test_cmd,
+    f.addStep(NinjaCommand(targets=['check-lldb'],
+                          name='test',
                           flunkOnFailure=ignoreTestFail,
                           timeout=testTimeout,
-                          description='ninja test',
+                          description='ninja check-lldb',
                           workdir=build_dir,
                           doStepIf=bool(test),
                           env=env))

--- a/zorg/buildbot/builders/LLDBBuilder.py
+++ b/zorg/buildbot/builders/LLDBBuilder.py
@@ -57,7 +57,7 @@ def getLLDBCMakeBuildFactory(
     cmake_options = [
         "-G", "Ninja",
         "-DCMAKE_BUILD_TYPE=" + config,
-        "-DLLVM_LIT_ARGS='-v'",
+        "-DLLVM_LIT_ARGS=-v",
         "-DCMAKE_INSTALL_PREFIX=../install",
         "-DLLVM_ENABLE_PROJECTS=%s" % ";".join(f.depends_on_projects),
         ]


### PR DESCRIPTION
Which is what I tried to do in 330340b14f6325d76c96cb1713d29c4258e541b8, but forgot one detail. If there is no property the options have empty string added to them.

This means you get this:
`ninja "" ""`

And ninja thinks that those are targets to build, which don't exist of course.

NinjaCommand already handles this by removing any empty arguments as the final step of building the options. So use that for our ninja steps instead.