### PR TITLE
Remove llvm-new-debug-iterators worker, reassign sie-linux-worker3 and add notifications for darwin builders.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -945,7 +945,7 @@ all = [
 
     {'name': "llvm-clang-x86_64-gcc-ubuntu",
     'tags'  : ["llvm", "clang", "clang-tools-extra", "compiler-rt", "lld", "cross-project-tests"],
-    'workernames': ["doug-worker-2a"],
+    'workernames': ["sie-linux-worker3"],
     'builddir': "llvm-clang-x86_64-gcc-ubuntu",
     'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     depends_on_projects=['llvm','clang','clang-tools-extra','compiler-rt','lld','cross-project-tests'],
@@ -981,27 +981,6 @@ all = [
                         "-DLLVM_PARALLEL_LINK_JOBS=16",
                         "-DLLVM_USE_LINKER=gold",
                         "-DLLVM_ENABLE_WERROR=OFF"])},
-
-    {'name': "llvm-new-debug-iterators",
-    'tags'  : ["llvm", "clang", "clang-tools-extra", "compiler-rt", "lld", "cross-project-tests"],
-    'workernames': ["sie-linux-worker3"],
-    'builddir': "debug-iterators",
-    'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
-                    depends_on_projects=['llvm','clang','clang-tools-extra','compiler-rt','lld','cross-project-tests'],
-                    clean=True,
-                    extra_configure_args=[
-                        "-DCMAKE_C_COMPILER=gcc",
-                        "-DCMAKE_CXX_COMPILER=g++",
-                        "-DCMAKE_BUILD_TYPE=Release",
-                        "-DCLANG_ENABLE_CLANGD=OFF",
-                        "-DLLVM_BUILD_RUNTIME=ON",
-                        "-DLLVM_BUILD_TESTS=ON",
-                        "-DLLVM_ENABLE_ASSERTIONS=ON",
-                        "-DLLVM_EXPERIMENTAL_DEBUGINFO_ITERATORS=ON",
-                        "-DLLVM_INCLUDE_EXAMPLES=OFF",
-                        "-DLLVM_LIT_ARGS=--verbose -j48",
-                        "-DLLVM_PARALLEL_LINK_JOBS=16",
-                        "-DLLVM_USE_LINKER=gold"])},
 
     {'name': "llvm-clang-x86_64-darwin",
     'tags'  : ["llvm", "clang", "clang-tools-extra", "lld", "cross-project-tests"],

--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -266,7 +266,8 @@ def getReporters():
                         "cross-project-tests-sie-ubuntu",
                         "cross-project-tests-sie-ubuntu-dwarf5",
                         "clang-x86_64-linux-abi-test",
-                        "llvm-new-debug-iterators"]),
+                        "llvm-clang-x86_64-darwin",
+                        "llvm-clang-aarch64-darwin"]),
         reporters.MailNotifier(
             fromaddr = "llvm.buildmaster@lab.llvm.org",
             sendToInterestedUsers = False,
@@ -276,13 +277,6 @@ def getReporters():
             builders = ["llvm-clang-x86_64-sie-ubuntu-fast",
                         "llvm-clang-x86_64-sie-win",
                         "llvm-clang-x86_64-gcc-ubuntu"]),
-        reporters.MailNotifier(
-            fromaddr = "llvm.buildmaster@lab.llvm.org",
-            sendToInterestedUsers = False,
-            extraRecipients = ["jeremy.morse.llvm@gmail.com"],
-            subject = "Build %(builder)s Failure",
-            mode = "failing",
-            builders = ["llvm-new-debug-iterators"]),
         reporters.MailNotifier(
             fromaddr="llvm.buildmaster@lab.llvm.org",
             sendToInterestedUsers = False,


### PR DESCRIPTION
This change makes 3 updates to the SIE bot configuration.

1. Retire the llvm-new-debug-iterators worker as it is no longer needed, and remove the notification for this worker.
2. Reassign sie-linux-worker3 to perform the llvm-clang-x86_64-gcc-ubuntu build.
3. Add notifications for myself for my added darwin builders that I previously forget to add when I added the bots.