### PR TITLE
[libc] Update libc build config

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1874,6 +1874,8 @@ all += [
     'factory' : OpenMPBuilder.getOpenMPCMakeBuildFactory(
                         clean=True,
                         depends_on_projects=['llvm', 'clang', 'compiler-rt', 'libc', 'lld', 'openmp'],
+                        # Special case this bot to account for new (verbose) libc build syntax
+                        enable_runtimes=['openmp', 'compiler-rt'],
                         extraCmakeArgs=[
                             "-DCMAKE_BUILD_TYPE=Release",
                             "-DCLANG_DEFAULT_LINKER=lld",
@@ -1883,10 +1885,8 @@ all += [
                             "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
                             "-DLIBOMPTARGET_FOUND_AMDGPU_GPU=ON",
                             "-DLIBOMP_ARCHER_SUPPORT=OFF",
-                            "-DLIBC_GPU_BUILD=ON",
-                            "-DLIBC_GPU_ARCHITECTURES=gfx906",
-                            "-DLIBC_GPU_TEST_ARCHITECTURE=gfx906",
-                            "-DLIBC_GPU_TEST_JOBS=8",
+                            "-DRUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_RUNTIMES=libc",
+                            "-DLLVM_RUNTIME_TARGETS=default;amdgcn-amd-amdhsa",
                             ],
                         env={
                             'HSA_ENABLE_SDMA':'0',
@@ -1898,7 +1898,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_CFLAGS=-fopenmp;-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa;-march=gfx906",
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp;-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa;-march=gfx906",
                         ],
-                        add_lit_checks=["check-clang", "check-llvm", "check-lld", "check-libc"]
+                        add_lit_checks=["check-clang", "check-llvm", "check-lld", "check-libc-amdgcn-amd-amdhsa"]
                     )},
 
     {'name' : "openmp-offload-amdgpu-clang-flang",


### PR DESCRIPTION
How to build libc for GPU is about to change significantly, which requires an update to the way it is built in the bot.

After some back and forth, it appears that it cannot be easily added to the `-DLLVM_ENABLE_RUNTIMES` and instead requires some special handling. Thus, for the libc bot we intentionally work around the `enable_runtimes=auto` option and instead enable `'openmp'` and `'compiler-rt'` manually in the bot specification.
In addition, we specify the new CMake flags for the libc build on AMDGPU.