### PR TITLE
[OpenMP] Possiblity to add lit args to check-openmp

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1815,6 +1815,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_CFLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                         ],
+                        add_openmp_lit_args=["--time-tests", "--timeout 100"],
                     )},
 
     {'name' : "openmp-offload-amdgpu-runtime-2",
@@ -1844,6 +1845,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_CFLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                         ],
+                        add_openmp_lit_args=["--time-tests", "--timeout 100"],
                     )},
 
     {'name' : "openmp-offload-libc-amdgpu-runtime",
@@ -1908,6 +1910,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                         ],
                         add_lit_checks=["check-flang"],
+                        add_openmp_lit_args=["--time-tests", "--timeout 100"],
                     )},
 
 

--- a/zorg/buildbot/builders/OpenMPBuilder.py
+++ b/zorg/buildbot/builders/OpenMPBuilder.py
@@ -21,6 +21,7 @@ def getOpenMPCMakeBuildFactory(
         testsuite_sollvevv  = False,
         extraTestsuiteCmakeArgs = None,
         add_lit_checks      = None,
+        add_openmp_lit_args        = None,
         **kwargs):
 
     if extraCmakeArgs is None:
@@ -72,6 +73,9 @@ def getOpenMPCMakeBuildFactory(
     cmake_args = ['-DCMAKE_BUILD_TYPE=Release', '-DLLVM_ENABLE_ASSERTIONS=ON']
     if test:
         lit_args = '-vv --show-unsupported --show-xfail -j %s' % jobs
+        if add_openmp_lit_args:
+            for add_arg in add_openmp_lit_args:
+                lit_args += ' ' + add_arg
         cmake_args += [WithProperties('-DLLVM_LIT_ARGS=%s' % lit_args)]
     if install:
         cmake_args += [WithProperties('-DCMAKE_INSTALL_PREFIX=%(builddir)s/' + llvm_instdir)]


### PR DESCRIPTION
Enable passing additional lit arguments per bot to the `ninja check-openmp` configuration.
This can be used to set, e.g., timeouts or enable timing the individual tests. The latter requires the Python package `psutil` to be installed.