### PR TITLE
Add a new Darwin worker and release builder

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1002,7 +1002,7 @@ all = [
 
     {'name': "llvm-clang-aarch64-darwin",
     'tags'  : ["llvm", "clang", "clang-tools-extra", "lld", "cross-project-tests"],
-    'workernames': ["doug-worker-4"],
+    'workernames': ["doug-worker-4", "doug-worker-5"],
     'builddir': "aarch64-darwin",
     'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,

--- a/buildbot/osuosl/master/config/release_builders.py
+++ b/buildbot/osuosl/master/config/release_builders.py
@@ -280,4 +280,22 @@ all = [
                         "-DLLVM_PARALLEL_LINK_JOBS=16",
                         "-DLLVM_USE_LINKER=gold"])},
 
+    {'name': "llvm-clang-aarch64-darwin-release",
+    'tags'  : ["llvm", "clang", "clang-tools-extra", "lld", "cross-project-tests"],
+    'workernames': ["doug-worker-4"],
+    'builddir': "aarch64-darwin-rel",
+    'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                    clean=True,
+                    depends_on_projects=['llvm','clang','clang-tools-extra','lld','cross-project-tests'],
+                    extra_configure_args=[
+                        "-DCMAKE_C_COMPILER=clang",
+                        "-DCMAKE_CXX_COMPILER=clang++",
+                        "-DCMAKE_BUILD_TYPE=Release",
+                        "-DLLVM_BUILD_TESTS=ON",
+                        "-DLLVM_CCACHE_BUILD=ON",
+                        "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_INCLUDE_EXAMPLES=OFF",
+                        "-DLLVM_LIT_ARGS=--verbose",
+                        "-DLLVM_TARGETS_TO_BUILD=AArch64"])},
+
 ]

--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -267,7 +267,8 @@ def getReporters():
                         "cross-project-tests-sie-ubuntu-dwarf5",
                         "clang-x86_64-linux-abi-test",
                         "llvm-clang-x86_64-darwin",
-                        "llvm-clang-aarch64-darwin"]),
+                        "llvm-clang-aarch64-darwin",
+                        "llvm-clang-aarch64-darwin-release"]),
         reporters.MailNotifier(
             fromaddr = "llvm.buildmaster@lab.llvm.org",
             sendToInterestedUsers = False,

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -294,6 +294,7 @@ def get_all():
         create_worker("doug-worker-3", properties={'jobs': 12}, max_builds=1),
         # Mac target, Apple M1, 16GB
         create_worker("doug-worker-4", properties={'jobs': 8}, max_builds=1),
+        create_worker("doug-worker-5", properties={'jobs': 8}, max_builds=1),
 
         # XCore target, Ubuntu 20.04 x64 host
         create_worker("xcore-ubuntu20-x64", properties={'jobs': 4}, max_builds=1),


### PR DESCRIPTION
Add a new release builder for the AArch64 Darwin target, and a new worker to share build responsibilities for the llvm-clang-aarch64-darwin builder.