### PR TITLE
Make a few buildbot changes to the SIE buildbots

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -958,8 +958,7 @@ all = [
                         "-DLLVM_BUILD_TESTS=ON",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
                         "-DLLVM_INCLUDE_EXAMPLES=OFF",
-                        "-DLLVM_LIT_ARGS=--verbose -j48",
-                        "-DLLVM_PARALLEL_LINK_JOBS=16",
+                        "-DLLVM_LIT_ARGS=--verbose",
                         "-DLLVM_USE_LINKER=gold"])},
 
     {'name': "clang-x86_64-linux-abi-test",
@@ -977,8 +976,7 @@ all = [
                         "-DLLVM_BUILD_TESTS=ON",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
                         "-DLLVM_INCLUDE_EXAMPLES=OFF",
-                        "-DLLVM_LIT_ARGS=--verbose -j48",
-                        "-DLLVM_PARALLEL_LINK_JOBS=16",
+                        "-DLLVM_LIT_ARGS=--verbose",
                         "-DLLVM_USE_LINKER=gold",
                         "-DLLVM_ENABLE_WERROR=OFF"])},
 

--- a/buildbot/osuosl/master/config/release_builders.py
+++ b/buildbot/osuosl/master/config/release_builders.py
@@ -263,7 +263,7 @@ all = [
 
     {'name': "llvm-clang-x86_64-gcc-ubuntu-release",
     'tags'  : ["llvm", "clang", "clang-tools-extra", "compiler-rt", "lld", "cross-project-tests"],
-    'workernames': ["doug-worker-2a"],
+    'workernames': ["sie-linux-worker3"],
     'builddir': "x86_64-gcc-rel",
     'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     depends_on_projects=['llvm','clang','clang-tools-extra','compiler-rt','lld','cross-project-tests'],
@@ -276,8 +276,7 @@ all = [
                         "-DLLVM_BUILD_TESTS=ON",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
                         "-DLLVM_INCLUDE_EXAMPLES=OFF",
-                        "-DLLVM_LIT_ARGS=--verbose -j48",
-                        "-DLLVM_PARALLEL_LINK_JOBS=16",
+                        "-DLLVM_LIT_ARGS=--verbose",
                         "-DLLVM_USE_LINKER=gold"])},
 
 ]

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -284,8 +284,8 @@ def get_all():
         # Ubuntu 18.04 in docker container on Ryzen 4800U
         create_worker("doug-worker-2a", properties={'jobs': 16}, max_builds=1),
         # Ubuntu 20.04 on AWS, AMD EPYC 7R13 shared
-        create_worker("sie-linux-worker2", properties={'jobs': 32}, max_builds=1),
-        create_worker("sie-linux-worker3", properties={'jobs': 32}, max_builds=1),
+        create_worker("sie-linux-worker2", max_builds=1),
+        create_worker("sie-linux-worker3", max_builds=1),
 
         # Windows Server 2019 on AWS, x86_64 PS4 target
         create_worker("sie-win-worker", properties={'jobs': 64}, max_builds=1),


### PR DESCRIPTION
I am shuffling around the builder assignments for a few workers, so needed to remove the hard coded values as they were causing the machines to become unresponsive when I scaled down the hardware. Also update the llvm-clang-x86_64-gcc-ubuntu release builder to use the sie-linux-worker3 worker (I forgot to update this in a previous change when I updated the non-release job to use this worker).

1. Remove jobs property for 2 linux workers
2. Switch llvm-clang-x86_64-gcc-ubuntu-release to sie-linux-worker3
3. Remove -j value for some LLVM_LIT_ARGS for 2 builds
4. Remove argument LLVM_PARALLEL_LINK_JOBS for 2 builders