### PR TITLE
Revert "Add -DLLVM_DISABLE_ASSEMBLY_FILES=ON to work around a bug in Apple Clang (#129)"

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -998,7 +998,6 @@ all = [
                         "-DCMAKE_BUILD_TYPE=Release",
                         "-DLLVM_BUILD_TESTS=ON",
                         "-DLLVM_CCACHE_BUILD=ON",
-                        "-DLLVM_DISABLE_ASSEMBLY_FILES=ON", # Can be removed once llvm/llvm-project#81967 is fixed
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
                         "-DLLVM_INCLUDE_EXAMPLES=OFF"
                         "-DLLVM_LIT_ARGS=--verbose",


### PR DESCRIPTION
Updating to Apple Clang 1500.3.9.4 fixes the problem that was causing test failures.

Build/test is now passing: https://lab.llvm.org/staging/#/builders/188/builds/444.