### PR TITLE
Try adding an option to automatically install MLIR pip requirements to getCmakeWithNinjaBuildFactory

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3003,6 +3003,7 @@ all += [
                     vs="autodetect",
                     depends_on_projects=["clang-tools-extra", "clang", "flang", "libclc", "lld", "llvm", "mlir", "polly", "pstl"],
                     checks=["check-all"],
+                    install_pip_requirements = True,
                     extra_configure_args=[
                         "-DCMAKE_BUILD_TYPE=Release",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
@@ -3021,6 +3022,7 @@ all += [
     'builddir': "premerge-monolithic-linux",
     'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     depends_on_projects=["bolt", "clang", "clang-tools-extra", "compiler-rt", "flang", "libc", "libclc", "lld", "llvm", "mlir", "polly", "pstl"],
+                    install_pip_requirements = True,
                     extra_configure_args=[
                       "-DCMAKE_BUILD_TYPE=Release",
                       "-DLLVM_ENABLE_ASSERTIONS=ON",

--- a/zorg/buildbot/builders/UnifiedTreeBuilder.py
+++ b/zorg/buildbot/builders/UnifiedTreeBuilder.py
@@ -251,6 +251,7 @@ def getCmakeBuildFactory(
            install_dir = None,
            clean = False,
            extra_configure_args = None,
+           install_pip_requirements = False,
            env = None,
            **kwargs):
 
@@ -264,6 +265,13 @@ def getCmakeBuildFactory(
             **kwargs) # Pass through all the extra arguments.
 
     cleanBuildRequested = lambda step: step.build.getProperty("clean", default=step.build.getProperty("clean_obj")) or clean
+
+    if install_pip_requirements:
+        # Install python requirements, right now for MLIR
+        # but can evolve to more projects later.
+        f.addStep(steps.ShellCommand(command=["pip", "install", "-q", "-r", "mlir/python/requirements.txt"],
+                                     workdir=llvm_srcdir]))
+
     addCmakeSteps(
         f,
         cleanBuildRequested=cleanBuildRequested,
@@ -287,6 +295,7 @@ def getCmakeWithNinjaBuildFactory(
            install_dir = None,
            clean = False,
            extra_configure_args = None,
+           install_pip_requirements = False,
            env = None,
            **kwargs):
 
@@ -321,6 +330,7 @@ def getCmakeWithNinjaBuildFactory(
             install_dir=install_dir,
             clean=clean,
             extra_configure_args=cmake_args,
+            install_pip_requirements=install_pip_requirements,
             env=merged_env,
             **kwargs) # Pass through all the extra arguments.
 


### PR DESCRIPTION
Trying to fix the pre-merge bots which are broken right now.

I can't test it though since I don't have SSH access to these bots.