### PR TITLE
Fix a comma that was accidentally deleted in an argument list.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -999,7 +999,7 @@ all = [
                         "-DLLVM_BUILD_TESTS=ON",
                         "-DLLVM_CCACHE_BUILD=ON",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
-                        "-DLLVM_INCLUDE_EXAMPLES=OFF"
+                        "-DLLVM_INCLUDE_EXAMPLES=OFF",
                         "-DLLVM_LIT_ARGS=--verbose",
                         "-DLLVM_TARGETS_TO_BUILD=X86"])},
 


### PR DESCRIPTION
I was looking at the cmake command for the llvm-clang-x86_64-darwin builder and noticed that two of the arguments were being combined and traced that back to a missing comma in the arguments for the specification of this builder. This change puts that comma back.