### PR TITLE
[flang] Enable OpenMP project for Linaro's bots

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2111,7 +2111,7 @@ all += [
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
                     checks=['check-flang'],
-                    depends_on_projects=['llvm','mlir','clang','flang'],
+                    depends_on_projects=['llvm','mlir','clang','flang','openmp'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DLLVM_BUILD_LLVM_DYLIB=ON",
@@ -2126,7 +2126,7 @@ all += [
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
                     checks=['check-flang'],
-                    depends_on_projects=['llvm','mlir','clang','flang'],
+                    depends_on_projects=['llvm','mlir','clang','flang','openmp'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DBUILD_SHARED_LIBS=ON",
@@ -2159,7 +2159,7 @@ all += [
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
                     checks=['check-flang'],
-                    depends_on_projects=['llvm','mlir','clang','flang'],
+                    depends_on_projects=['llvm','mlir','clang','flang','openmp'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DCMAKE_BUILD_TYPE=Debug",
@@ -2175,7 +2175,7 @@ all += [
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
                     checks=['check-flang'],
-                    depends_on_projects=['llvm','mlir','clang','flang'],
+                    depends_on_projects=['llvm','mlir','clang','flang','openmp'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DLLVM_INSTALL_UTILS=ON",
@@ -2195,7 +2195,7 @@ all += [
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
                     checks=['check-flang'],
-                    depends_on_projects=['llvm','mlir','clang','flang'],
+                    depends_on_projects=['llvm','mlir','clang','flang','openmp'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DCMAKE_BUILD_TYPE=Release",
@@ -2210,7 +2210,7 @@ all += [
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
                     checks=['check-flang'],
-                    depends_on_projects=['llvm','mlir','clang','flang'],
+                    depends_on_projects=['llvm','mlir','clang','flang','openmp'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
@@ -2226,7 +2226,7 @@ all += [
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
                     checks=['check-flang'],
-                    depends_on_projects=['llvm','mlir','clang','flang'],
+                    depends_on_projects=['llvm','mlir','clang','flang','openmp'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DLLVM_INSTALL_UTILS=ON",

--- a/zorg/buildbot/builders/FlangBuilder.py
+++ b/zorg/buildbot/builders/FlangBuilder.py
@@ -14,7 +14,7 @@ def getFlangOutOfTreeBuildFactory(
         env = dict()
 
     f = getCmakeWithNinjaBuildFactory(
-            depends_on_projects=['llvm','clang','mlir'],
+            depends_on_projects=['llvm','clang','mlir','openmp'],
             obj_dir="build_llvm",
             checks=[],
             clean=clean,


### PR DESCRIPTION
As discussed in Discourse and proposed in
https://github.com/llvm/llvm-project/pull/80874, Flang will start
to use C/C++ header files and Fortran modules from OpenMP runtime.

When the mentioned PR lands, all of Flang's OpenMP tests will be
skipped as unsupported, unless the OpenMP project is enabled.