### PR TITLE
Fix hip-build.sh to build llvm/runtime together

### DIFF
--- a/zorg/buildbot/builders/annotated/hip-build.sh
+++ b/zorg/buildbot/builders/annotated/hip-build.sh
@@ -96,7 +96,6 @@ cmake -G Ninja \
   ${LLVM_ROOT}/llvm
 
 build_step "Building LLVM"
-ninja $NINJAOPT runtimes
 ninja $NINJAOPT
 
 build_step "Install LLVM"


### PR DESCRIPTION
Previsouly the bot build runtime first using the old llvm/clang.

This does not work of libc++ or other runtime requires new llvm/clang.