### PR TITLE
clang-aarch64-full-2stage: build lld for stage2 tests

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -425,7 +425,7 @@ all = [
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=False,
                     checkout_flang=True,
-                    checkout_lld=False,
+                    checkout_lld=True,
                     useTwoStage=True,
                     testStage1=False,
                     runTestSuite=True,


### PR DESCRIPTION
A new bitcode format for debug info was added in LLVM in
[e419084da7a00b269368aeb95698e0d36b24e8ec](https://github.com/llvm/llvm-project/commit/e419084da7a00b269368aeb95698e0d36b24e8ec) (currently reverted).

Several tests started failing for this stage2 builder: https://lab.llvm.org/buildbot/#/builders/179/builds/9629

The error indicates the tests are using an incompatible lld to load the new bitcode:
ld.lld: error: Invalid value (Producer: 'LLVM19.0.0git' Reader: 'LLVM 17.0.6')

Locally, re-enabling the currently reverted patch, these tests pass if LLD is built with LLVM_ENABLE_PROJECTS, and fail otherwise.

---

I don't really know how zorg works - I'm not sure if this is the right way to get the stage2 build to build an lld for those tests to use. I think a stage1 build of lld would also be fine, if those tests can find it? Any help would be appreciated.