### PR TITLE
[OpenMP/Offload] Enable Offload runtime and add check

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1832,14 +1832,13 @@ all += [
     'builddir': "openmp-offload-amdgpu-runtime-2",
     'factory' : OpenMPBuilder.getOpenMPCMakeBuildFactory(
                         clean=True,
-                        enable_runtimes=['openmp'],
+                        enable_runtimes=['openmp','offload'],
                         depends_on_projects=['llvm','clang','lld','openmp'],
                         extraCmakeArgs=[
                             "-DCMAKE_BUILD_TYPE=Release",
                             "-DCLANG_DEFAULT_LINKER=lld",
                             "-DLLVM_TARGETS_TO_BUILD=X86;AMDGPU",
                             "-DLLVM_ENABLE_ASSERTIONS=ON",
-                            "-DLLVM_ENABLE_RUNTIMES=openmp",
                             "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                             "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
                             ],
@@ -1853,6 +1852,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_CFLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                         ],
+                        add_lit_checks=['-C runtimes/runtimes-bins check-libomptarget'],
                         add_openmp_lit_args=["--time-tests", "--timeout 100"],
                     )},
 


### PR DESCRIPTION
This enables the new "offload" runtime that
https://github.com/llvm/llvm-project/pull/75125 will create. In addition, it adds a new lit test target.
I removed the extra CMake argument that would again specify which runtimes to build manually, so that we rely on the factory to add the respective runtimes.

Since the PR does not make `check-libomptarget` available in the top level configuration, we have to change the ninja working directory into the runtimes build folder, where the target is known. Whether or not this works with this crude "additional lit checks" mechanism is an experiment.