### PR TITLE
[OpenMP/Offload] Experiment w/ additional lit target

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1853,6 +1853,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_CFLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                         ],
+                        add_lit_checks=['-C runtimes/runtimes-bins check-libomptarget'],
                         add_openmp_lit_args=["--time-tests", "--timeout 100"],
                     )},
 


### PR DESCRIPTION
This commit adds a lit target that has to change the ninja workdir for a target to be picked-up. This is meant as a test as  I'm unsure whether the somewhat crude implementation of add_lit_check is capable to handle it.