### PR TITLE
[green-dragon-migration] fix stage2 thinLTO jobs

### DIFF
--- a/zorg/jenkins/monorepo_build.py
+++ b/zorg/jenkins/monorepo_build.py
@@ -427,6 +427,7 @@ def clang_builder(target):
                                    '-DCLANG_INCLUDE_TESTS=On',
                                    '-DLLVM_INCLUDE_UTILS=On',
                                    '-DCMAKE_MACOSX_RPATH=On',
+                                   '-DLLVM_ENABLE_MODULES=Off',
                                    ]
 
             if conf.llvm_enable_runtimes:


### PR DESCRIPTION
This fixes
```
CMake Error at cmake/modules/HandleLLVMOptions.cmake:714 (message):
  LLVM_ENABLE_MODULES is not supported by this compiler
Call Stack (most recent call first):
  CMakeLists.txt:953 (include)
```

https://green.lab.llvm.org/job/llvm.org/job/clang-stage2-Rthinlto/52/console


Tested and shown to work on https://green.lab.llvm.org/