### PR TITLE
[GreenDragon] Workaround Stage 2 bots being broken

### DIFF
--- a/zorg/jenkins/build.py
+++ b/zorg/jenkins/build.py
@@ -396,6 +396,7 @@ def clang_builder(target):
                                    '-DCLANG_INCLUDE_TESTS=On',
                                    '-DLLVM_INCLUDE_UTILS=On',
                                    '-DCMAKE_MACOSX_RPATH=On',
+                                   '-DLLVM_ENABLE_MODULES=Off', # Workaround Stage 2 Green Dragon being broken
                                    ]
 
             if dyld_path:


### PR DESCRIPTION
Stage 2 jobs are currently broken. E.g.:

https://green.lab.llvm.org/job/llvm.org/job/clang-stage2-Rthinlto/59/

```
CMake Error at cmake/modules/HandleLLVMOptions.cmake:714 (message):
  LLVM_ENABLE_MODULES is not supported by this compiler
Call Stack (most recent call first):
  CMakeLists.txt:953 (include)
```

While the root cause of the stage 1 compiler not supporting modules is investigated we should disable building with modules to get signal from the job.

It appears that `LLVM_ENABLE_MODULES` is on by default because of the `clang/cmake/caches/Apple-stage2*.cmake` initial cache files (see 1cc3474ec11dcb267544e5b4630d52b3aa3e66b3 in llvm-project repo)

rdar://125123985