### PR TITLE
[OpenMP] Adds SLES 15 SP4 build bot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1921,6 +1921,38 @@ all += [
                         add_openmp_lit_args=["--time-tests", "--timeout 100"],
                     )},
 
+    # This bot, for now does not run OpenMP/Offload runtime tests, as we have no GPU yet
+    {'name' : "openmp-offload-sles-build-only",
+    'tags'  : ["openmp"],
+    'workernames' : ["rocm-worker-hw-04-sles"],
+    'builddir': "openmp-offload-sles-build",
+    'factory' : OpenMPBuilder.getOpenMPCMakeBuildFactory(
+                        clean=True,
+                        test=False, # we have no GPU avail, skip runtime tests
+                        enable_runtimes=['openmp'],
+                        depends_on_projects=['llvm','clang', 'flang', 'lld','openmp'],
+                        extraCmakeArgs=[
+                            "-DCMAKE_BUILD_TYPE=Release",
+                            "-DCLANG_DEFAULT_LINKER=lld",
+                            "-DLLVM_TARGETS_TO_BUILD=X86;AMDGPU",
+                            "-DLLVM_ENABLE_ASSERTIONS=ON",
+                            "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
+                            "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
+                            ],
+                        env={
+                            'HSA_ENABLE_SDMA':'0',
+                            },
+                        install=True,
+                        testsuite=False,
+                        testsuite_sollvevv=False,
+                        extraTestsuiteCmakeArgs=[
+                            "-DTEST_SUITE_SOLLVEVV_OFFLOADING_CFLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
+                            "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
+                        ],
+                        add_lit_checks=["check-clang", "check-flang", "check-llvm", "check-lld"],
+                        add_openmp_lit_args=["--time-tests", "--timeout 100"],
+                    )},
+
 
 # Whole-toolchain builders.
 

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -309,6 +309,7 @@ def get_all():
         # Flang OpenMP on AMDGPU, Ubuntu 22.04.3, AMD(R) EPYC 9354 @ 2.5GHz with 512GB Memory, 1 MI210 GPU with 64GB Memory
         create_worker("rocm-worker-hw-01", properties={'jobs': 64}, max_builds=1),
         create_worker("rocm-worker-hw-02", properties={'jobs': 64}, max_builds=1),
+        create_worker("rocm-worker-hw-04-sles", properties={'jobs': 32}, max_builds=1),
 
         # AMD ROCm support, Ubuntu 18.04.6, AMD Ryzen @ 1.5 GHz, MI200 GPU
         create_worker("mi200-buildbot", max_builds=1),


### PR DESCRIPTION
The bot runs a build of clang, flang, llvm, mlir, lld and openmp inside a SLES container.
It does not currently run check-openmp as we do not have a GPU available for the offloading runtime tests.