### PR TITLE
[green-dragon-migration] Update task shell scripts

### DIFF
--- a/tasks/lnt-ctmark.sh
+++ b/tasks/lnt-ctmark.sh
@@ -9,6 +9,10 @@ LNT_FLAGS="$(build arg --optional LNT_FLAGS)"
 : ${SUBMIT_NAME:="${NODE_NAME-}_${JOB_NAME-}"}
 : ${SUBMIT_ORDER:="${GIT_DISTANCE-}"}
 
+. "${TASKDIR}"/utils/venv.sh
+. "${TASKDIR}"/utils/pip_install.sh --upgrade pip
+. "${TASKDIR}"/utils/pip_install.sh awscli
+
 # A generic ctmark run designed to run as a recurring jenkins job with varying
 # cmake caches and submission to an lnt server.
 build get compiler
@@ -18,7 +22,6 @@ build get lnt
 DEPENDENCY_FILES="${TASKDIR}"/lnt-testsuite.dep
 . "${TASKDIR}"/utils/check_dependencies.sh
 . "${TASKDIR}"/utils/normalize_compiler.sh
-. "${TASKDIR}"/utils/venv.sh
 . "${TASKDIR}"/utils/venv_lit.sh
 . "${TASKDIR}"/utils/venv_lnt.sh
 

--- a/tasks/lnt-testsuite.dep
+++ b/tasks/lnt-testsuite.dep
@@ -1,3 +1,2 @@
 os_version >= 10.11.6 # Oldest CI nodes are currently 10.11.6
 brew cmake >= 3.6.0 # Need 3.6 for CMAKE_TRY_COMPILE_TARGET_TYPE
-pip virtualenv >= 15.1.0 # Really any version.  It has not been updated since 2016 though, so most recent.

--- a/tasks/test-suite-verify-machineinstrs.sh
+++ b/tasks/test-suite-verify-machineinstrs.sh
@@ -1,10 +1,13 @@
 CMAKE_FLAGS="$(build arg --optional CMAKE_FLAGS)"
 
+. "${TASKDIR}"/utils/venv.sh
+. "${TASKDIR}"/utils/pip_install.sh --upgrade pip
+. "${TASKDIR}"/utils/pip_install.sh awscli
+
 build get compiler
 build get test-suite
 
 . "${TASKDIR}"/utils/normalize_compiler.sh
-. "${TASKDIR}"/utils/venv.sh
 . "${TASKDIR}"/utils/venv_lit.sh
 
 TEST_SUITE_CMAKE_FLAGS+=" -C ${TASKDIR}/cmake/caches/verify-machineinstrs.cmake"

--- a/tasks/utils/venv.sh
+++ b/tasks/utils/venv.sh
@@ -1,5 +1,5 @@
 echo "@@@ LNT VirtualEnv @@@"
-xcrun python3 -m venv venv
+python3 -m venv venv
 set +u
 . venv/bin/activate
 set -u

--- a/tasks/utils/venv.sh
+++ b/tasks/utils/venv.sh
@@ -1,5 +1,5 @@
 echo "@@@ LNT VirtualEnv @@@"
-/usr/local/bin/virtualenv --python=python3 venv
+xcrun python3 -m venv venv
 set +u
 . venv/bin/activate
 set -u


### PR DESCRIPTION
## In This PR

* Update task shell scripts to use python 3
* Update any shell scripts pulling the compiler to install the awscli dependency needed
* Don't require virtualenv as with python3 we just use venv built into the python stdlib


This code has been tested on https://green.lab.llvm.org/