### PR TITLE
[green-dragon-migration] check in jenkins requirements file

### DIFF
--- a/zorg/jenkins/jobs/requirements.txt
+++ b/zorg/jenkins/jobs/requirements.txt
@@ -1,0 +1,9 @@
+six==1.15.0
+urllib3==1.26.8
+requests==2.25.1
+pexpect==4.9.0
+pyOpenSSL==24.0.0
+cryptography==42.0.5
+psutil==5.9.8
+lit==17.0.6
+awscli==1.32.41


### PR DESCRIPTION
## In This PR
* Add the requirements.txt file for jenkins CI agents. We separate this from the global requirements.txt file since it's specific to green dragon CI agents, and we don't want to inadvertently break any build bots

This code has been tested on https://green.lab.llvm.org/