### PR TITLE
[GreenDragon] Workaround Stage 2 bots being broken

### DIFF
--- a/zorg/jenkins/build.py
+++ b/zorg/jenkins/build.py
@@ -428,6 +428,7 @@ def clang_builder(target):
                                    '-DCLANG_INCLUDE_TESTS=On',
                                    '-DLLVM_INCLUDE_UTILS=On',
                                    '-DCMAKE_MACOSX_RPATH=On',
+                                   '-DLLVM_ENABLE_MODULES=Off', # Workaround Stage 2 Green Dragon being broken
                                    ]
 
             if conf.llvm_enable_runtimes:


### PR DESCRIPTION
Simply mimicking https://github.com/llvm/llvm-zorg/pull/144/

The change was made to the wrong build script initially