### PR TITLE
[flang] Disable OpenMP on flang-aarch64-libcxx bot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2242,7 +2242,7 @@ all += [
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
                     checks=['check-flang'],
-                    depends_on_projects=['llvm','mlir','clang','flang','openmp'],
+                    depends_on_projects=['llvm','mlir','clang','flang'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DLLVM_INSTALL_UTILS=ON",


### PR DESCRIPTION
Building LLVM with libc++ and OpenMP as a runtime on a glibc based
system causes some hard to fix build failures (see
https://github.com/llvm/llvm-project/issues/61693).

As the point of building against libc++ was to make sure flang works
well with it, adding OpenMP doesn’t help that, and flang OpenMP
tests are already enabled on other flang bots, just disable OpenMP
on flang-aarch64-libcxx.
