### PR TITLE
Enable FLANG_LIBCUDACXX_PATH for 'flang-runtime-cuda-gcc' builder.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2988,6 +2988,7 @@ all += [
                         "-DCMAKE_CUDA_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
+                        WithProperties("-DFLANG_LIBCUDACXX_PATH=%(nv_cccl_root_path)s/libcudacxx"),
                     ],
                     env={
                         'CCACHE_DIR' : WithProperties("%(builddir)s/ccache-db"),

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -215,7 +215,11 @@ def get_all():
 
         # NVPTX builders.
         # Ubuntu 22.04 LTS x86_64 Intel Xeon 6330 CPU 2Sx64Cx128LP @ 2.0GHz, 256GB RAM
-        create_worker("as-builder-7", properties={'jobs': 128}, max_builds=2),
+        create_worker("as-builder-7", properties={
+                        'jobs': 128,
+                        'nv_cccl_root_path'     : '/home/buildbot/worker/third-party/nv/cccl',
+                     },
+                     max_builds=2),
         # Windows Server on Intel Xeon 6330 CPU 2Sx64Cx128LP @ 2.0GHz, 256GB RAM
         create_worker("as-builder-8", properties={'jobs': 128}, max_builds=1),
 


### PR DESCRIPTION
Pass a path to LIBCUDACXX source code to avoid the following build warnings:

  warning #20014-D: calling a __host__ function ...