### PR TITLE
Fixed relative paths for Flang out-of-tree builder.

### DIFF
--- a/zorg/buildbot/builders/FlangBuilder.py
+++ b/zorg/buildbot/builders/FlangBuilder.py
@@ -44,14 +44,12 @@ def getFlangOutOfTreeBuildFactory(
     mlir_dir = "{}/lib/cmake/mlir".format(f.obj_dir)
     clang_dir = "{}/lib/cmake/clang".format(f.obj_dir)
     CmakeCommand.applyRequiredOptions(flang_cmake_args, [
-        # We actually need the paths to be relative to the source directory,
-        # otherwise find_package can't locate the config files.
         ('-DLLVM_DIR:PATH=',
-            LLVMBuildFactory.pathRelativeTo(llvm_dir, flang_src_dir)),
+            LLVMBuildFactory.pathRelativeTo(llvm_dir, flang_obj_dir)),
         ('-DMLIR_DIR:PATH=',
-            LLVMBuildFactory.pathRelativeTo(mlir_dir, flang_src_dir)),
+            LLVMBuildFactory.pathRelativeTo(mlir_dir, flang_obj_dir)),
         ('-DCLANG_DIR:PATH=',
-            LLVMBuildFactory.pathRelativeTo(clang_dir, flang_src_dir)),
+            LLVMBuildFactory.pathRelativeTo(clang_dir, flang_obj_dir)),
         ])
 
     # We can't use addCmakeSteps as that would use the path in f.llvm_srcdir.


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/87822
we can specify real relative paths from the flang build directory
to the directories containing LLVM/CLANG/etc. projects' config
files.
