### PR TITLE
Use updated lunch configuration format

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1240,7 +1240,7 @@ all = [
     'workernames' : ["hexagon-build-03"],
     'builddir': "aosp",
     'factory' : AOSPBuilder.getAOSPBuildFactory(
-                    device="angler",
+                    device="arm64",
                     extra_cmake_args=[
                         "-G", "Ninja",
                         "-DLLVM_TARGETS_TO_BUILD='ARM;AArch64'",


### PR DESCRIPTION
With this patch lunch target will be aosp_arm64-trunk-userdebug
Doc:  https://source.android.com/docs/setup/build/building#view_the_current_target

Should fix buildbot failure: https://lab.llvm.org/buildbot/#/builders/82/builds/15143
