### PR TITLE
[Offload] Enable check-offload in AMDGPU prod bot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1828,6 +1828,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_CFLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                         ],
+                        add_lit_checks=['check-offload'],
                         add_openmp_lit_args=["--time-tests", "--timeout 100"],
                     )},
 


### PR DESCRIPTION
This adds `check-offload` to the AMDGPU OpenMP Offloading production buildbot, to re-enable coverage of OpenMP offload testing.