### PR TITLE
[RISCV] Add new "native" (qemu-system) builders

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3126,6 +3126,95 @@ all += [
                         'CXX': 'clang++',
                     })},
 
+    ## RISC-V RVA20 profile check-all 2-stage
+    {'name' : "clang-riscv-rva20-2stage",
+    'tags'  : ["clang"],
+    'workernames' : ["rise-clang-riscv-rva20-2stage"],
+    'builddir':"clang-riscv-rva20-2stage",
+    'factory' : ClangBuilder.getClangCMakeBuildFactory(
+                clean=False,
+                useTwoStage=True,
+                runTestSuite=False,
+                testStage1=False,
+                extra_cmake_args=[
+                    "-DCMAKE_C_COMPILER=clang",
+                    "-DCMAKE_CXX_COMPILER=clang++",
+                    "-DLLVM_ENABLE_LLD=True",
+                    "-DLLVM_TARGETS_TO_BUILD=riscv"
+                    "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
+                    "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"],
+                extra_stage2_cmake_args=[
+                    "-DLLVM_ENABLE_LLD=True",
+                    "-DCMAKE_C_FLAGS='-march=rva20u64'",
+                    "-DCMAKE_CXX_FLAGS='-march=rva20u64'"]
+                ])},
+
+    ## RISC-V RVA23 profile check-all 2-stage
+    {'name' : "clang-riscv-rva23-2stage",
+    'workernames' : ["rise-clang-riscv-rva23-2stage"],
+    'builddir':"clang-riscv-rva23-2stage",
+    'factory' : ClangBuilder.getClangCMakeBuildFactory(
+                clean=False,
+                useTwoStage=True,
+                runTestSuite=False,
+                testStage1=False,
+                extra_cmake_args=[
+                    "-DCMAKE_C_COMPILER=clang",
+                    "-DCMAKE_CXX_COMPILER=clang++",
+                    "-DLLVM_ENABLE_LLD=True",
+                    "-DLLVM_TARGETS_TO_BUILD=riscv"
+                    "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
+                    "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"],
+                extra_stage2_cmake_args=[
+                    "-DLLVM_ENABLE_LLD=True",
+                    "-DCMAKE_C_FLAGS='-march=rva23u64'",
+                    "-DCMAKE_CXX_FLAGS='-march=rva23u64'"]
+                ])},
+
+    ## RISC-V RVA23 profile with -mrvv-vector-bits=zvl check-all 2-stage
+    {'name' : "clang-riscv-rva23-mrvv-vec-bits-2stage",
+    'workernames' : ["rise-clang-riscv-rva23-mrvv-vec-bits-2stage"],
+    'builddir':"clang-riscv-rva23-mrvv-vec-bits-2stage",
+    'factory' : ClangBuilder.getClangCMakeBuildFactory(
+                clean=False,
+                useTwoStage=True,
+                runTestSuite=False,
+                testStage1=False,
+                extra_cmake_args=[
+                    "-DCMAKE_C_COMPILER=clang",
+                    "-DCMAKE_CXX_COMPILER=clang++",
+                    "-DLLVM_ENABLE_LLD=True",
+                    "-DLLVM_TARGETS_TO_BUILD=riscv"
+                    "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
+                    "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"],
+                extra_stage2_cmake_args=[
+                    "-DLLVM_ENABLE_LLD=True",
+                    "-DCMAKE_C_FLAGS='-march=rva23u64 -mrvv-vector-bits=zvl'",
+                    "-DCMAKE_CXX_FLAGS='-march=rva23u64 -mrvv-vector-bits=zvl'"]
+                ])},
+
+    ## RISC-V RVA23 profile with EVL vectorizer check-all 2-stage
+    {'name' : "clang-riscv-rva23-evl-vec-2stage",
+    'workernames' : ["rise-clang-riscv-rva23-evl-vec-2stage"],
+    'builddir':"clang-riscv-rva23-evl-vec-2stage",
+    'factory' : ClangBuilder.getClangCMakeBuildFactory(
+                clean=False,
+                useTwoStage=True,
+                runTestSuite=False,
+                testStage1=False,
+                extra_cmake_args=[
+                    "-DCMAKE_C_COMPILER=clang",
+                    "-DCMAKE_CXX_COMPILER=clang++",
+                    "-DLLVM_ENABLE_LLD=True",
+                    "-DLLVM_TARGETS_TO_BUILD=riscv"
+                    "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
+                    "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"],
+                extra_stage2_cmake_args=[
+                    "-DLLVM_ENABLE_LLD=True",
+                    "-DCMAKE_C_FLAGS='-march=rva23u64 -mllvm -force-tail-folding-style=data-with-evl -mllvm -prefer-predicate-over-epilogue=predicate-dont-vectorize",
+                    "-DCMAKE_CXX_FLAGS='-march=rva23u64 -mllvm -force-tail-folding-style=data-with-evl -mllvm -prefer-predicate-over-epilogue=predicate-dont-vectorize"]
+                ])},
+
     # Builders similar to used in Buildkite premerge pipeline.
     # Please keep in sync with llvm-project/.ci configurations.
 

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3167,8 +3167,8 @@ all += [
                     "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"],
                 extra_stage2_cmake_args=[
                     "-DLLVM_ENABLE_LLD=True",
-                    "-DCMAKE_C_FLAGS='-march=rva23u64'",
-                    "-DCMAKE_CXX_FLAGS='-march=rva23u64'"]
+                    "-DCMAKE_C_FLAGS='-menable-experimental-extensions -march=rva23u64'",
+                    "-DCMAKE_CXX_FLAGS='-menable-experimental-extensions -march=rva23u64'"]
                 ])},
 
     ## RISC-V RVA23 profile with -mrvv-vector-bits=zvl check-all 2-stage
@@ -3189,8 +3189,8 @@ all += [
                     "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"],
                 extra_stage2_cmake_args=[
                     "-DLLVM_ENABLE_LLD=True",
-                    "-DCMAKE_C_FLAGS='-march=rva23u64 -mrvv-vector-bits=zvl'",
-                    "-DCMAKE_CXX_FLAGS='-march=rva23u64 -mrvv-vector-bits=zvl'"]
+                    "-DCMAKE_C_FLAGS='-menable-experimental-extensions -march=rva23u64 -mrvv-vector-bits=zvl'",
+                    "-DCMAKE_CXX_FLAGS='-menable-experimental-extensions -march=rva23u64 -mrvv-vector-bits=zvl'"]
                 ])},
 
     ## RISC-V RVA23 profile with EVL vectorizer check-all 2-stage
@@ -3211,8 +3211,8 @@ all += [
                     "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"],
                 extra_stage2_cmake_args=[
                     "-DLLVM_ENABLE_LLD=True",
-                    "-DCMAKE_C_FLAGS='-march=rva23u64 -mllvm -force-tail-folding-style=data-with-evl -mllvm -prefer-predicate-over-epilogue=predicate-dont-vectorize",
-                    "-DCMAKE_CXX_FLAGS='-march=rva23u64 -mllvm -force-tail-folding-style=data-with-evl -mllvm -prefer-predicate-over-epilogue=predicate-dont-vectorize"]
+                    "-DCMAKE_C_FLAGS='-menable-experimental-extensions -march=rva23u64 -mllvm -force-tail-folding-style=data-with-evl -mllvm -prefer-predicate-over-epilogue=predicate-dont-vectorize",
+                    "-DCMAKE_CXX_FLAGS='-menable-experimental-extensions -march=rva23u64 -mllvm -force-tail-folding-style=data-with-evl -mllvm -prefer-predicate-over-epilogue=predicate-dont-vectorize"]
                 ])},
 
     # Builders similar to used in Buildkite premerge pipeline.

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -338,6 +338,10 @@ def get_all():
         # RISC-V workers
         create_worker("rv64gc-qemu-user", properties={'jobs' : 32}, max_builds=1),
         create_worker("rv32gc-qemu-system", properties={'jobs' : 32}, max_builds=1),
+        create_worker("rise-clang-riscv-rva20-2stage", properties={'jobs' : 32}, max_builds=1),
+        create_worker("rise-clang-riscv-rva23-2stage", properties={'jobs' : 32}, max_builds=1),
+        create_worker("rise-clang-riscv-rva23-mrvv-vec-bits-2stage", properties={'jobs' : 16}, max_builds=1),
+        create_worker("rise-clang-riscv-rva23-evl-vec-2stage", properties={'jobs' : 16}, max_builds=1),
 
         # FIXME: A placeholder for annoying worker which nobody could stop.
         # adding it avoid logs spammed by failed authentication for that worker.


### PR DESCRIPTION
For background, I don't expect these builders to graduate from the staging buildmaster in the current configuration. I'm spinning them up so we get some slow feedback while I, in parallel, explore alternative build configs that make better tradeoffs in terms of response time vs feedback.

These are all qemu-system based. Please note that the first commit adds a new ability to set cmake flags that apply only to the second-stage build, which I use to apply `-march` that the system compiler may not understand as well as to have ccache enabled for the first stage only. Happy to split that out to a separate PR if you prefer.