### PR TITLE
[Offload] Adds RHEL 9.4 buildbot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1987,6 +1987,38 @@ all += [
                         add_openmp_lit_args=["--time-tests", "--timeout 100"],
                     )},
 
+    {'name' : "openmp-offload-rhel-9.4",
+    'tags'  : ["openmp"],
+    'workernames' : ["rocm-worker-hw-04-rhel-9.4"],
+    'builddir': "openmp-offload-rhel-9.4-build",
+    'factory' : OpenMPBuilder.getOpenMPCMakeBuildFactory(
+                        clean=True,
+                        test=True,
+                        enable_runtimes=['openmp', 'compiler-rt', 'offload'],
+                        depends_on_projects=['llvm','clang', 'flang', 'lld', 'mlir', 'offload', 'openmp'],
+                        extraCmakeArgs=[
+                            "-DCMAKE_BUILD_TYPE=Release",
+                            "-DCLANG_DEFAULT_LINKER=lld",
+                            "-DLLVM_TARGETS_TO_BUILD=X86;AMDGPU",
+                            "-DLLVM_ENABLE_ASSERTIONS=ON",
+                            "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
+                            "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
+                            ],
+                        env={
+                            'HSA_ENABLE_SDMA':'0',
+                            'LD_LIBRARY_PATH':'/opt/rocm/lib',
+                            },
+                        install=True,
+                        testsuite=False,
+                        testsuite_sollvevv=False,
+                        extraTestsuiteCmakeArgs=[
+                            "-DTEST_SUITE_SOLLVEVV_OFFLOADING_CFLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
+                            "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
+                        ],
+                        add_lit_checks=["check-clang", "check-flang", "check-llvm", "check-lld", "check-mlir", "check-offload"],
+                        add_openmp_lit_args=["--time-tests", "--timeout 100"],
+                    )},
+
 
 # Whole-toolchain builders.
 

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -319,6 +319,7 @@ def get_all():
         create_worker("rocm-worker-hw-02", properties={'jobs': 64}, max_builds=1),
         create_worker("rocm-worker-hw-03", properties={'jobs': 64}, max_builds=1),
         create_worker("rocm-worker-hw-04-sles", properties={'jobs': 32}, max_builds=1),
+        create_worker("rocm-worker-hw-04-rhel-9.4", properties={'jobs': 32}, max_builds=1),
 
         # AMD ROCm support, Ubuntu 18.04.6, AMD Ryzen @ 1.5 GHz, MI200 GPU
         create_worker("mi200-buildbot", max_builds=1),


### PR DESCRIPTION
This adds a dockerized RHEL 9.4 buildbot that builds clang, flang, mlir, openmp, offload, llvm and lld and runs all the tests.