### PR TITLE
[LoongArch] Switch the toolchain used by the `clang-loongarch64-linux` builder from default to clang+lld

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -797,6 +797,9 @@ all = [
                     checkout_lld=False,
                     testsuite_flags=['--threads=32', '--build-threads=32'],
                     extra_cmake_args=['-DLLVM_TARGETS_TO_BUILD=LoongArch',
+                                      '-DCMAKE_C_COMPILER=/usr/local/bin/clang',
+                                      '-DCMAKE_CXX_COMPILER=/usr/local/bin/clang++',
+                                      '-DLLVM_USE_LINKER=lld',
                                       '-DLLVM_ENABLE_PROJECTS=clang'])},
 
     {'name' : "clang-hexagon-elf",


### PR DESCRIPTION
Currently the default toolchain is used:
- gcc (GCC) 13.0.0 20221013 (experimental)
- GNU ld (GNU Binutils) 2.39.50.20221029

But recently we find that a new added llvm unittest (llvm/unittests/Frontend/OpenMPDecompositionTest.cpp) can't be compiled by the default toolchain (causing memory exhausted and killed by the system). Error:
```
command timed out: 1200 seconds without output running [b'ninja', b'check-all'], attempting to kill
process killed by signal 9
program finished with exit code -1
elapsedTime=1669.062469
```
See https://lab.llvm.org/staging/#/builders/5/builds/4199.

This patch fixex this issue by switching to clang+lld (v17.0.6).

An alternative (workaround) is setting `useTwoStage=True` and `testStage1=False`, but I think we'd better to create a dedicated builder for that in future.