### PR TITLE
Activate venv in 17.0.6 build

### DIFF
--- a/zorg/jenkins/jobs/jobs/lldb-cmake-matrix
+++ b/zorg/jenkins/jobs/jobs/lldb-cmake-matrix
@@ -220,6 +220,8 @@ pipeline {
                     export SRC_DIR='clang_1706'
                     export BUILD_DIR='clang_1706_build'
 
+                    source ./venv/bin/activate
+
                     python3 llvm-zorg/zorg/jenkins/monorepo_build.py cmake build \
                       $MATRIX_COMMON_BUILD_PARAMETERS \
                       --assertions \


### PR DESCRIPTION
will fix
```
ModuleNotFoundError: No module named 'requests'
```