### PR TITLE
Disable PDB generation in stage1 of the clang-cl self-host bot

### DIFF
--- a/zorg/buildbot/builders/annotated/clang-windows.py
+++ b/zorg/buildbot/builders/annotated/clang-windows.py
@@ -40,7 +40,7 @@ def main(argv):
                       stages=stages,
                       check_targets=check_targets,
                       extra_cmake_args=extra_cmake_args,
-                      stage1_extra_cmake_args=extra_cmake_args,
+                      stage1_extra_cmake_args=stage1_extra_cmake_args,
                       check_stages=check_stages,
                       compiler=compiler,
                       linker=linker,

--- a/zorg/buildbot/builders/annotated/clang-windows.py
+++ b/zorg/buildbot/builders/annotated/clang-windows.py
@@ -11,6 +11,9 @@ def main(argv):
     # TODO: Add back debuginfo-tests once it works.
     projects = ['llvm', 'clang', 'clang-tools-extra', 'lld']
     stages = 2
+    stage1_extra_cmake_args = [
+        '-DCMAKE_BUILD_TYPE=Release',
+    ]
     extra_cmake_args = [
         '-DCMAKE_BUILD_TYPE=Release',
         '-DLLVM_ENABLE_PDB=ON',
@@ -18,13 +21,13 @@ def main(argv):
         '-DLLVM_TARGETS_TO_BUILD=all',
     ]
     check_targets = [
-            'check-llvm',
-            'check-clang',
-            'check-clang-tools',
-            'check-clangd',
-            'check-lld',
-            #'check-debuginfo', # TODO: Add back soon.
-            ]
+        'check-llvm',
+        'check-clang',
+        'check-clang-tools',
+        'check-clangd',
+        'check-lld',
+        #'check-debuginfo', # TODO: Add back when it works.
+    ]
 
     # Check both stage 1 and stage 2.
     check_stages = [True] * stages
@@ -35,8 +38,9 @@ def main(argv):
     builder = annotated_builder.AnnotatedBuilder()
     builder.run_steps(projects=projects,
                       stages=stages,
-                      extra_cmake_args=extra_cmake_args,
                       check_targets=check_targets,
+                      extra_cmake_args=extra_cmake_args,
+                      stage1_extra_cmake_args=extra_cmake_args,
                       check_stages=check_stages,
                       compiler=compiler,
                       linker=linker,


### PR DESCRIPTION
PDB generation is resource-intensive and does not perform well for statically linked unit tests. The stage2 build generates PDBs to exercise clang-cl's debug info generation abilities, but we generally do not use the debug info from the stage 1 builds. PDB build errors are also a common source of builder unreliability and lead to excessive disk usage, so disable them for now.

Here is a recent example of PDB unreliability:
https://lab.llvm.org/buildbot/#/builders/123/builds/26898
```
... GeneratorTest.cpp: fatal error C1051: program database file, '...\vc140.pdb', has an obsolete format, delete it and recompile
```