### PR TITLE
Fix ClangBuilder after f59269f1ef7823fe68775d9a2fcc975673654bae

### DIFF
--- a/zorg/buildbot/builders/ClangBuilder.py
+++ b/zorg/buildbot/builders/ClangBuilder.py
@@ -436,17 +436,17 @@ def _getClangCMakeBuildFactory(
                             stage1_install,
                             cxx))
 
-    # If we have a separate stage2 cmake arg list, then ensure we re-apply
-    # enable_projects and enable_runtimes if necessary.
-    if extra_stage2_cmake_args:
-        if f.enable_projects:
-            CmakeCommand.applyRequiredOptions(extra_stage2_cmake_args, [
-                ('-DLLVM_ENABLE_PROJECTS=', ";".join(f.enable_projects)),
-                ])
-        if f.enable_runtimes:
-            CmakeCommand.applyRequiredOptions(extra_stage2_cmake_args, [
-                ('-DLLVM_ENABLE_RUNTIMES=', ";".join(f.enable_runtimes)),
-                ])
+        # If we have a separate stage2 cmake arg list, then ensure we re-apply
+        # enable_projects and enable_runtimes if necessary.
+        if extra_stage2_cmake_args:
+            if f.enable_projects:
+                CmakeCommand.applyRequiredOptions(extra_stage2_cmake_args, [
+                    ('-DLLVM_ENABLE_PROJECTS=', ";".join(f.enable_projects)),
+                    ])
+            if f.enable_runtimes:
+                CmakeCommand.applyRequiredOptions(extra_stage2_cmake_args, [
+                    ('-DLLVM_ENABLE_RUNTIMES=', ";".join(f.enable_runtimes)),
+                    ])
 
         rel_src_dir = LLVMBuildFactory.pathRelativeTo(f.llvm_srcdir, stage2_build)
         cmake_cmd2 = [cmake, "-G", "Ninja", rel_src_dir,


### PR DESCRIPTION
The way that change was indented meant that the cmake/build/check steps of stage 2 were only added if extra_stage2_cmake_args was not empty.

This caused any 2 stage builder without those extra options to skip building stage 2. Which left them green but not doing their
job, or red if they tried to run the test suite using stage 2.