### PR TITLE
Update configuration for armv7l/aarch64 Win-to-Linux cross toolchain builders.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -217,8 +217,8 @@ all = [
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=ARM",
                         "-DTOOLCHAIN_TARGET_TRIPLE=armv7-unknown-linux-gnueabihf",
-                        "-DDEFAULT_SYSROOT=C:/buildbot/.arm-ubuntu",
-                        "-DZLIB_ROOT=C:/buildbot/.zlib-win32",
+                        WithProperties("-DCLANG_CONFIG_FILE_USER_DIR=%(clang_configs_path)s"),
+                        WithProperties("-DZLIB_ROOT=%(zlib_root_path)s"),
                         "-DLLVM_LIT_ARGS=-v -vv --threads=32",
                         WithProperties("%(remote_test_host:+-DREMOTE_TEST_HOST=)s%(remote_test_host:-)s"),
                         WithProperties("%(remote_test_user:+-DREMOTE_TEST_USER=)s%(remote_test_user:-)s"),
@@ -256,7 +256,7 @@ all = [
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DTOOLCHAIN_TARGET_TRIPLE=aarch64-unknown-linux-gnu",
-                        WithProperties("-DDEFAULT_SYSROOT=%(sysroot_path_aarch64)s"),
+                        WithProperties("-DCLANG_CONFIG_FILE_USER_DIR=%(clang_configs_path)s"),
                         WithProperties("-DZLIB_ROOT=%(zlib_root_path)s"),
                         "-DLLVM_LIT_ARGS=-v -vv --threads=32",
                         WithProperties("%(remote_test_host:+-DREMOTE_TEST_HOST=)s%(remote_test_host:-)s"),

--- a/buildbot/osuosl/master/config/release_builders.py
+++ b/buildbot/osuosl/master/config/release_builders.py
@@ -131,8 +131,8 @@ all = [
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=ARM",
                         "-DTOOLCHAIN_TARGET_TRIPLE=armv7-unknown-linux-gnueabihf",
-                        "-DDEFAULT_SYSROOT=C:/buildbot/.arm-ubuntu",
-                        "-DZLIB_ROOT=C:/buildbot/.zlib-win32",
+                        WithProperties("-DCLANG_CONFIG_FILE_USER_DIR=%(clang_configs_path)s"),
+                        WithProperties("-DZLIB_ROOT=%(zlib_root_path)s"),
                         "-DLLVM_LIT_ARGS=-v -vv --threads=32",
                         WithProperties("%(remote_test_host:+-DREMOTE_TEST_HOST=)s%(remote_test_host:-)s"),
                         WithProperties("%(remote_test_user:+-DREMOTE_TEST_USER=)s%(remote_test_user:-)s"),
@@ -170,7 +170,7 @@ all = [
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DTOOLCHAIN_TARGET_TRIPLE=aarch64-unknown-linux-gnu",
-                        WithProperties("-DDEFAULT_SYSROOT=%(sysroot_path_aarch64)s"),
+                        WithProperties("-DCLANG_CONFIG_FILE_USER_DIR=%(clang_configs_path)s"),
                         WithProperties("-DZLIB_ROOT=%(zlib_root_path)s"),
                         "-DLLVM_LIT_ARGS=-v -vv --threads=32",
                         WithProperties("%(remote_test_host:+-DREMOTE_TEST_HOST=)s%(remote_test_host:-)s"),

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -178,8 +178,10 @@ def get_all():
 
         # Windows Server on Xeon Gold 6130 (2x2.1GHz), 128Gb of RAM
         create_worker("as-builder-1", properties={
-                        'remote_test_host': 'jetson6.lab.llvm.org',
-                        'remote_test_user': 'ubuntu'
+                        'remote_test_host'      : 'jetson6.lab.llvm.org',
+                        'remote_test_user'      : 'ubuntu',
+                        'clang_configs_path'    : 'c:/buildbot/clang-configs',
+                        'zlib_root_path'        : 'c:/buildbot/fs/zlib-win32',
                      },
                      max_builds=1),
 
@@ -187,7 +189,7 @@ def get_all():
         create_worker("as-builder-2", properties={
                         'remote_test_host'      : 'jetson-agx-2197.lab.llvm.org',
                         'remote_test_user'      : 'ubuntu',
-                        'sysroot_path_aarch64'  : 'c:/buildbot/fs/jetson-agx-ubuntu',
+                        'clang_configs_path'    : 'c:/buildbot/clang-configs',
                         'zlib_root_path'        : 'c:/buildbot/fs/zlib-win32',
                      },
                      max_builds=1),


### PR DESCRIPTION
* llvm-clang-win-x-{armv7l,aarch64}-release
* llvm-clang-win-x-{armv7l,aarch64}

Removed DEFAULT_SYSROOT from the build configurations. Use the local clang configuration files instead.

More details could be found here:
    https://github.com/llvm/llvm-project/issues/94284