### PR TITLE
Update configuration for armv7l/aarch64 Win-to-Linux cross toolchain release builders.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -217,7 +217,7 @@ all = [
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=ARM",
                         "-DTOOLCHAIN_TARGET_TRIPLE=armv7-unknown-linux-gnueabihf",
-                        WithProperties("-DCLANG_CONFIG_FILE_USER_DIR=%(clang_configs_path)s"),
+                        WithProperties("-DDTOOLCHAIN_TARGET_SYSROOTFS=%(sysroot_path_armv7)s"),
                         WithProperties("-DZLIB_ROOT=%(zlib_root_path)s"),
                         "-DLLVM_LIT_ARGS=-v -vv --threads=32",
                         WithProperties("%(remote_test_host:+-DREMOTE_TEST_HOST=)s%(remote_test_host:-)s"),
@@ -256,7 +256,7 @@ all = [
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DTOOLCHAIN_TARGET_TRIPLE=aarch64-unknown-linux-gnu",
-                        WithProperties("-DCLANG_CONFIG_FILE_USER_DIR=%(clang_configs_path)s"),
+                        WithProperties("-DDTOOLCHAIN_TARGET_SYSROOTFS=%(sysroot_path_aarch64)s"),
                         WithProperties("-DZLIB_ROOT=%(zlib_root_path)s"),
                         "-DLLVM_LIT_ARGS=-v -vv --threads=32",
                         WithProperties("%(remote_test_host:+-DREMOTE_TEST_HOST=)s%(remote_test_host:-)s"),

--- a/buildbot/osuosl/master/config/release_builders.py
+++ b/buildbot/osuosl/master/config/release_builders.py
@@ -131,7 +131,7 @@ all = [
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=ARM",
                         "-DTOOLCHAIN_TARGET_TRIPLE=armv7-unknown-linux-gnueabihf",
-                        WithProperties("-DCLANG_CONFIG_FILE_USER_DIR=%(clang_configs_path)s"),
+                        WithProperties("-DTOOLCHAIN_TARGET_SYSROOTFS=%(sysroot_path_armv7)s"),
                         WithProperties("-DZLIB_ROOT=%(zlib_root_path)s"),
                         "-DLLVM_LIT_ARGS=-v -vv --threads=32",
                         WithProperties("%(remote_test_host:+-DREMOTE_TEST_HOST=)s%(remote_test_host:-)s"),
@@ -170,7 +170,7 @@ all = [
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DTOOLCHAIN_TARGET_TRIPLE=aarch64-unknown-linux-gnu",
-                        WithProperties("-DCLANG_CONFIG_FILE_USER_DIR=%(clang_configs_path)s"),
+                        WithProperties("-DDTOOLCHAIN_TARGET_SYSROOTFS=%(sysroot_path_aarch64)s"),
                         WithProperties("-DZLIB_ROOT=%(zlib_root_path)s"),
                         "-DLLVM_LIT_ARGS=-v -vv --threads=32",
                         WithProperties("%(remote_test_host:+-DREMOTE_TEST_HOST=)s%(remote_test_host:-)s"),

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -180,7 +180,8 @@ def get_all():
         create_worker("as-builder-1", properties={
                         'remote_test_host'      : 'jetson6.lab.llvm.org',
                         'remote_test_user'      : 'ubuntu',
-                        'clang_configs_path'    : 'c:/buildbot/clang-configs',
+                        'sysroot_path_aarch64'  : 'c:/buildbot/fs/jetson-agx-ubuntu',
+                        'sysroot_path_armv7'    : 'c:/buildbot/fs/jetson-tk1-arm-ubuntu',
                         'zlib_root_path'        : 'c:/buildbot/fs/zlib-win32',
                      },
                      max_builds=1),
@@ -189,7 +190,8 @@ def get_all():
         create_worker("as-builder-2", properties={
                         'remote_test_host'      : 'jetson-agx-2197.lab.llvm.org',
                         'remote_test_user'      : 'ubuntu',
-                        'clang_configs_path'    : 'c:/buildbot/clang-configs',
+                        'sysroot_path_aarch64'  : 'c:/buildbot/fs/jetson-agx-ubuntu',
+                        'sysroot_path_armv7'    : 'c:/buildbot/fs/jetson-tk1-arm-ubuntu',
                         'zlib_root_path'        : 'c:/buildbot/fs/zlib-win32',
                      },
                      max_builds=1),
@@ -203,14 +205,18 @@ def get_all():
 
         # Windows Server on Xeon Gold 6230 (2x2.1GHz), 256Gb of RAM
         create_worker("as-builder-5", properties={  # arm
-                        'remote_test_host': 'jetson4.lab.llvm.org',
-                        'remote_test_user': 'ubuntu'
+                        'remote_test_host'      : 'jetson4.lab.llvm.org',
+                        'remote_test_user'      : 'ubuntu',
+                        'sysroot_path_aarch64'  : 'c:/buildbot/fs/jetson-agx-ubuntu',
+                        'sysroot_path_armv7'    : 'c:/buildbot/fs/jetson-tk1-arm-ubuntu',
+                        'zlib_root_path'        : 'c:/buildbot/fs/zlib-win32',
                      },
                      max_builds=1),
         create_worker("as-builder-6", properties={  # aarch64
                         'remote_test_host'      : 'jetson-agx-2198.lab.llvm.org',
                         'remote_test_user'      : 'ubuntu',
                         'sysroot_path_aarch64'  : 'c:/buildbot/fs/jetson-agx-ubuntu',
+                        'sysroot_path_armv7'    : 'c:/buildbot/fs/jetson-tk1-arm-ubuntu',
                         'zlib_root_path'        : 'c:/buildbot/fs/zlib-win32',
                      },
                      max_builds=1),


### PR DESCRIPTION
Missed configuration for the workers hosting the release builders.

See #199 for details.

Related https://github.com/llvm/llvm-project/issues/94284