### PR TITLE
[Offload][OpenMP] XFail proc-bind test on containered bots

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2024,7 +2024,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                         ],
                         add_lit_checks=["check-clang", "check-flang", "check-llvm", "check-lld", "check-mlir", "check-offload"],
-                        add_openmp_lit_args=["--time-tests", "--timeout 100"],
+                        add_openmp_lit_args=["--time-tests", "--timeout 100", "--xfail=affinity/format/proc_bind.c"],
                     )},
 
     {'name' : "openmp-offload-rhel-8_8",
@@ -2056,7 +2056,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                         ],
                         add_lit_checks=["check-clang", "check-flang", "check-llvm", "check-lld", "check-mlir", "check-offload"],
-                        add_openmp_lit_args=["--time-tests", "--timeout 100"],
+                        add_openmp_lit_args=["--time-tests", "--timeout 100", "--xfail=affinity/format/proc_bind.c"],
                     )},
 
 


### PR DESCRIPTION
The containerized RHEL bots use custom CPU sets from the docker runtime and as a result this test fails reliably.
XFAIL the test on those two platforms.