### PR TITLE
ClangBuilder: fix cmake error due to wrong f-string

### DIFF
--- a/zorg/buildbot/builders/ClangBuilder.py
+++ b/zorg/buildbot/builders/ClangBuilder.py
@@ -447,7 +447,7 @@ def _getClangCMakeBuildFactory(
         cmake_cmd2 = [cmake, "-G", "Ninja", rel_src_dir,
                       stage1_cc,
                       stage1_cxx,
-                      "-DCMAKE_BUILD_TYPE={stage2_config}",
+                      f"-DCMAKE_BUILD_TYPE={stage2_config}",
                       "-DLLVM_ENABLE_ASSERTIONS=True",
                       f"-DLLVM_LIT_ARGS={lit_args}",
                       f"-DCMAKE_INSTALL_PREFIX=../{stage2_install}"


### PR DESCRIPTION
AArch64 stage-2 bots were failing with:
  Unknown value for CMAKE_BUILD_TYPE: {stage2_config}

Formatting was not done due to missing 'f' prefix

Issue reported by F.Hahn

Introduced by 8127be09b18be742911a01fef5d9d5f93d5ae329