### PR TITLE
Added the summary to the github comment

### DIFF
--- a/zorg/buildbot/reporters/utils.py
+++ b/zorg/buildbot/reporters/utils.py
@@ -117,6 +117,8 @@ Full details are available at: {{ build_url }}
 
 Here is the relevant piece of the build log for the reference:
 ```
+{{ summary }}
+
 {{ details }}
 ```
 """


### PR DESCRIPTION
The timeout error description (`command timed out: 1200 seconds without output running ..., attempting to kill`) in LitTestCommand can be retrieved only via getResultSummary(). Without the summary the log is useless in this case.