### PR TITLE
[OpenMP][Offload] Enable check-offload for CUDA OpenMP builders

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1776,6 +1776,7 @@ all += [
                             "-DTEST_SUITE_OFFLOADING_CXX_LDFLAGS=--offload-arch=native;--cuda-path=/opt/cuda",
                             "-DSYSTEM_GPU=nvidia", "-DTEST_SUITE_SYSTEM_GPU=nvidia",
                         ],
+                        add_openmp_lit_args=["--time-tests"],
                     )},
 
     {'name' : "openmp-offload-cuda-runtime",
@@ -1807,6 +1808,7 @@ all += [
                             "-DTEST_SUITE_OFFLOADING_CXX_LDFLAGS=--offload-arch=native;--cuda-path=/opt/cuda",
                             "-DSYSTEM_GPU=nvidia", "-DTEST_SUITE_SYSTEM_GPU=nvidia",
                         ],
+                        add_openmp_lit_args=["--time-tests"],
                     )},
 
 # OpenMP AMDGPU Builders

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1766,6 +1766,7 @@ all += [
                                 "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
                             ],
                         install=True,
+                        add_lit_checks=["check-offload"],
                         testsuite=True,
                         testsuite_sollvevv=True,
                         extraTestsuiteCmakeArgs=[
@@ -1796,6 +1797,7 @@ all += [
                                 "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
                             ],
                         install=True,
+                        add_lit_checks=["check-offload"],
                         testsuite=True,
                         testsuite_sollvevv=True,
                         extraTestsuiteCmakeArgs=[


### PR DESCRIPTION
In contrast to `check-openmp`, `check-offload` is not implicit. Also add `--time-tests` to be able to see the duration of each test.

Thanks to @jplehr for the hint.