### PR TITLE
[RISCV] Move fuse-ld flag to CMAKE_EXE_LINKER_FLAGS_INIT

### DIFF
--- a/zorg/buildbot/builders/annotated/libc-linux.py
+++ b/zorg/buildbot/builders/annotated/libc-linux.py
@@ -101,10 +101,11 @@ def main(argv):
         if riscv32_build:
             cmake_args.append('-DCMAKE_C_FLAGS=-mabi=ilp32d -march=rv32imafdc \
                                --target=riscv32-unknown-linux-gnu --sysroot=/opt/riscv/sysroot \
-                               --gcc-toolchain=/opt/riscv -fuse-ld=lld-15')
+                               --gcc-toolchain=/opt/riscv')
             cmake_args.append('-DCMAKE_CXX_FLAGS=-mabi=ilp32d -march=rv32imafdc \
                                --target=riscv32-unknown-linux-gnu --sysroot=/opt/riscv/sysroot \
-                               --gcc-toolchain=/opt/riscv -fuse-ld=lld')
+                               --gcc-toolchain=/opt/riscv')
+            cmake_args.append('-DCMAKE_EXE_LINKER_FLAGS_INIT=-fuse-ld=lld')
             cmake_args.append('-DCMAKE_CROSSCOMPILING_EMULATOR={}/cross.sh'.format(os.getenv('HOME')))
             cmake_args.append('-DLIBC_TARGET_TRIPLE=riscv32-unknown-linux-gnu')
             cmake_args.append('-DCMAKE_SYSTEM_NAME=Linux')


### PR DESCRIPTION
The build bot fails with the current message:

clang-15: error: argument unused during compilation: '-fuse-ld=lld'

because we are passing the fuse-ld flag as a compilation argument.

This patch sets it to CMAKE_EXE_LINKER_FLAGS_INIT so it can be loaded by LD_FLAGS instead.