### PR TITLE
fix hip-build.sh about compiler-rt

### DIFF
--- a/zorg/buildbot/builders/annotated/hip-build.sh
+++ b/zorg/buildbot/builders/annotated/hip-build.sh
@@ -79,8 +79,9 @@ cmake -G Ninja \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
   -DCMAKE_VERBOSE_MAKEFILE=1 \
   -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" \
-  -DLLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra;compiler-rt" \
-  -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
+  -DLLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra" \
+  -DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi;libunwind" \
+  -DCLANG_DEFAULT_LINKER=lld \
   -DLIBCXX_ENABLE_SHARED=OFF \
   -DLIBCXX_ENABLE_STATIC=ON \
   -DLIBCXX_INSTALL_LIBRARY=OFF \


### PR DESCRIPTION
Build compiler-rt as runtime instead of project. This will use freshly built clang to build compiler-rt instead of the system compiler. Also use lld to link compiler-rt. Both can lower the risk of encounter issues with old system compiler and linker.

Fixes buildbot failure https://lab.llvm.org/buildbot/#/builders/123/builds/1580