### PR TITLE
[test] Fix errors in Import.py test

### DIFF
--- a/test/buildbot/builders/Import.py
+++ b/test/buildbot/builders/Import.py
@@ -6,6 +6,6 @@ from zorg.buildbot.builders import SanitizerBuilder
 
 # Just check that we can instantiate the build factors, what else can we do?
 
-print ClangBuilder.getClangBuildFactory()
+print(ClangBuilder.getClangCMakeBuildFactory())
 
-print SanitizerBuilder.getSanitizerBuildFactory()
+print(SanitizerBuilder.getSanitizerBuildFactory())


### PR DESCRIPTION
This test had Python2 style prints, and needs to call ClangBuilder.getClangCMakeBuildFactory rather than ClangBuilder.getClangBuildFactory.