### PR TITLE
[RISCV] Limit the number the parallel processes for rv32

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2246,7 +2246,7 @@ all += [
     'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
                     script="libc-linux.py",
                     depends_on_projects=['llvm', 'libc'],
-                    extra_args=['--debug'])},
+                    extra_args=['--debug', '--jobs=8'])},
 
 # Flang builders.
 

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -355,7 +355,7 @@ def get_all():
 
         # RISC-V workers
         create_worker("rv64gc-qemu-user", properties={'jobs' : 32}, max_builds=1),
-        create_worker("rv32gc-qemu-system", properties={'jobs' : 32}, max_builds=1),
+        create_worker("rv32gc-qemu-system", properties={'jobs' : 8}, max_builds=1),
         create_worker("rise-clang-riscv-rva20-2stage", properties={'jobs' : 32}, max_builds=1),
         create_worker("rise-clang-riscv-rva23-2stage", properties={'jobs' : 32}, max_builds=1),
         create_worker("rise-clang-riscv-rva23-mrvv-vec-bits-2stage", properties={'jobs' : 16}, max_builds=1),


### PR DESCRIPTION
This patch is intended to limit the number of parallel processes to 8 in the rv32 buildbot, since it's running the tests are run inside qemu and too many processes ends up causing test failures.