### PR TITLE
Fix failed test/buildbot/builders/unified_cmakeex.py test (issue #235).

### DIFF
--- a/test/buildbot/builders/unified_cmakeex.py
+++ b/test/buildbot/builders/unified_cmakeex.py
@@ -11,11 +11,16 @@ import zorg
 from zorg.buildbot.builders import UnifiedTreeBuilder
 from zorg.buildbot.process.factory import LLVMBuildFactory
 
+#Note:
+# - this function currently supports only %(kw:*)s formatting for the Interpolates.
+# - this function does not support the substitutions for arguments (such as '%(kw:arg:-)s' & etc).
+# - this function does not support the other types of the renderables except Interpolate
+#   (such as WithProperties and os on).
 def partly_rendered(r):
     if isinstance(r, buildbot.process.properties.Interpolate):
         interpolations = {}
         for k, v in r.kwargs.items():
-            interpolations[f"kw:{k}"] = v
+            interpolations[f"kw:{k}"] = v if v else ""
         return r.fmtstring % interpolations
     elif type(r) == str:
         return r
@@ -90,7 +95,7 @@ assert factory_has_num_steps(f, 7)
 assert factory_has_step(f, "set-props")
 assert factory_has_step(f, "clean-src-dir")
 assert factory_has_step(f, "clean-obj-dir")
-assert factory_has_step(f, "Checkout the source code")
+assert factory_has_step(f, "checkout")
 
 assert factory_has_step(f, "cmake-configure")
 assert factory_has_step(f, "cmake-configure", hasarg = "generator", contains = "Ninja")
@@ -193,7 +198,7 @@ assert factory_has_num_steps(f, 13)
 assert factory_has_step(f, "set-props")
 assert factory_has_step(f, "clean-src-dir")
 assert factory_has_step(f, "clean-obj-dir")
-assert factory_has_step(f, "Checkout the source code")
+assert factory_has_step(f, "checkout")
 
 assert factory_has_step(f, "clean-install-dir")
 assert factory_has_step(f, "cmake-configure")
@@ -231,13 +236,13 @@ f = UnifiedTreeBuilder.getCmakeExBuildFactory(vs = "autodetect")
 print(f"factory with VS environment autodetect: {f}\n")
 
 assert factory_has_num_steps(f, 8)
-assert factory_has_step(f, "set-pros.vs_env")
+assert factory_has_step(f, "set-props.vs_env")
 
 f = UnifiedTreeBuilder.getCmakeExBuildFactory(vs = "manual", vs_arch = "amd64")
 print(f"factory with VS environment manual: {f}\n")
 
 assert factory_has_num_steps(f, 8)
-assert factory_has_step(f, "set-pros.vs_env")
+assert factory_has_step(f, "set-props.vs_env")
 
 # Check custom CMake generator
 f = UnifiedTreeBuilder.getCmakeExBuildFactory(generator = "Unix Makefiles")
@@ -350,3 +355,13 @@ assert factory_has_step(f, "post_build_step1", hasarg = "property", contains = "
 assert factory_has_step(f, "post_build_step2", hasarg = "command", contains = ["ls"])
 assert factory_has_step(f, "pre_install_step", hasarg = "property", contains = "SomeProperty")
 assert factory_has_step(f, "post_finalize_step", hasarg = "property", contains = "SomeProperty")
+
+
+# Hint
+f = UnifiedTreeBuilder.getCmakeExBuildFactory(
+        hint = "stage-hint"
+    )
+print(f"Hint option: {f}\n")
+
+assert factory_has_step(f, "cmake-configure-stage-hint")
+assert factory_has_step(f, "build-default-stage-hint")

--- a/zorg/buildbot/builders/UnifiedTreeBuilder.py
+++ b/zorg/buildbot/builders/UnifiedTreeBuilder.py
@@ -800,6 +800,8 @@ def getCmakeExBuildFactory(
                 install => install-stageX
                 & etc.
 
+            Note: cannot be a renderable object.
+
         Returns
         -------
 
@@ -842,6 +844,7 @@ def getCmakeExBuildFactory(
                                                  "The 'pre_install_steps' argument must be a list() or BuildFactory()."
     assert not post_finalize_steps or isinstance(post_finalize_steps, (list, BuildFactory)), \
                                                  "The 'post_finalize_steps' argument must be a list() or BuildFactory()."
+    assert not hint or isinstance(hint, str),    "The 'hint' argument must be a str object."
 
     # This function extends the current workflow with provided custom steps.
     def extend_with_custom_steps(fc, s):
@@ -994,7 +997,7 @@ def getCmakeExBuildFactory(
             workdir         = f.obj_dir
         ))
 
-    hint_suffix = f"-{hint}" if hint else None
+    hint_suffix = f"-{hint}" if hint else ""
     # Build Commands.
     #NOTE: please note that the default target (.) cannot be specified by the IRenderable object.
     for target in targets:
@@ -1008,7 +1011,7 @@ def getCmakeExBuildFactory(
 
         f.addStep(
             steps.CMake(
-                name            = util.Interpolate("build-%(kw:title)s%(kw:hint:-)s",
+                name            = util.Interpolate("build-%(kw:title)s%(kw:hint)s",
                                                    title = target_title, hint = hint_suffix),
                 options         = cmake_build_options,
                 description     = ["Build target", target_title],
@@ -1025,7 +1028,7 @@ def getCmakeExBuildFactory(
     for target in checks:
         f.addStep(
             LitTestCommand(
-                name            = util.Interpolate("test-%(kw:title)s%(kw:hint:-)s",
+                name            = util.Interpolate("test-%(kw:title)s%(kw:hint)s",
                                                    title = target, hint = hint_suffix),
                 command         = [steps.CMake.DEFAULT_CMAKE, "--build", ".", "--target", target],
                 description     = ["Test just built components:", target],
@@ -1039,7 +1042,7 @@ def getCmakeExBuildFactory(
     for target, cmd in checks_on_target:
         f.addStep(
             LitTestCommand(
-                name            = util.Interpolate("test-%(kw:title)s%(kw:hint:-)s",
+                name            = util.Interpolate("test-%(kw:title)s%(kw:hint)s",
                                                    title = target, hint = hint_suffix),
                 command         = cmd,
                 description     = ["Test just built components:", target],
@@ -1059,7 +1062,7 @@ def getCmakeExBuildFactory(
             f.addStep(
                 steps.CMake(
                     name            = util.Transform(lambda s: s if s.startswith("install") else f"install-{s}",
-                                                     util.Interpolate("%(kw:title)s%(kw:hint:-)s", title = target, hint = hint_suffix)),
+                                                     util.Interpolate("%(kw:title)s%(kw:hint)s", title = target, hint = hint_suffix)),
                     options         = ["--build", ".", "--target", target],
                     description     = ["Install just built components:", target],
                     haltOnFailure   = False,


### PR DESCRIPTION
The changes for UnifiedTreeBuilder.getCmakeExBuildFactory factory and its test:

* updated the step formatting with 'hint' argument (avoid usage of substitutions).
* allowed only 'str' or None for the 'hint' argument.
* updated 'test/buildbot/builders/unified_cmakeex.py' test for the factory changes accordingly.

See #235 for more details.