### PR TITLE
Fix test/buildbot/builders/Import.py test accordingly the current Zorg version.

### DIFF
--- a/test/buildbot/builders/Import.py
+++ b/test/buildbot/builders/Import.py
@@ -6,6 +6,6 @@ from zorg.buildbot.builders import SanitizerBuilder
 
 # Just check that we can instantiate the build factors, what else can we do?
 
-print ClangBuilder.getClangBuildFactory()
+print("{}".format(ClangBuilder.getClangCMakeBuildFactory()))
 
-print SanitizerBuilder.getSanitizerBuildFactory()
+print("{}".format(SanitizerBuilder.getSanitizerBuildFactory()))


### PR DESCRIPTION
Update accordingly the current version of Zorg's buildbot factories and supported min python version (3.6).