### PR TITLE
[libc] Rename riscv32 buildbot to enable fullbuild

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2239,10 +2239,10 @@ all += [
                     depends_on_projects=['llvm', 'libc'],
                     extra_args=['--debug'])},
 
-    {'name' : "libc-riscv32-qemu-debian-dbg",
+    {'name' : "libc-riscv32-qemu-yocto-fullbuild-dbg",
     'tags'  : ["libc"],
     'workernames' : ["rv32gc-qemu-system"], # TODO: workername?
-    'builddir': "libc-riscv32-qemu-debian-dbg",
+    'builddir': "libc-riscv32-qemu-yocto-fullbuild-dbg",
     'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
                     script="libc-linux.py",
                     depends_on_projects=['llvm', 'libc'],


### PR DESCRIPTION
The libc buildbots use the builder's name to enable/disable libc features, so we add 'fullbuild' to the bot's name to enable libc's fullbuild.