### PR TITLE
Removing the ppc64be buildbots due to ppc64 linux OS EOL

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -619,37 +619,6 @@ all = [
                                       '-DCMAKE_C_COMPILER_TARGET="mips64el-unknown-linux-gnu"',
                                       '-DLLVM_TARGETS_TO_BUILD=Mips'])},
 
-    {'name' : "clang-ppc64be-linux-test-suite",
-    'tags'  : ["clang", "ppc"],
-    'workernames' : ["ppc64be-clang-test-suite"],
-    'builddir': "clang-ppc64be-test-suite",
-    'factory' : TestSuiteBuilder.getTestSuiteBuildFactory(
-                    depends_on_projects=["llvm", "clang", "clang-tools-extra",
-                                         "compiler-rt"],
-                    checks=['check-all', 'check-runtimes'],
-                    extra_configure_args=[
-                        "-DLLVM_ENABLE_ASSERTIONS=ON",
-                        "-DCMAKE_BUILD_TYPE=Release",
-                        "-DLLVM_LIT_ARGS=-v",
-                        "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
-                        "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"])},
-
-    {'name' : "clang-ppc64be-linux-multistage",
-    'tags'  : ["clang", "ppc"],
-    'workernames' : ["ppc64be-clang-multistage-test"],
-    'builddir': "clang-ppc64be-multistage",
-    'factory' : ClangBuilder.getClangCMakeBuildFactory(
-                    clean=False,
-                    checks=['check-all', 'check-runtimes'],
-                    checkout_lld=False,
-                    useTwoStage=True,
-                    stage1_config='Release',
-                    stage2_config='Release',
-                    extra_cmake_args=[
-                        "-DLLVM_ENABLE_ASSERTIONS=ON",
-                        "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
-                        "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"])},
-
     {'name' : "clang-ppc64le-linux-test-suite",
     'tags'  : ["clang", "ppc", "ppc64le"],
     'workernames' : ["ppc64le-clang-test-suite"],
@@ -1687,12 +1656,6 @@ all += [
     ],
     'builddir': "sanitizer-aarch64-linux-fuzzer",
     'factory' : SanitizerBuilder.getSanitizerBuildFactory()},
-
-    {'name' : "sanitizer-ppc64be-linux",
-    'tags'  : ["sanitizer", "ppc"],
-    'workernames' : ["ppc64be-sanitizer"],
-    'builddir': "sanitizer-ppc64be",
-    'factory' : SanitizerBuilder.getSanitizerBuildFactory(timeout=1800)},
 
     {'name' : "sanitizer-ppc64le-linux",
     'tags'  : ["sanitizer", "ppc", "ppc64le"],

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -61,11 +61,6 @@ def get_all():
         create_worker("debian-akiko-m68k", properties={'jobs': 1}, max_builds=1),
         create_worker("suse-gary-m68k-cross", properties={'jobs': 4}, max_builds=1),
 
-        # POWER7 PowerPC big endian (powerpc64)
-        create_worker("ppc64be-clang-test-suite", max_builds=1),
-        create_worker("ppc64be-clang-multistage-test", properties={'jobs': 16}, max_builds=1),
-        create_worker("ppc64be-sanitizer", properties={'jobs': 16}, max_builds=1),
-
         # POWER 8 PowerPC little endian (powerpc64le)
         create_worker("ppc64le-clang-test-suite", max_builds=1),
         create_worker("ppc64le-clang-multistage-test", properties={'jobs': 8}, max_builds=1),

--- a/zorg/buildbot/builders/sanitizers/buildbot_selector.py
+++ b/zorg/buildbot/builders/sanitizers/buildbot_selector.py
@@ -13,7 +13,6 @@ def in_script_dir(path):
 
 BOT_ASSIGNMENT = {
     'sanitizer-ppc64le-linux': 'buildbot_cmake.sh',
-    'sanitizer-ppc64be-linux': 'buildbot_cmake.sh',
     'sanitizer-x86_64-linux': 'buildbot_cmake.sh',
     'sanitizer-x86_64-linux-fast': 'buildbot_fast.sh',
     'sanitizer-x86_64-linux-autoconf': 'buildbot_standard.sh',
@@ -33,7 +32,6 @@ BOT_ASSIGNMENT = {
 
 BOT_ADDITIONAL_ENV = {
     'sanitizer-ppc64le-linux': {},
-    'sanitizer-ppc64be-linux': {},
     'sanitizer-x86_64-linux': {},
     'sanitizer-x86_64-linux-fast': {},
     'sanitizer-x86_64-linux-autoconf': {},


### PR DESCRIPTION
RHEL 7.9, the only remaining officially supported Big Endian
Linux operating system, has reached its end of life. This patch
removes these buildbots due to their host and target arch
lack of OS security fixes and support.
