### PR TITLE
[ClangBuilder] Pass -k to make for test-suite runs

### DIFF
--- a/zorg/buildbot/builders/ClangBuilder.py
+++ b/zorg/buildbot/builders/ClangBuilder.py
@@ -527,7 +527,9 @@ def _getClangCMakeBuildFactory(
                               '--test-suite', test_suite_dir,
                               '--cc', cc,
                               '--cxx', cxx,
-                              '--use-lit', lit]
+                              '--use-lit', lit,
+                              # Carry on building even if there is a failure.
+                              '--build-tool-options', '"-k"']
             # Enable fortran if flang is checked out
             if checkout_flang:
                 fortran_flags = [


### PR DESCRIPTION
When https://github.com/llvm/llvm-lnt/commit/768874171529d31d12adb032df57b1c5f1c1fa77 enabled using Ninja, it removed the -k flag from make. -k causes make to carry on if there's a build failure.

Without this flag, a single compilation failure turns into thousands of missing executables in the final results. As subsequent targets are not built.

https://github.com/llvm/llvm-lnt/pull/25 is adding an option to the lnt runner to pass options to the build tool.

This PR uses that to pass -k to make to restore the old behaviour on the build bots.