### PR TITLE
Update LLVM WoA buildbots for better coverage

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -320,10 +320,10 @@ all = [
                     clean=False,
                     checkout_flang=True,
                     checkout_lld=True,
-                    checkout_compiler_rt=False,
                     extra_cmake_args=[
+                        "-DCLANG_DEFAULT_LINKER=lld",
                         "-DCMAKE_TRY_COMPILE_CONFIGURATION=Release",
-                        "-DLLVM_TARGETS_TO_BUILD='AArch64'",
+                        "-DCOMPILER_RT_BUILD_SANITIZERS=OFF",
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"])},
 
@@ -593,20 +593,20 @@ all = [
 
     {'name' : "clang-arm64-windows-msvc-2stage",
     'tags'  : ["clang"],
-    'workernames' : ["linaro-armv8-windows-msvc-01", "linaro-armv8-windows-msvc-02", "linaro-armv8-windows-msvc-03"],
+    'workernames' : ["linaro-armv8-windows-msvc-02"],
     'builddir': "clang-arm64-windows-msvc-2stage",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     vs="manual",
+                    clean=False,
                     useTwoStage=True,
                     checkout_flang=True,
+                    testStage1=False,
                     extra_cmake_args=[
+                        "-DCLANG_DEFAULT_LINKER=lld",
                         "-DCMAKE_TRY_COMPILE_CONFIGURATION=Release",
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
-                        # FIXME: compiler-rt\lib\sanitizer_common\sanitizer_unwind_win.cpp assumes WIN64 is x86_64,
-                        #        so, before that's fixed, disable everything that triggers its build.
-                        "-DCOMPILER_RT_BUILD_SANITIZERS=OFF",
-                        "-DCOMPILER_RT_BUILD_PROFILE=OFF"])},
+                        "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"])},
 
     {'name' : 'clang-x64-windows-msvc',
     'tags'  : ["clang"],

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -41,9 +41,7 @@ def get_all():
         create_worker("linaro-g3-04", max_builds=1),
 
         # AArch64 Windows Microsoft Surface X Pro
-        create_worker("linaro-armv8-windows-msvc-01", max_builds=1),
         create_worker("linaro-armv8-windows-msvc-02", max_builds=1),
-        create_worker("linaro-armv8-windows-msvc-03", max_builds=1),
         create_worker("linaro-armv8-windows-msvc-04", max_builds=1),
         create_worker("linaro-armv8-windows-msvc-05", max_builds=1),
 


### PR DESCRIPTION
This updates LLVM WoA bots with following changes:
1) Do not run stage1 testing on 2 stage clang bot. 
2) Remove redundant workers.
3) Remove -DCOMPILER_RT_BUILD_PROFILE=OFF
4) Add compiler-rt to single stage bot
5) Set clean=False for the 2stage bots
6) Set "-DCLANG_DEFAULT_LINKER=lld" for all WoA bots