### PR TITLE
Add WoA testsuite buildbot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -320,10 +320,10 @@ all = [
                     clean=False,
                     checkout_flang=True,
                     checkout_lld=True,
-                    checkout_compiler_rt=False,
                     extra_cmake_args=[
+                        "-DCLANG_DEFAULT_LINKER=lld",
                         "-DCMAKE_TRY_COMPILE_CONFIGURATION=Release",
-                        "-DLLVM_TARGETS_TO_BUILD='AArch64'",
+                        "-DCOMPILER_RT_BUILD_SANITIZERS=OFF",
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"])},
 
@@ -593,20 +593,20 @@ all = [
 
     {'name' : "clang-arm64-windows-msvc-2stage",
     'tags'  : ["clang"],
-    'workernames' : ["linaro-armv8-windows-msvc-01", "linaro-armv8-windows-msvc-02", "linaro-armv8-windows-msvc-03"],
+    'workernames' : ["linaro-armv8-windows-msvc-02"],
     'builddir': "clang-arm64-windows-msvc-2stage",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     vs="manual",
+                    clean=False,
                     useTwoStage=True,
                     checkout_flang=True,
+                    testStage1=False,
                     extra_cmake_args=[
+                        "-DCLANG_DEFAULT_LINKER=lld",
                         "-DCMAKE_TRY_COMPILE_CONFIGURATION=Release",
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
-                        # FIXME: compiler-rt\lib\sanitizer_common\sanitizer_unwind_win.cpp assumes WIN64 is x86_64,
-                        #        so, before that's fixed, disable everything that triggers its build.
-                        "-DCOMPILER_RT_BUILD_SANITIZERS=OFF",
-                        "-DCOMPILER_RT_BUILD_PROFILE=OFF"])},
+                        "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"])},
 
     {'name' : 'clang-x64-windows-msvc',
     'tags'  : ["clang"],

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -591,6 +591,26 @@ all = [
                         "-DMLIR_RUN_ARM_SVE_TESTS=True",
                         "-DLLVM_LIT_ARGS='-v'"])},
 
+    {'name' : "clang-arm64-windows-msvc-testsuite",
+    'tags'  : ["clang"],
+    'workernames' : ["linaro-armv8-windows-msvc-03"],
+    'builddir': "clang-arm64-windows-msvc-testsuite",
+    'factory' : ClangBuilder.getClangCMakeBuildFactory(
+                    vs="manual",
+                    checks=[],
+                    clean=False,
+                    checkout_flang=True,
+                    checkout_lld=True,
+                    runTestSuite=True,
+                    testWithLNT=False,
+                    testsuite_flags=["-DTEST_SUITE_SUBDIRS='Fortran'"],
+                    extra_cmake_args=[
+                        "-DCMAKE_TRY_COMPILE_CONFIGURATION=Release",
+                        "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
+                        "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
+                        "-DCLANG_DEFAULT_LINKER=lld",
+                        "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"])},
+
     {'name' : "clang-arm64-windows-msvc-2stage",
     'tags'  : ["clang"],
     'workernames' : ["linaro-armv8-windows-msvc-02"],

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -42,6 +42,7 @@ def get_all():
 
         # AArch64 Windows Microsoft Surface X Pro
         create_worker("linaro-armv8-windows-msvc-02", max_builds=1),
+        create_worker("linaro-armv8-windows-msvc-03", max_builds=1),
         create_worker("linaro-armv8-windows-msvc-04", max_builds=1),
         create_worker("linaro-armv8-windows-msvc-05", max_builds=1),
 

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -41,9 +41,7 @@ def get_all():
         create_worker("linaro-g3-04", max_builds=1),
 
         # AArch64 Windows Microsoft Surface X Pro
-        create_worker("linaro-armv8-windows-msvc-01", max_builds=1),
         create_worker("linaro-armv8-windows-msvc-02", max_builds=1),
-        create_worker("linaro-armv8-windows-msvc-03", max_builds=1),
         create_worker("linaro-armv8-windows-msvc-04", max_builds=1),
         create_worker("linaro-armv8-windows-msvc-05", max_builds=1),
 


### PR DESCRIPTION
This is a follow up patch on #245 and #252
It adds a new builder called clang-arm64-windows-msvc-testsuite. It will
do stage1 and stage2 builds without running checks. Checks are already
covered by single stage and 2 stage bots.
