### PR TITLE
Make all clang-aarch64-full-2stage builds clean builds

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -471,7 +471,7 @@ all = [
     'workernames' : ["linaro-clang-aarch64-full-2stage"],
     'builddir': "clang-aarch64-full-2stage",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
-                    clean=False,
+                    clean=True,
                     checkout_flang=True,
                     checkout_lld=True,
                     useTwoStage=True,


### PR DESCRIPTION
This is step 1 to addressing the rapidly expanding build queues we're seeing (#250).

The bot is currently on silent, and the plan is:
* Mark all builds as clean (we use ccache so it shouldn't be a big impact).
* Clear the existing requests.
* See what happens to the queue.

It's possible we will need a follow up to make collapsing work, but this is the first step either way.