### PR TITLE
[lldb][Arm] Use lld for linking and tests

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1311,6 +1311,7 @@ all = [
                         '-DLLVM_ENABLE_ASSERTIONS=True',
                         '-DLLVM_LIT_ARGS=-vj 4',
                         '-DLLVM_USE_LINKER=lld',
+                        '-DCLANG_DEFAULT_LINKER=lld',
                         '-DLLDB_ENFORCE_STRICT_TEST_REQUIREMENTS=ON'])},
 
     {'name' : "lldb-aarch64-windows",

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1310,7 +1310,7 @@ all = [
                     extra_cmake_args=[
                         '-DLLVM_ENABLE_ASSERTIONS=True',
                         '-DLLVM_LIT_ARGS=-vj 4',
-                        '-DLLVM_USE_LINKER=gold',
+                        '-DLLVM_USE_LINKER=lld',
                         '-DLLDB_ENFORCE_STRICT_TEST_REQUIREMENTS=ON'])},
 
     {'name' : "lldb-aarch64-windows",


### PR DESCRIPTION
Since https://lab.llvm.org/buildbot/#/builders/18/builds/3578 the build has been failing with:
```
FAILED: lib/libclang-cpp.so.20.0git
: && /usr/local/bin/c++ -fPIC -fPIC -fno-semantic-interposition <...> -lm  /usr/lib/arm-linux-gnueabihf/libz.so && :
/usr/bin/ld.gold: internal error in open, at ../../gold/descriptors.cc:99
```

gold is no longer maintained and in my own experience hitting this same sort of error, my only solution was to switch to ld or lld.

There's no particular reason to use gold here I think it was just set that way before lld was useable on Arm.

Since we're linking clang with it we might as well use it in tests too, so make lld clang's default linker.