### PR TITLE
ClangBuilder: Use "flang" instead of "flang-new" for the test suite

### DIFF
--- a/zorg/buildbot/builders/ClangBuilder.py
+++ b/zorg/buildbot/builders/ClangBuilder.py
@@ -403,11 +403,11 @@ def _getClangCMakeBuildFactory(
     if not vs:
         cc = 'clang'
         cxx = 'clang++'
-        fc = 'flang-new'
+        fc = 'flang'
     else:
         cc = 'clang-cl.exe'
         cxx = 'clang-cl.exe'
-        fc = 'flang-new.exe'
+        fc = 'flang.exe'
 
 
     ############# STAGE 2


### PR DESCRIPTION
See https://discourse.llvm.org/t/proposal-rename-flang-new-to-flang/69462 for background.

This is to be landed once https://github.com/llvm/llvm-project/pull/110023 has landed.