### PR TITLE
Remove OS version from build_deps

### DIFF
--- a/zorg/jenkins/clang_build_dependencies.dep
+++ b/zorg/jenkins/clang_build_dependencies.dep
@@ -1,4 +1,3 @@
-os_version == 14.1 # All nodes should be on 14.1
 brew cmake >= 3.17.2 # All nodes have 3.17.2
 brew ninja >= 1.8.2 # Stage2 verbose output
 pip psutil >= 5.4.5 # Required for timeouts in the GTest Suite.


### PR DESCRIPTION
We have a fleet which has multiple OS versions, and we don't actually require that the OS == 14.1, so this check is really only causing false-positive errors to appear in the console logs