### PR TITLE
[lldb] Flags for running Shell tests remotely on "lldb-remote-linux-ubuntu" builder

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3330,6 +3330,9 @@ all += [
 
                         "LLDB_TEST_ARCH"                : "aarch64",
                         "LLDB_TEST_COMPILER"            : util.Interpolate("%(prop:tools_root_path)s/aarch64-clang-18/bin/clang"),
+                        "LLDB_TEST_PLATFORM_URL"        : util.Interpolate("connect://%(prop:remote_test_host)s:1234"),
+                        "LLDB_TEST_PLATFORM_WORKING_DIR": "/home/ubuntu/lldb-tests",
+                        "LLDB_TEST_SYSROOT"             : util.Interpolate("%(prop:sysroot_path_aarch64)s"),
                         "LLDB_ENABLE_PYTHON"            : "ON",
                         "LLDB_ENABLE_SWIG"              : "ON",
                         "LLDB_ENABLE_LIBEDIT"           : "OFF",
@@ -3340,11 +3343,8 @@ all += [
                         # We are going to build it for the target platform later.
                         "LLDB_CAN_USE_LLDB_SERVER"      : "OFF",
                         "LLDB_TEST_USER_ARGS"           : util.Interpolate(
-                                                            "--env;USE_LLVM_TOOLS=1;--env;ARCH_CFLAGS=-mcpu=cortex-a78;" \
-                                                            "--sysroot=%(prop:sysroot_path_aarch64)s;" \
-                                                            "--platform-name;remote-linux;" \
-                                                            "--platform-url;connect://%(prop:remote_test_host)s:1234;" \
-                                                            "--platform-working-dir;/home/ubuntu/lldb-tests"),
+                                                            "--env;ARCH_CFLAGS=-mcpu=cortex-a78;" \
+                                                            "--platform-name;remote-linux"),
                     },
                     cmake_options = {
                     },


### PR DESCRIPTION
dotest.py flags are replaced with CMake flags introduced in https://github.com/llvm/llvm-project/pull/95986 to run Shell tests remotely.

Also, USE_LLVM_TOOLS is removed since it's implied by default that LLVM tools will be used for API tests since https://github.com/llvm/llvm-project/pull/109961.