### PR TITLE
Revert "[windows] Increase timeout for sanitizer-windows"

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1687,9 +1687,7 @@ all += [
     'builddir': "sanitizer-windows",
     'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
                     script="sanitizer-windows.py",
-                    depends_on_projects=["llvm", "clang", "lld", "compiler-rt"],
-                    # FIXME: Restore `timeout` to default when fixed https://github.com/llvm/llvm-project/issues/102513
-                    timeout=2400)},
+                    depends_on_projects=["llvm", "clang", "lld", "compiler-rt"])},
 
 # OpenMP builders.
 


### PR DESCRIPTION
For #102513

It should not be needed after https://github.com/llvm/llvm-project/pull/110986.

This reverts commit 73d07e033335e77f64a4ca0e202a34609e926662.
This reverts commit d0f47695ab36b38a4d1192d9ac4fe818b1f0b79c.
