### PR TITLE
[CI] Using libgcc breaks Driver test

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1964,7 +1964,7 @@ all += [
                             "-DBUILD_SHARED_LIBS=ON",
                             "-DLLVM_ENABLE_LIBCXX=ON",
                             "-DCLANG_DEFAULT_RTLIB=compiler-rt",
-                            "-DCLANG_DEFAULT_UNWINDLIB=libgcc",
+                            "-DCLANG_DEFAULT_UNWINDLIB=libunwind",
                             "-DLIBOMPTARGET_PLUGINS_TO_BUILD=amdgpu;host",
                             ],
                         env={


### PR DESCRIPTION
This makes using libunwind the default and work around a breakage in check-flang when setting libgcc as the default unwind lib.

(Should I remove the unrelated whitespace changes?)