### PR TITLE
Add clone of llvm-clang-x86_64-gcc-ubuntu builder that builds without assertions.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1013,6 +1013,24 @@ all = [
                         "-DLLVM_LIT_ARGS=--verbose",
                         "-DLLVM_TARGETS_TO_BUILD=AArch64"])},
 
+    {'name': "llvm-clang-x86_64-gcc-ubuntu-no-asserts",
+    'tags'  : ["llvm", "clang", "clang-tools-extra", "compiler-rt", "lld", "cross-project-tests"],
+    'workernames': ["doug-worker-6"],
+    'builddir': "gcc-no-asserts",
+    'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                    depends_on_projects=['llvm','clang','clang-tools-extra','compiler-rt','lld','cross-project-tests'],
+                    extra_configure_args=[
+                        "-DCMAKE_C_COMPILER=gcc",
+                        "-DCMAKE_CXX_COMPILER=g++",
+                        "-DCMAKE_BUILD_TYPE=Release",
+                        "-DCLANG_ENABLE_CLANGD=OFF",
+                        "-DLLVM_BUILD_RUNTIME=ON",
+                        "-DLLVM_BUILD_TESTS=ON",
+                        "-DLLVM_ENABLE_ASSERTIONS=OFF",
+                        "-DLLVM_INCLUDE_EXAMPLES=OFF",
+                        "-DLLVM_LIT_ARGS=--verbose",
+                        "-DLLVM_USE_LINKER=gold"])},
+
 # Polly builders.
 
     {'name' : "polly-arm-linux",

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1029,7 +1029,7 @@ all = [
                         "-DLLVM_ENABLE_ASSERTIONS=OFF",
                         "-DLLVM_INCLUDE_EXAMPLES=OFF",
                         "-DLLVM_LIT_ARGS=--verbose",
-                        "-DLLVM_USE_LINKER=gold"])},
+                        "-DLLVM_USE_LINKER=lld"])},
 
 # Polly builders.
 

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -331,6 +331,9 @@ def get_all():
         create_worker("doug-worker-4", properties={'jobs': 8}, max_builds=1),
         create_worker("doug-worker-5", properties={'jobs': 8}, max_builds=1),
 
+        # Ubuntu 20.04, AMD Ryzen 5 PRO 3400GE, 32GB
+        create_worker("doug-worker-6", properties={'jobs': 8}, max_builds=1),
+
         # XCore target, Ubuntu 20.04 x64 host
         create_worker("xcore-ubuntu20-x64", properties={'jobs': 4}, max_builds=1),
 


### PR DESCRIPTION
This adds a builder which is a clone of our existing llvm-clang-x86_64-gcc-ubuntu builder, except without assertions enabled. This is useful for finding tests that are added/updated but rely on (usually debug) information that isn't available when assertions are not enabled. This should help to catch those issues.