### PR TITLE
[zorg][lldb] Add new LLDB metrics bot

### DIFF
--- a/zorg/jenkins/jobs/jobs/lldb-statistics
+++ b/zorg/jenkins/jobs/jobs/lldb-statistics
@@ -1,0 +1,166 @@
+#!/usr/bin/env groovy
+pipeline {
+    options {
+        disableConcurrentBuilds()
+
+        timeout(time: 12, unit: 'HOURS')
+    }
+
+    parameters {
+        string(name: 'LABEL', defaultValue: params.LABEL ?: 'macos-x86_64', description: 'Node label to run on')
+        string(name: 'GIT_SHA', defaultValue: params.GIT_REVISION ?: '*/release/19.x', description: 'Git commit to build.')
+        string(name: 'ARTIFACT', defaultValue: params.ARTIFACT ?: 'lldb-cmake-intel/latest', description: 'Clang/LLDB artifact to use')
+        booleanParam(name: 'CLEAN', defaultValue: params.CLEAN ?: false, description: 'Wipe the build directory?')
+    }
+
+    agent {
+        node {
+            label params.LABEL
+        }
+    }
+    stages {
+        stage('Checkout') {
+            steps {
+                script {
+                    if(params.CLEAN) {
+                        deleteDir()
+                    }
+                }
+
+                timeout(30) {
+                    dir('src/clang-19') {
+                        checkout([$class: 'GitSCM', branches: [
+                            [name: params.GIT_SHA]
+                        ], userRemoteConfigs: [
+                            [url: 'https://github.com/llvm/llvm-project.git']
+                        ], extensions: [
+                            [$class: 'CloneOption',
+                            noTags: true, timeout: 30]
+                        ]])
+                    }
+                    dir('llvm-zorg') {
+                        checkout([$class: 'GitSCM', branches: [
+                            [name: '*/main']
+                        ], userRemoteConfigs: [
+                            [url: 'https://github.com/llvm/llvm-zorg.git']
+                        ]])
+                    }
+                }
+            }
+        }
+        stage('Setup Venv') {
+            environment {
+               PATH="$PATH:/usr/bin:/usr/local/bin"
+            }
+            steps {
+                sh '''
+                   rm -rf venv
+                   python3 -m venv venv
+                   set +u
+                   source ./venv/bin/activate
+                   pip install -r ./llvm-zorg/zorg/jenkins/jobs/requirements.txt
+                   set -u
+               '''
+            }
+        }
+        stage('Fetch Artifact') {
+            environment {
+               PATH="$PATH:/usr/bin:/usr/local/bin"
+            }
+            steps {
+                withCredentials([string(credentialsId: 's3_resource_bucket', variable: 'S3_BUCKET')]) {
+                    sh """
+                        source ./venv/bin/activate
+                        echo "ARTIFACT=${params.ARTIFACT}"
+                        python llvm-zorg/zorg/jenkins/monorepo_build.py fetch
+                        ls $WORKSPACE/host-compiler/lib/clang/
+                        VERSION=`ls $WORKSPACE/host-compiler/lib/clang/`
+                    """
+                }
+            }
+        }
+        stage('Build') {
+            environment {
+               PATH="$PATH:/usr/bin:/usr/local/bin"
+               SRC="$WORKSPACE/src"
+               BUILD="$WORKSPACE/clang-19-build"
+               TEST="$WORKSPACE/test"
+               RESULTS="$WORKSPACE/results"
+               CC="$WORKSPACE/host-compiler/bin/clang"
+               CXX="$WORKSPACE/host-compiler/bin/clang++"
+               HISTORIC_COMPILER="clang-19"
+            }
+            steps {
+                withCredentials([string(credentialsId: 's3_resource_bucket', variable: 'S3_BUCKET')]) {
+                    sh '''
+                       source ./venv/bin/activate
+
+                       cd src/clang-19
+                       git tag -a -m "First Commit" first_commit 97724f18c79c7cc81ced24239eb5e883bf1398ef || true
+
+                       git_desc=$(git describe --match "first_commit")
+                       export GIT_DISTANCE=$(echo ${git_desc} | cut -f 2 -d "-")
+
+                       sha=$(echo ${git_desc} | cut -f 3 -d "-")
+                       export GIT_SHA=${sha:1}
+
+                       cd -
+
+                       set -eux
+
+                       $CXX --version
+                       LLVM_REV=${GIT_DISTANCE}
+
+                       mkdir -p $HISTORIC_COMPILER-src
+                       mkdir -p $HISTORIC_COMPILER-build
+                       rsync -a $SRC/$HISTORIC_COMPILER/ $HISTORIC_COMPILER-src/
+                       cd $HISTORIC_COMPILER-build
+                       cmake ../$HISTORIC_COMPILER-src/llvm \
+                         -DCMAKE_BUILD_TYPE=Debug \
+                         -DLLVM_ENABLE_PROJECTS="clang;lldb" \
+                         -DLLVM_ENABLE_ASSERTIONS=Off \
+                         -DLLVM_ENABLE_MODULES=Off \
+                         -DLLDB_INCLUDE_TESTS=Off \
+                         -DLLDB_ENABLE_PYTHON=Off \
+                         -DLLDB_ENABLE_LUA=Off \
+                         -DLLVM_TARGETS_TO_BUILD='X86;AArch64' \
+                         -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
+                         -DCMAKE_C_COMPILER=$CC \
+                         -DCMAKE_CXX_COMPILER=$CXX \
+                         -G Ninja
+                       cmake --build .
+                       cd ../..
+                   '''
+                }
+            }
+        }
+        stage('Run metrics') {
+            environment {
+               HOST_BUILD_DIR="$WORKSPACE/host-compiler"
+               HISTORIC_BUILD_DIR="$WORKSPACE/clang-19-build"
+            }
+            steps {
+                sh '''
+                   ./llvm-zorg/zorg/jenkins/jobs/util/run_lldb_metrics.sh $HOST_BUILD_DIR $HISTORIC_BUILD_DIR
+                '''
+            }
+        }
+        //stage('Submit debuginfo statistics to LNT') {
+        //    steps {
+        //        sh '''
+        //            source ./venv/bin/activate
+
+        //            cd src/clang-13
+        //            git tag -a -m "First Commit" first_commit 97724f18c79c7cc81ced24239eb5e883bf1398ef || true
+
+        //            git_desc=$(git describe --match "first_commit")
+        //            export GIT_DISTANCE=$(echo ${git_desc} | cut -f 2 -d "-")
+
+        //            cd -
+
+        //            python llvm-zorg/zorg/jenkins/jobs/util/submit-debuginfo-statistics-to-lnt.py
+        //        '''
+        //    }
+        //}
+    }
+}

--- a/zorg/jenkins/jobs/jobs/lldb-statistics
+++ b/zorg/jenkins/jobs/jobs/lldb-statistics
@@ -1,4 +1,23 @@
 #!/usr/bin/env groovy
+
+// These are the LLVM build directories involved:
+//
+// (a) The "host" compiler/LLDB is taken from whatever the LLDB incremental built/used.
+//     The metrics we collect are from that "host" LLDB that we fetched. Throughout this
+//     file it is commonly referred to as 'host-compiler' or 'HOST_BUILD_DIR'.
+// 
+// (b) The debugger/compiler that we're debugging as part of metrics collection is pinned to
+//     the llvm-19.x release and is supposed to be unchanging across runs of this job.
+//     Throughout this file we refer to it as "historic" or 'clang-19'.
+// 
+// (c) We use the compiler from (a) to build the "historic" Clang/LLDB.
+// 
+// (d) The compiler compiling the debugger in (a) is the Clang produced by the clang-stage2
+//     buildbot and happens outside the purview job.
+//
+// In summary, the only stable version of Clang/LLVM is the one we use as the inferior during
+// metrics collection.
+
 pipeline {
     options {
         disableConcurrentBuilds()
@@ -145,6 +164,8 @@ pipeline {
                 '''
             }
         }
+
+        // TODO: for now we just dump the statistics to the console.
         //stage('Submit debuginfo statistics to LNT') {
         //    steps {
         //        sh '''

--- a/zorg/jenkins/jobs/jobs/lldb-statistics
+++ b/zorg/jenkins/jobs/jobs/lldb-statistics
@@ -154,6 +154,7 @@ pipeline {
                          -DCMAKE_C_COMPILER=$CC \
                          -DCMAKE_CXX_COMPILER=$CXX \
                          -DCLANG_ENABLE_BOOTSTRAP=On \
+                         -DCLANG_BOOTSTRAP_PASSTHROUGH="LLDB_INCLUDE_TESTS;LLDB_ENABLE_PYTHON;LLDB_ENABLE_LUA" \
                          -DBOOTSTRAP_CMAKE_BUILD_TYPE=Debug \
                          -G Ninja
                        cmake --build .

--- a/zorg/jenkins/jobs/jobs/lldb-statistics
+++ b/zorg/jenkins/jobs/jobs/lldb-statistics
@@ -1,5 +1,9 @@
 #!/usr/bin/env groovy
 
+// This pipeline collects LLDB metrics by attaching LLDB to stable a
+// version of clang-19/lldb-19, run various LLDB commands and then
+// dump LLDB statistics.
+
 // These are the LLVM build directories involved:
 //
 // (a) The "host" compiler/LLDB is taken from whatever the LLDB incremental built/used.
@@ -8,7 +12,10 @@
 // 
 // (b) The debugger/compiler that we're debugging as part of metrics collection is pinned to
 //     the llvm-19.x release and is supposed to be unchanging across runs of this job.
-//     Throughout this file we refer to it as "historic" or 'clang-19'.
+//     Throughout this file we refer to it as "historic" or 'clang-19'. We build this
+//     historic compiler with a 2-stage bootstrap build (the first stage in Release to
+//     speed up the build process, and the second stage in Debug since we need to attach
+//     LLDB to it).
 // 
 // (c) We use the compiler from (a) to build the "historic" Clang/LLDB.
 // 
@@ -135,7 +142,7 @@ pipeline {
                        rsync -a $SRC/$HISTORIC_COMPILER/ $HISTORIC_COMPILER-src/
                        cd $HISTORIC_COMPILER-build
                        cmake ../$HISTORIC_COMPILER-src/llvm \
-                         -DCMAKE_BUILD_TYPE=Debug \
+                         -DCMAKE_BUILD_TYPE=Release \
                          -DLLVM_ENABLE_PROJECTS="clang;lldb" \
                          -DLLVM_ENABLE_ASSERTIONS=Off \
                          -DLLVM_ENABLE_MODULES=Off \
@@ -146,6 +153,8 @@ pipeline {
                          -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
                          -DCMAKE_C_COMPILER=$CC \
                          -DCMAKE_CXX_COMPILER=$CXX \
+                         -DCLANG_ENABLE_BOOTSTRAP=On \
+                         -DBOOTSTRAP_CMAKE_BUILD_TYPE=Debug \
                          -G Ninja
                        cmake --build .
                        cd ../..

--- a/zorg/jenkins/jobs/jobs/lldb-statistics
+++ b/zorg/jenkins/jobs/jobs/lldb-statistics
@@ -166,7 +166,7 @@ pipeline {
         stage('Run metrics') {
             environment {
                HOST_BUILD_DIR="$WORKSPACE/host-compiler"
-               HISTORIC_BUILD_DIR="$WORKSPACE/clang-19-build"
+               HISTORIC_BUILD_DIR="$WORKSPACE/clang-19-build/tools/clang/stage2-bins"
             }
             steps {
                 sh '''

--- a/zorg/jenkins/jobs/util/run_lldb_metrics.sh
+++ b/zorg/jenkins/jobs/util/run_lldb_metrics.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 
+# Invoke as: ./run_lldb_metrics.sh /path/to/llvm/under/test /path/to/debug/llvm/build
+
 set -xeou pipefail
 
+# This directory contains the LLDB under test for which we collect metrics.
 LLVM_BUILD_DIR=$1
 if [ -z "${LLVM_BUILD_DIR}" ] || [ ! -d "${LLVM_BUILD_DIR}" ]; then
     echo "Invalid path to host Clang specified: ${LLVM_BUILD_DIR}"
     exit 1
 fi
 
+# This directory contains a debug build of clang and LLDB. We attach
+# the LLDB under test (in LLVM_BUILD_DIR) to these debug binaries
+# to collect metrics.
 DEBUG_BUILD_DIR=$2
 if [ -z "${DEBUG_BUILD_DIR}" ] || [ ! -d "${DEBUG_BUILD_DIR}" ]; then
     echo "Invalid path to host debug Clang/LLDB specified: ${DEBUG_BUILD_DIR}"

--- a/zorg/jenkins/jobs/util/run_lldb_metrics.sh
+++ b/zorg/jenkins/jobs/util/run_lldb_metrics.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+set -xeou pipefail
+
+LLVM_BUILD_DIR=$1
+if [ -z "${LLVM_BUILD_DIR}" ]; then
+    echo "Path to host Clang not specified."
+    exit 1
+fi
+
+DEBUG_BUILD_DIR=$2
+if [ -z "${DEBUG_BUILD_DIR}" ]; then
+    echo "Path to debug Clang/LLDB not specified."
+    exit 1
+fi
+
+ARTIFACTS=/tmp/lldb-metrics
+CSV_DIR=${ARTIFACTS}/csv
+HYPERFINE_RUNS=5
+HYPERFINE_WARMUP=3
+SYSROOT=`xcrun --show-sdk-path`
+TEST_COMPILE_FLAGS="-g -O0 -isysroot ${SYSROOT}"
+TEST_SRC_FILE=${ARTIFACTS}/main.cpp
+
+profile() {
+  local test_case_name=$1
+  if [ -z "${test_case_name}" ]; then
+      echo "ERROR: Test-case name is empty."
+      return
+  fi
+
+  local csv_path="${CSV_DIR}/${test_case_name}.csv"
+  if [ -f ${csv_path} ]; then
+      echo "Results already exist at '${csv_path}'."
+      return
+  fi
+
+  hyperfine \
+      --warmup ${HYPERFINE_WARMUP} \
+      --runs ${HYPERFINE_RUNS} \
+      --export-csv ${csv_path} \
+      --shell=bash \
+      -- \
+      "$2"
+
+  [[ -f $csv_path ]] && cat $csv_path
+}
+
+profile_clang() {
+    local test_case_name="clang_$1"
+
+    # Invocation to be profiled.
+    local profile_invocation=$2
+
+    # Debuggee that LLDB will launch.
+    local debuggee_invocation="${DEBUG_BUILD_DIR}/bin/clang++ -c ${TEST_COMPILE_FLAGS} ${TEST_SRC_FILE} -o $ARTIFACTS/a.o"
+
+    # Where to write the 'statistics dump' output to.
+    local stats_filename="${CSV_DIR}/${test_case_name}.json"
+
+    # Launch hyperfine.
+    profile \
+        $test_case_name \
+        "${profile_invocation} -o 'script -- f=open(\"${stats_filename}\",\"w\"); lldb.debugger.SetOutputFileHandle(f,True); lldb.debugger.HandleCommand(\"statistics dump\")' --batch -- ${debuggee_invocation}"
+
+    [[ -f $stats_filename ]] && cat $stats_filename
+}
+
+profile_lldb() {
+    local test_case_name="lldb_$1"
+
+    # Invocation to be profiled.
+    local profile_invocation=$2
+
+    local debuggee="${ARTIFACTS}/a.out"
+    if [ ! -f "${debuggee}" ]; then
+        ${DEBUG_BUILD_DIR}/bin/clang++ -isysroot ${SYSROOT} ${TEST_COMPILE_FLAGS} ${TEST_SRC_FILE} -o ${debuggee}
+    fi
+
+    # Debuggee that LLDB will launch.
+    local debuggee_invocation="${DEBUG_BUILD_DIR}/bin/lldb ${debuggee} -o 'br se -p return' -o run -o 'expr fib(1)'"
+
+    # Where to write the 'statistics dump' output to.
+    local stats_filename="${CSV_DIR}/${test_case_name}.json"
+
+    # Launch hyperfine.
+    profile \
+        $test_case_name \
+        "${profile_invocation} -o 'script -- f=open(\"${stats_filename}\",\"w\"); lldb.debugger.SetOutputFileHandle(f,True); lldb.debugger.HandleCommand(\"statistics dump\")' --batch -- ${debuggee_invocation}"
+
+    [[ -f $stats_filename ]] && cat $stats_filename
+}
+
+# Clean previous results
+
+rm -rf $ARTIFACTS
+mkdir $ARTIFACTS
+mkdir $CSV_DIR
+
+cat >${TEST_SRC_FILE} <<EOL
+#include <map>
+
+int fib(int n) {
+    static auto cache = [] {
+        auto ans = std::map<int, int>();
+        ans[0] = 0;
+        ans[1] = 1;
+        return ans;
+    }();
+    if (auto it = cache.find(n); it != cache.end()) return it->second;
+    auto ans = fib(n - 1) + fib(n - 2);
+    cache[ans] = ans;
+    return ans;
+}
+
+int main() {
+    fib(5);
+    return 0;
+}
+EOL
+
+# Clang benchmarks
+
+profile_clang \
+    "frame_status" \
+    "${LLVM_BUILD_DIR}/bin/lldb -o 'b CodeGenFunction::GenerateCode' -o run"
+
+profile_clang \
+    "expr_deref" \
+    "${LLVM_BUILD_DIR}/bin/lldb -o 'b CodeGenFunction::GenerateCode' -o run -o 'expr *Fn'"
+
+profile_clang \
+    "expr_method_call" \
+    "${LLVM_BUILD_DIR}/bin/lldb -o 'b CodeGenFunction::GenerateCode' -o run -o 'expr Fn->isVarArg()'"
+
+profile_clang \
+    "expr_re_eval" \
+    "${LLVM_BUILD_DIR}/bin/lldb -o 'b CodeGenFunction::GenerateCode' -o run -o 'expr *Fn' -o 'expr *Fn'"
+
+profile_clang \
+    "expr_two_stops" \
+    "${LLVM_BUILD_DIR}/bin/lldb -o 'b CodeGenFunction::GenerateCode' -o run -o 'expr *Fn' -o 'br del 1' -o 'b AsmPrinter::emitFunctionBody' -o c -o 'expr this->isVerbose()' -o 'expr TM'"
+
+profile_clang \
+    "var_then_expr" \
+    "${LLVM_BUILD_DIR}/bin/lldb -o 'b CodeGenFunction::GenerateCode' -o run -o up -o 'frame var' -o down -o 'expr *this'"
+
+profile_clang \
+    "var" \
+    "${LLVM_BUILD_DIR}/bin/lldb -o 'b CodeGenFunction::GenerateCode' -o run -o 'frame var'"
+
+# LLDB benchmarks
+
+profile_lldb \
+    "frame_status" \
+    "${LLVM_BUILD_DIR}/bin/lldb -o 'b ClangASTSource::FindExternalVisibleDeclsByName' -o run"
+
+profile_lldb \
+    "expr_deref" \
+    "${LLVM_BUILD_DIR}/bin/lldb -o 'b ClangASTSource::FindExternalVisibleDeclsByName' -o run -o 'expr m_active_lexical_decls'"
+
+profile_lldb \
+    "expr_method_call" \
+    "${LLVM_BUILD_DIR}/bin/lldb -o 'b ClangASTSource::FindExternalVisibleDeclsByName' -o run -o 'expr clang_decl_name.getAsString()'"
+
+profile_lldb \
+    "expr_re_eval" \
+    "${LLVM_BUILD_DIR}/bin/lldb -o 'b ClangASTSource::FindExternalVisibleDeclsByName' -o run -o 'expr m_active_lexical_decls' -o 'expr m_active_lexical_decls'"
+
+profile_lldb \
+    "expr_two_stops" \
+    "${LLVM_BUILD_DIR}/bin/lldb -o 'b ClangASTSource::FindExternalVisibleDeclsByName' -o run -o 'expr m_active_lexical_decls' -o 'b CodeGeneratorImpl::HandleTranslationUnit' -o 'br del 1' -o c -o 'expr Builder' -o 'expr Ctx.getLangOpts()'"
+
+profile_lldb \
+    "var_then_expr" \
+    "${LLVM_BUILD_DIR}/bin/lldb -o 'b ClangASTSource::FindExternalVisibleDeclsByName' -o run -o up -o 'frame var' -o down -o 'expr *this'"
+
+profile_lldb \
+    "var" \
+    "${LLVM_BUILD_DIR}/bin/lldb -o 'b ClangASTSource::FindExternalVisibleDeclsByName' -o run -o 'frame var'"


### PR DESCRIPTION
This patch adds a new job to collect LLDB metrics.

This is heavily based on the `debuginfo-statistics` job (but currently doesn't publish data to LNT).

Currently this job would do the following:
1. Check out the Clang 19.x release and build it
2. Use the LLDB and Clang from the `lldb-cmake-intel` job (not actually sure if that job publishes the right artifacts at the moment) to run the `run_lldb_metrics.sh` script.
3. Said script will attach LLDB to Clang/LLDB and run various commands. Then it will dump the `statistics dump` command to `stdout` (note we don't do any kind of averaging of these over multiple runs, since the metrics we care about **should** stable across runs). We also currently run these test-scenarios through `hyperfine` and dump the timing data. But maybe for a first attempt this isn't necessary.