### PR TITLE
[GHA] Add GitHub Action to run the tests for llvm-zorg itself

### DIFF
--- a/.github/workflows/lit-tests.yml
+++ b/.github/workflows/lit-tests.yml
@@ -1,4 +1,4 @@
-name: Run llvm-zorg's lit tests
+name: llvm-zorg testing
 
 on: [push, pull_request]
 
@@ -6,7 +6,8 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  check_zorg:
+    name: llvm-zorg lit tests
     if: github.repository_owner == 'llvm'
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/lit-tests.yml
+++ b/.github/workflows/lit-tests.yml
@@ -1,0 +1,21 @@
+name: Run llvm-zorg's lit tests
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    if: github.repository_owner == 'llvm'
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y llvm-18-tools buildbot
+        sudo ln -s /usr/lib/llvm-18/build/utils/lit/lit.py /usr/bin/lit
+        sudo ln -s /usr/bin/FileCheck-18 /usr/bin/FileCheck
+    - name: Run lit tests
+      run: /usr/lib/llvm-18/build/utils/lit/lit.py -v --xfail jenkins/test_build.py test


### PR DESCRIPTION
This adds a GitHub action to at least run the very minimal lit tests we have for zorg itself. With appropriate repository settings (perhaps it just works as-is? I've tested a variant on a downstream fork), it should provide pass/fail for both PRs and commits.

The GH Actions in the main llvm-repos tend to be gated on `if: github.repository_owner == 'llvm'`, which I've copied across here.

There's a question mark about how to handle `test/jenkins/test_build.py`. I've marked it XFAIL as a command-line `lit` option, as the test ends up trying to call `xcrun` which has no hope of succeeding on Linux. But perhaps the test is fixable, or it would be better to mark the test itself XFAIL. Either way, I think the GH Action in the PR is definitely an improvement over the status quo.