### PR TITLE
Run cmake install to build package

### DIFF
--- a/zorg/jenkins/jobs/jobs/lldb-cmake-intel
+++ b/zorg/jenkins/jobs/jobs/lldb-cmake-intel
@@ -184,6 +184,8 @@ pipeline {
                        export INSTALL_DIR=lldb-install
 
                        cd -
+                       python3 llvm-zorg/zorg/jenkins/monorepo_build.py lldb-cmake install
+
                        python3 llvm-zorg/zorg/jenkins/monorepo_build.py artifact
                        '''
                    }


### PR DESCRIPTION
We need to install so we can actually create the binary dir which is then converted to the tarball