### PR TITLE
WoA LLVM bots config update to improve build time

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -296,6 +296,7 @@ all = [
                     checkout_flang=True,
                     checkout_lld=True,
                     extra_cmake_args=[
+                        "-DLLVM_TARGETS_TO_BUILD='ARM;AArch64;X86'",
                         "-DCLANG_DEFAULT_LINKER=lld",
                         "-DCMAKE_TRY_COMPILE_CONFIGURATION=Release",
                         "-DCOMPILER_RT_BUILD_SANITIZERS=OFF",
@@ -572,15 +573,21 @@ all = [
     'builddir': "clang-arm64-windows-msvc-2stage",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     vs="manual",
-                    clean=False,
+                    clean=True,
                     useTwoStage=True,
-                    checkout_flang=True,
                     testStage1=False,
                     extra_cmake_args=[
+                        "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DCLANG_DEFAULT_LINKER=lld",
                         "-DCMAKE_TRY_COMPILE_CONFIGURATION=Release",
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
+                        "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"],
+                    extra_stage2_cmake_args=[
+                        "-DLLVM_TARGETS_TO_BUILD='ARM;AArch64;X86'",
+                        "-DLLVM_ENABLE_PROJECTS=flang;mlir",
+                        "-DCLANG_DEFAULT_LINKER=lld",
+                        "-DCMAKE_TRY_COMPILE_CONFIGURATION=Release",
                         "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"])},
 
     {'name' : 'clang-x64-windows-msvc',


### PR DESCRIPTION
Since #252 we have got increased build times on WoA build bots. Also WoA 2 stage bot does not collapse the queue because it is not configured to always do a clean build. This patch tries to fix above issues.

On both single and 2 stage bots:
- Set `LLVM_TARGETS_TO_BUILD` to 'ARM;AArch64;X86'. We only care about these targets on windows.

On 2 stage bot:
- Set stage 1 LLVM_TARGETS_TO_BUILD to AArch64 only.
- Set extra_stage2_cmake_args which overrides extra_cmake_flags.
- Disable flang build on stage1 by setting checkout_flang=False.
- Enabled `LLVM_ENABLE_PROJECTS=flang;mlir` for stage 2.
- Switched to a clean build (`clean=True`) for collapsing queue.
- Like stage 1 set stage 2 CLANG_DEFAULT_LINKER to lld. This makes sure just built lld is used by just built clang as default linker.