### PR TITLE
Add local testing mode to the buildmaster config

### DIFF
--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -4,7 +4,10 @@ from buildbot.plugins import worker
 import config
 
 def create_worker(name, *args, **kwargs):
-    password = config.options.get('Worker Passwords', name)
+    if config.options.getboolean('Internal', 'test_mode'):
+        password = "test"
+    else:
+        password = config.options.get('Worker Passwords', name)
     return worker.Worker(name, password=password, *args, **kwargs)
 
 def get_all():

--- a/buildbot/osuosl/master/master.cfg
+++ b/buildbot/osuosl/master/master.cfg
@@ -26,11 +26,18 @@ c['buildbotNetUsageData'] = None
 import config
 reload(config)
 
+# Detect if the BUILDMASTER_TEST environment variable is set and non-zero.
+# This will be used to enable a local testing mode.
+buildmaster_test = os.environ.get('BUILDMASTER_TEST')
+test_mode = bool(buildmaster_test) and buildmaster_test != '0'
+config.options['Internal'] = {}
+config.options['Internal']['test_mode'] = str(test_mode)
+
 ####### Workers
 
 c['workers'] = config.workers.get_all()
 
-c['protocols'] = {'pb': {'port': 9990}}
+c['protocols'] = {'pb': {'port': "tcp:9990:interface=127.0.0.1" if test_mode else 9990}}
 
 ####### CHANGESOURCES
 
@@ -94,25 +101,29 @@ c['services'] = config.status.getReporters()
 
 ####### PROJECT IDENTITY
 
-c['title'] = config.options.get('Buildbot', 'title')
-c['titleURL'] = config.options.get('Buildbot', 'title_url')
-c['buildbotURL'] = config.options.get('Buildbot', 'my_url')
+c['title'] = "LLVM Buildbot (local testing mode)" if test_mode else config.options.get('Buildbot', 'title')
+c['titleURL'] = "http://localhost:8011" if test_mode else config.options.get('Buildbot', 'title_url')
+c['buildbotURL'] = "http://localhost:8011" if test_mode else config.options.get('Buildbot', 'my_url')
 
 # minimalistic config to activate new web UI
-c['www'] = dict(port=8011,
-                plugins=dict(waterfall_view={}, console_view={}, grid_view={}), # TODO: badges
-                default_page='console',
-                auth=config.auth.getAuth(),
-                authz=config.auth.getAuthz(),
-                #logRotateLength=
-                #maxRotatedFiles=
-                #versions=
+www_config = dict(port="tcp:8011:interface=127.0.0.1" if test_mode else 8011,
+                  plugins=dict(waterfall_view={}, console_view={}, grid_view={}), # TODO: badges
+                  default_page='console',
+                  #logRotateLength=
+                  #maxRotatedFiles=
+                  #versions=
             )
+
+if not test_mode:
+    www_config['auth'] = config.auth.getAuth()
+    www_config['authz'] = config.auth.getAuthz()
+
+c['www'] = www_config
 
 ####### DB URL
 
 c['db'] = {
-    'db_url' : config.options.get('Database', 'db_url'),
+    'db_url' : "sqlite:///state.sqlite" if test_mode else config.options.get('Database', 'db_url'),
 }
 
 ####### RESOURCE USAGE

--- a/buildbot/osuosl/master/master.cfg
+++ b/buildbot/osuosl/master/master.cfg
@@ -101,7 +101,7 @@ c['services'] = config.status.getReporters()
 
 ####### PROJECT IDENTITY
 
-c['title'] = "LLVM Buildbot (local testing mode)" if test_mode else config.options.get('Buildbot', 'title')
+c['title'] = "Buildbot (test)" if test_mode else config.options.get('Buildbot', 'title')
 c['titleURL'] = "http://localhost:8011" if test_mode else config.options.get('Buildbot', 'title_url')
 c['buildbotURL'] = "http://localhost:8011" if test_mode else config.options.get('Buildbot', 'my_url')
 

--- a/buildbot/osuosl/master/master.cfg
+++ b/buildbot/osuosl/master/master.cfg
@@ -102,8 +102,8 @@ c['services'] = config.status.getReporters()
 ####### PROJECT IDENTITY
 
 c['title'] = "Buildbot (test)" if test_mode else config.options.get('Buildbot', 'title')
-c['titleURL'] = "http://localhost:8011" if test_mode else config.options.get('Buildbot', 'title_url')
-c['buildbotURL'] = "http://localhost:8011" if test_mode else config.options.get('Buildbot', 'my_url')
+c['titleURL'] = "http://localhost:8011/" if test_mode else config.options.get('Buildbot', 'title_url')
+c['buildbotURL'] = "http://localhost:8011/" if test_mode else config.options.get('Buildbot', 'my_url')
 
 # minimalistic config to activate new web UI
 www_config = dict(port="tcp:8011:interface=127.0.0.1" if test_mode else 8011,


### PR DESCRIPTION
This makes it (relatively) easy to test a builder setup locally. The buildmaster and the web interface should be bound only to local interfaces for security reasons (you can use ssh port forwarding if wanting to run on a server).

---
This patch ended up fairly small, but it needed quite a lot of fiddling about to get something that works and requires such minimal changes. I assume everyone has their own flows or downstream patches for testing with a local buildmaster, but I want to make it substantially easier for anyone to do this without repeating that effort. With this change, you just need to set the BUILDMASTER_TEST environment variable when starting the buildmaster, and it will bind to local interfaces and default to a "test" password for workers. The web interface is configured with no auth needed in this case.

I believe that any notification generation is disabled by default as `getReporters()` in `buildbot/osuosl/master/config/status.py` returns an empty array unless a config option is_production is explicitly set. It would be helpful if people more familiar with the codebase could also confirm there's no chance this will try to send unwelcome emails.

Open issue:
* The LLVM buildmaster seems to be running off a downstream buildbot fork that isn't publicly available. The issue I have running with buildbot 3.11.7 is the length of some step names overflow the limit (see [upstream issue](https://github.com/buildbot/buildbot/issues/3414)). I hack around this locally by removing the call to check_param_length in `site-packages/buildbot/process/buildstep.py` in my venv (running with an sqlite database, I don't believe the width is enforced anyway).

I intend to pair this with a section on local testing of a build config in <https://llvm.org/docs/HowToAddABuilder.html>, but the basic gist of using this is:
* python -m venv myenv
* source myenv/bin/activate
* pip install buildbot{,-console-view,-grid-view,-waterfall-view,-worker,-www}==3.11.7 urllib3
    * Ideally we'd use requirements.txt, but the inacessible buildbot fork is a barrier
* Hack site-packages/buildbot/process/buildstep.py to remove check for step name length (obviously it would be good to remove this requirement...)
* cd to buildbot/osuosl/master
* BUILDMASTER_TEST=1 buildbot checkconfig
* BUILDMASTER_TEST=1 buildbot upgrade-master . # needed to init the db first time
* BUILDMASTER_TEST=1 buildbot start --nodaemon .
* Confirm you see the web UI at http://localhost:8011
* Then create a buildbot worker (or workers) with the same name as one of the configured workers, password 'test', and set to connect to localhost:9990
* You can either wait until the poller sets off a build, or force one in the web UI.