### PR TITLE
Rename BUILDMASTER_TEST to BUILDBOT_TEST

### DIFF
--- a/buildbot/osuosl/master/master.cfg
+++ b/buildbot/osuosl/master/master.cfg
@@ -26,10 +26,10 @@ c['buildbotNetUsageData'] = None
 import config
 reload(config)
 
-# Detect if the BUILDMASTER_TEST environment variable is set and non-zero.
-# This will be used to enable a local testing mode.
-buildmaster_test = os.environ.get('BUILDMASTER_TEST')
-test_mode = bool(buildmaster_test) and buildmaster_test != '0'
+# Detect if the BUILDBOT_TEST environment variable is set and non-zero. This
+# will be used to enable a local testing mode.
+buildbot_test = os.environ.get('BUILDBOT_TEST')
+test_mode = bool(buildbot_test) and buildbot_test != '0'
 config.options['Internal'] = {}
 config.options['Internal']['test_mode'] = str(test_mode)
 


### PR DESCRIPTION
BUILDBOT_TEST is sufficiently descriptive (after all, 'buildbot' is the package name and the name of the binary invoked to create a buildmaster) and it's possible upstream may later remove the buildmaster terminology <https://github.com/buildbot/buildbot/issues/5382> or alternatively we might move away from it downstream. As such, it seems prudent to use a name that would be unaffected.

----

This came partially from discussion at https://github.com/llvm/llvm-project/pull/115024 - I figure tweaking the name is a lot easier now, before it's fully documented/advertised and part of people's workflows, than later.