### PR TITLE
[GHA] Use pip and venv to install buildbot for lit tests

### DIFF
--- a/.github/workflows/lit-tests.yml
+++ b/.github/workflows/lit-tests.yml
@@ -15,8 +15,12 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y llvm-18-tools buildbot
+        sudo apt-get install -y llvm-18-tools
         sudo ln -s /usr/lib/llvm-18/build/utils/lit/lit.py /usr/bin/lit
         sudo ln -s /usr/bin/FileCheck-18 /usr/bin/FileCheck
+        python3 -m venv venv
+        source venv/bin/activate
+        pip install buildbot==3.11.7
+        echo "PATH=$PATH" >> "$GITHUB_ENV"
     - name: Run lit tests
       run: /usr/lib/llvm-18/build/utils/lit/lit.py -v --xfail jenkins/test_build.py test


### PR DESCRIPTION
Installing a specific version of buildbot is more robust to future changes vs using whatever is packaged for Debian.

---
See here for an example of this working https://github.com/asb/llvm-zorg/actions/runs/11765732176/job/32772399920

I want to move over to this as a precursor to adding `buildbot checkconfig` to this flow, taking advantage of the local testing mode added in #289.

As a sidenote, the `run:` line can be changed to just `lit -v --xfail jenkins/test_build.py test` (as in the setup stage I'd added a symlink to allow this, but forgot to change the run line). I've left that change out of this PR to avoid changing two things at once, and as it's trivial I'd intend to just directly commit.