### PR TITLE
don't poll or include changelog for release branches

### DIFF
--- a/zorg/jenkins/jobs/jobs/lldb-cmake-matrix
+++ b/zorg/jenkins/jobs/jobs/lldb-cmake-matrix
@@ -211,7 +211,10 @@ pipeline {
                         ], extensions: [
                             [$class: 'CloneOption', timeout: 30,
                             timeout: 30]
-                        ]])
+                        ],
+                        changelog: false,
+                        poll: false
+                        ])
                     }
                 }
                 timeout(90) {
@@ -276,7 +279,10 @@ pipeline {
                         ], extensions: [
                             [$class: 'CloneOption', timeout: 30,
                             timeout: 30]
-                        ]])
+                        ],
+                        changelog: false,
+                        poll: false
+                        ])
                     }
                 }
                 timeout(90) {


### PR DESCRIPTION
Don't poll or include changelist for the static tags which are checked out (llvmorg-17.0.6, llvmorg-15.0.1). This should hopefully reduce the changeless to just those on the main branch