### PR TITLE
Revert "Revert "[windows] Increase timeout for sanitizer-windows""

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1694,7 +1694,9 @@ all += [
     'builddir': "sanitizer-windows",
     'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
                     script="sanitizer-windows.py",
-                    depends_on_projects=["llvm", "clang", "lld", "compiler-rt"])},
+                    depends_on_projects=["llvm", "clang", "lld", "compiler-rt"],
+                    # FIXME: Restore `timeout` to default when fixed https://github.com/llvm/llvm-project/issues/102513
+                    timeout=2400)},
 
 # OpenMP builders.
 


### PR DESCRIPTION
Reverts llvm/llvm-zorg#272

For https://github.com/llvm/llvm-project/issues/102513

Timeouts are back, but I didn't profile the build to check if the cause is the same file.
https://lab.llvm.org/buildbot/#/builders/107/builds/4901