### PR TITLE
Add Linaro Graviton 4 workers

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -473,7 +473,8 @@ all = [
     # problems sooner rather than later.
     {'name' : "clang-aarch64-sve-vla",
     'tags'  : ["clang"],
-    'workernames' : ["linaro-g3-01", "linaro-g3-02", "linaro-g3-03", "linaro-g3-04"],
+    'workernames' : ["linaro-g3-01", "linaro-g3-02", "linaro-g3-03", "linaro-g3-04",
+                     "linaro-g4-01", "linaro-g4-02"],
     'builddir': "clang-aarch64-sve-vla",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=False,
@@ -496,7 +497,8 @@ all = [
     # AArch64 Clang+LLVM+RT+LLD check-all + flang + test-suite 2-stage w/SVE-Vector-Length-Agnostic
     {'name' : "clang-aarch64-sve-vla-2stage",
     'tags'  : ["clang"],
-    'workernames' : ["linaro-g3-01", "linaro-g3-02", "linaro-g3-03", "linaro-g3-04"],
+    'workernames' : ["linaro-g3-01", "linaro-g3-02", "linaro-g3-03", "linaro-g3-04",
+                     "linaro-g4-01", "linaro-g4-02"],
     'builddir': "clang-aarch64-sve-vla-2stage",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=True,

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -473,8 +473,7 @@ all = [
     # problems sooner rather than later.
     {'name' : "clang-aarch64-sve-vla",
     'tags'  : ["clang"],
-    'workernames' : ["linaro-g3-01", "linaro-g3-02", "linaro-g3-03", "linaro-g3-04",
-                     "linaro-g4-01", "linaro-g4-02"],
+    'workernames' : ["linaro-g3-01", "linaro-g3-02", "linaro-g3-03", "linaro-g3-04"],
     'builddir': "clang-aarch64-sve-vla",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=False,
@@ -497,8 +496,7 @@ all = [
     # AArch64 Clang+LLVM+RT+LLD check-all + flang + test-suite 2-stage w/SVE-Vector-Length-Agnostic
     {'name' : "clang-aarch64-sve-vla-2stage",
     'tags'  : ["clang"],
-    'workernames' : ["linaro-g3-01", "linaro-g3-02", "linaro-g3-03", "linaro-g3-04",
-                     "linaro-g4-01", "linaro-g4-02"],
+    'workernames' : ["linaro-g3-01", "linaro-g3-02", "linaro-g3-03", "linaro-g3-04"],
     'builddir': "clang-aarch64-sve-vla-2stage",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=True,

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -38,10 +38,14 @@ def get_all():
         create_worker("linaro-flang-aarch64-release", max_builds=1),
         create_worker("linaro-flang-aarch64-rel-assert", max_builds=1),
         create_worker("linaro-flang-aarch64-latest-gcc", max_builds=1),
+        # Graviton 3
         create_worker("linaro-g3-01", max_builds=1),
         create_worker("linaro-g3-02", max_builds=1),
         create_worker("linaro-g3-03", max_builds=1),
         create_worker("linaro-g3-04", max_builds=1),
+        # Graviton 4
+        create_worker("linaro-g4-01", max_builds=1),
+        create_worker("linaro-g4-02", max_builds=1),
 
         # AArch64 Windows Microsoft Surface X Pro
         create_worker("linaro-armv8-windows-msvc-02", max_builds=1),


### PR DESCRIPTION
Aside from the new CPU and different core/RAM amounts, these will be the same as our existing Gravition 3 ("g3") workers.

Builders to use these coming in a separate PR.