### PR TITLE
libc: add additional scudo cmake command line options

### DIFF
--- a/zorg/buildbot/builders/annotated/libc-linux.py
+++ b/zorg/buildbot/builders/annotated/libc-linux.py
@@ -93,6 +93,9 @@ def main(argv):
 
         if fullbuild and not args.asan and not lint_build and not riscv_build:
             cmake_args.append('-DLLVM_LIBC_INCLUDE_SCUDO=ON')
+            cmake_args.append('-DCOMPILER_RT_BUILD_SCUDO_STANDALONE_WITH_LLVM_LIBC=ON')
+            cmake_args.append('-DCOMPILER_RT_BUILD_GWP_ASAN=OFF')
+            cmake_args.append('-DCOMPILER_RT_SCUDO_STANDALONE_BUILD_SHARED=OFF')
             cmake_args.append('-DLIBC_INCLUDE_BENCHMARKS=ON')
 
         if fullbuild:


### PR DESCRIPTION
I just rekicked the cmake cache on the buildbots, which are now failing the
libc-scudo-integration-test ninja target with linker errors regarding undefined
reference to gwp_asan related symbols.
