### PR TITLE
Add AArch64 SVE2 Vector Length Agnostic builders

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -464,6 +464,9 @@ all = [
                         "-DMLIR_RUN_ARM_SME_TESTS=True",
                         "-DARM_EMULATOR_EXECUTABLE=qemu-aarch64"])},
 
+    # All SVE (as opposed to SVE2) builders are using optimisation flags
+    # for Graviton 3 "balanced" from
+    # https://github.com/aws/aws-graviton-getting-started/blob/main/c-c++.md.
 
     # AArch64 Clang+LLVM+RT+LLD check-all + flang + test-suite +
     # mlir-integration-tests w/SVE-Vector-Length-Agnostic Note that in this and
@@ -566,7 +569,10 @@ all = [
                         "-DMLIR_RUN_ARM_SVE_TESTS=True",
                         "-DLLVM_LIT_ARGS='-v'"])},
 
-    # Note that this is SVE2 as opposed to SVE.
+    # All SVE2 builders are using optimisation flags for Graviton 4 "performance" from
+    # https://github.com/aws/aws-graviton-getting-started/blob/main/c-c++.md
+    # (using balanced would not enable the SVE2 extension).
+
     {'name' : "clang-aarch64-sve2-vla",
     'tags'  : ["clang"],
     'workernames' : ["linaro-g4-01", "linaro-g4-02"],

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -566,6 +566,53 @@ all = [
                         "-DMLIR_RUN_ARM_SVE_TESTS=True",
                         "-DLLVM_LIT_ARGS='-v'"])},
 
+    # Note that this is SVE2 as opposed to SVE.
+    {'name' : "clang-aarch64-sve2-vla",
+    'tags'  : ["clang"],
+    'workernames' : ["linaro-g4-01", "linaro-g4-02"],
+    'builddir': "clang-aarch64-sve2-vla",
+    'factory' : ClangBuilder.getClangCMakeBuildFactory(
+                    clean=False,
+                    checkout_flang=True,
+                    runTestSuite=True,
+                    env={
+                        'NO_STOP_MESSAGE':'1', # For Fortran test-suite
+                    },
+                    testsuite_flags=[
+                        '--cppflags', '-mcpu=neoverse-v2 -mllvm -scalable-vectorization=preferred -mllvm -treat-scalable-fixed-error-as-warning=false -O3',
+                        '--threads=48', '--build-threads=48'],
+                    extra_cmake_args=[
+                        "-DCMAKE_C_FLAGS='-mcpu=neoverse-v2'",
+                        "-DCMAKE_CXX_FLAGS='-mcpu=neoverse-v2'",
+                        "-DLLVM_ENABLE_LLD=True",
+                        "-DMLIR_INCLUDE_INTEGRATION_TESTS=True",
+                        "-DMLIR_RUN_ARM_SVE_TESTS=True"])},
+
+    # AArch64 Clang+LLVM+RT+LLD check-all + flang + test-suite 2-stage with SVE2
+    # (not just SVE) Vector Length Agnostic codegen.
+    {'name' : "clang-aarch64-sve2-vla-2stage",
+    'tags'  : ["clang"],
+    'workernames' : ["linaro-g4-01", "linaro-g4-02"],
+    'builddir': "clang-aarch64-sve2-vla-2stage",
+    'factory' : ClangBuilder.getClangCMakeBuildFactory(
+                    clean=True,
+                    checkout_flang=True,
+                    useTwoStage=True,
+                    testStage1=False,
+                    runTestSuite=True,
+                    env={
+                        'NO_STOP_MESSAGE':'1', # For Fortran test-suite
+                    },
+                    testsuite_flags=[
+                        '--cppflags', '-mcpu=neoverse-v2 -mllvm -scalable-vectorization=preferred -mllvm -treat-scalable-fixed-error-as-warning=false -O3',
+                        '--threads=48', '--build-threads=48'],
+                    extra_cmake_args=[
+                        "-DCMAKE_C_FLAGS='-mcpu=neoverse-v2 -mllvm -scalable-vectorization=preferred -mllvm -treat-scalable-fixed-error-as-warning=false'",
+                        "-DCMAKE_CXX_FLAGS='-mcpu=neoverse-v2 -mllvm -scalable-vectorization=preferred -mllvm -treat-scalable-fixed-error-as-warning=false'",
+                        "-DLLVM_ENABLE_LLD=True",
+                        "-DMLIR_INCLUDE_INTEGRATION_TESTS=True",
+                        "-DMLIR_RUN_ARM_SVE_TESTS=True"])},
+
     {'name' : "clang-arm64-windows-msvc-2stage",
     'tags'  : ["clang"],
     'workernames' : ["linaro-armv8-windows-msvc-02"],


### PR DESCRIPTION
These generate code that uses the SVE2 extension, as opposed to our existing builders that only use SVE. Therefore they will run on our Graviton 4 workers only, which are Neoverse v2 cores with SVE and SVE2.

The optimisation guide:
https://github.com/aws/aws-graviton-getting-started/blob/main/c-c++.md

Suggests -mcpu=neoverse-v2 for best performance, but here I'm using it just so we get the SVE2 feature enabled. If we used the balanced -mcpu=neoverse-512tvb, we wouldn't get SVE2 without fiddly extra flags.

```
$ ~/clang+llvm-18.1.8-aarch64-linux-gnu/bin/clang /tmp/test.c -o /dev/null -mcpu=neoverse-v2 -###
<...> "-target-feature" "+sve" "-target-feature" "+sve2-bitperm" "-target-feature" "+sve2" <...>
```

I have not added vector length settings as these builders will generate scalable ("length agnostic" - LA) code.

Otherwise, the builders have identical setups to the existing SVE VLA builders.