### PR TITLE
Revert "libc: disable scudo integration tests for now"

### DIFF
--- a/zorg/buildbot/builders/annotated/libc-linux.py
+++ b/zorg/buildbot/builders/annotated/libc-linux.py
@@ -143,9 +143,8 @@ def main(argv):
             return
         with step('libc-integration-tests'):
             run_command(['ninja', 'libc-integration-tests'])
-        # TODO: https://github.com/llvm/llvm-project/issues/116895
-        # with step('libc-scudo-integration-test'):
-        #     run_command(['ninja', 'libc-scudo-integration-test'])
+        with step('libc-scudo-integration-test'):
+            run_command(['ninja', 'libc-scudo-integration-test'])
         with step('Benchmark Utils Tests'):
             run_command(['ninja', 'libc-benchmark-util-tests'])
 


### PR DESCRIPTION
Reverts llvm/llvm-zorg#315 since the issue should have been addressed.