### PR TITLE
Remove explicit LLVM_LIT_ARGS='-v' from Linaro builders

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -398,8 +398,7 @@ all = [
                 extra_cmake_args=[
                     "-DCMAKE_C_FLAGS='-mcpu=cortex-a57'",
                     "-DCMAKE_CXX_FLAGS='-mcpu=cortex-a57'",
-                    "-DLLVM_ENABLE_LLD=True",
-                    "-DLLVM_LIT_ARGS='-v'"])},
+                    "-DLLVM_ENABLE_LLD=True"])},
 
     ## AArch64 run test-suite at -O0 (GlobalISel is now default).
     {'name' : "clang-aarch64-global-isel",
@@ -490,8 +489,7 @@ all = [
                         "-DCMAKE_CXX_FLAGS='-mcpu=neoverse-512tvb'",
                         "-DLLVM_ENABLE_LLD=True",
                         "-DMLIR_INCLUDE_INTEGRATION_TESTS=True",
-                        "-DMLIR_RUN_ARM_SVE_TESTS=True",
-                        "-DLLVM_LIT_ARGS='-v'"])},
+                        "-DMLIR_RUN_ARM_SVE_TESTS=True"])},
 
     # AArch64 Clang+LLVM+RT+LLD check-all + flang + test-suite 2-stage w/SVE-Vector-Length-Agnostic
     {'name' : "clang-aarch64-sve-vla-2stage",
@@ -515,8 +513,7 @@ all = [
                         "-DCMAKE_CXX_FLAGS='-mcpu=neoverse-512tvb -mllvm -scalable-vectorization=preferred -mllvm -treat-scalable-fixed-error-as-warning=false'",
                         "-DLLVM_ENABLE_LLD=True",
                         "-DMLIR_INCLUDE_INTEGRATION_TESTS=True",
-                        "-DMLIR_RUN_ARM_SVE_TESTS=True",
-                        "-DLLVM_LIT_ARGS='-v'"])},
+                        "-DMLIR_RUN_ARM_SVE_TESTS=True"])},
 
     # AArch64 Clang+LLVM+RT+LLD check-all + flang + test-suite w/SVE-Vector-Length-Specific
     {'name' : "clang-aarch64-sve-vls",
@@ -538,8 +535,7 @@ all = [
                         "-DCMAKE_CXX_FLAGS='-mcpu=neoverse-512tvb'",
                         "-DLLVM_ENABLE_LLD=True",
                         "-DMLIR_INCLUDE_INTEGRATION_TESTS=True",
-                        "-DMLIR_RUN_ARM_SVE_TESTS=True",
-                        "-DLLVM_LIT_ARGS='-v'"])},
+                        "-DMLIR_RUN_ARM_SVE_TESTS=True"])},
 
     # AArch64 Clang+LLVM+RT+LLD check-all + flang + test-suite 2-stage w/SVE-Vector-Length-Specific
     {'name' : "clang-aarch64-sve-vls-2stage",
@@ -563,8 +559,7 @@ all = [
                         "-DCMAKE_CXX_FLAGS='-mcpu=neoverse-512tvb -msve-vector-bits=256 -mllvm -treat-scalable-fixed-error-as-warning=false'",
                         "-DLLVM_ENABLE_LLD=True",
                         "-DMLIR_INCLUDE_INTEGRATION_TESTS=True",
-                        "-DMLIR_RUN_ARM_SVE_TESTS=True",
-                        "-DLLVM_LIT_ARGS='-v'"])},
+                        "-DMLIR_RUN_ARM_SVE_TESTS=True"])},
 
     {'name' : "clang-arm64-windows-msvc-2stage",
     'tags'  : ["clang"],
@@ -1296,7 +1291,6 @@ all = [
                     clean=True,
                     extra_cmake_args=[
                         '-DLLVM_ENABLE_ASSERTIONS=True',
-                        '-DLLVM_LIT_ARGS=-v',
                         '-DLLVM_USE_LINKER=lld',
                         '-DLLDB_ENFORCE_STRICT_TEST_REQUIREMENTS=ON'])},
 
@@ -1324,7 +1318,6 @@ all = [
                     extra_cmake_args=[
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
-                        '-DLLVM_LIT_ARGS=-v',
                         # Hardware breakpoints and watchpoints are not yet supported,
                         # https://github.com/llvm/llvm-project/issues/80665.
                         '-DLLDB_TEST_USER_ARGS=--skip-category=watchpoint',


### PR DESCRIPTION
As this is added by the build factories anyway.

Arm lldb has a thread limit so I've kept that in.

(this because the machine it runs on actually has a lot of headroom, but not all the time, so assuming you can always use every thread makes the results flaky)