### PR TITLE
Fix local testing mode by skipping downstream-only config setting

### DIFF
--- a/buildbot/osuosl/master/master.cfg
+++ b/buildbot/osuosl/master/master.cfg
@@ -39,7 +39,8 @@ c['workers'] = config.workers.get_all()
 
 c['protocols'] = {'pb': {'port': "tcp:9990:interface=127.0.0.1" if test_mode else 9990}}
 
-c['ignoreOfflineWorkersTimeout'] = 30 # minutes.
+if not test_mode: # Config key only supported on downstream buildbot fork.
+  c['ignoreOfflineWorkersTimeout'] = 30 # minutes.
 
 ####### CHANGESOURCES
 


### PR DESCRIPTION
Ideally we'd better replicate the the deployed config, but this hopefully moves things forward. Note: as the GitHub Actions pre-commit testing relies on "local testing mode", this PR fixes that too.

@gkistanova the requirements.txt just references a local checkout for the buildbot version being used - the other libs are all 3.11.7 so that's what I use for the GitHub actions and the guidance for "local testing mode". Is there a public repo of the buildbot fork that is deployed?