### PR TITLE
Revert "Do not create build requests for workers if offline longer than 30 minutes."

### DIFF
--- a/buildbot/osuosl/master/master.cfg
+++ b/buildbot/osuosl/master/master.cfg
@@ -39,8 +39,6 @@ c['workers'] = config.workers.get_all()
 
 c['protocols'] = {'pb': {'port': "tcp:9990:interface=127.0.0.1" if test_mode else 9990}}
 
-c['ignoreOfflineWorkersTimeout'] = 30 # minutes.
-
 ####### CHANGESOURCES
 
 ##from buildbot.changes.pb import PBChangeSource


### PR DESCRIPTION
This reverts commit 618344c61e1cd4aecfa714e65c844b734677506a.

Otherwise we observe the failure in presubmit:
   $ cd buildbot/osuosl/master && BUILDBOT_TEST=1 buildbot checkconfig
   Configuration Errors:
   Unknown BuildmasterConfig key ignoreOfflineWorkersTimeout

FWICT, ignoreOfflineWorkersTimeout is not documented anywhere.
