### PR TITLE
Revert "Do not create build requests for workers if offline longer than 30 minutes."

### DIFF
--- a/buildbot/osuosl/master/master.cfg
+++ b/buildbot/osuosl/master/master.cfg
@@ -39,9 +39,6 @@ c['workers'] = config.workers.get_all()
 
 c['protocols'] = {'pb': {'port': "tcp:9990:interface=127.0.0.1" if test_mode else 9990}}
 
-if not test_mode: # Config key only supported on downstream buildbot fork.
-  c['ignoreOfflineWorkersTimeout'] = 30 # minutes.
-
 ####### CHANGESOURCES
 
 ##from buildbot.changes.pb import PBChangeSource


### PR DESCRIPTION
This reverts commit 618344c61e1cd4aecfa714e65c844b734677506a and fab27e270d1a3754c98175d780bc4793e13fefc5.

Otherwise we observe the failure in presubmit:
   $ cd buildbot/osuosl/master && BUILDBOT_TEST=1 buildbot checkconfig
   Configuration Errors:
   Unknown BuildmasterConfig key ignoreOfflineWorkersTimeout

FWICT, ignoreOfflineWorkersTimeout is not documented anywhere. It has been implied that LLVM's buildbot has downstream patches. I could not find where these were published, and the issue is now blocking me from further updates to CI. Rip everything out for now.

>> LLVM's buildbot seems to be deploying a forked version

Link: https://github.com/llvm/llvm-zorg/commit/618344c61e1cd4aecfa714e65c844b734677506a