### PR TITLE
libc: remove libc-api-test

### DIFF
--- a/zorg/buildbot/builders/annotated/libc-linux.py
+++ b/zorg/buildbot/builders/annotated/libc-linux.py
@@ -135,8 +135,6 @@ def main(argv):
             run_command(['ninja', 'libc-unit-tests'])
 
     if fullbuild and not args.asan:
-        with step('libc-api-test'):
-            run_command(['ninja', 'libc-api-test'])
         if gcc_build or ('riscv' in builder_name):
             # The rest of the targets are either not yet gcc-clean or
             # not yet availabe on riscv.


### PR DESCRIPTION
This was removed with the removal of "old" hdrgen in
https://github.com/llvm/llvm-project/pull/117220.
