### PR TITLE
libc: make new bootstrap builder a dup of runtimes

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2237,10 +2237,10 @@ all += [
                     depends_on_projects=['llvm', 'libc', 'clang', 'clang-tools-extra'],
                     extra_args=['--debug', '--asan'])},
 
-    {'name' : "libc-x86_64-debian-dbg-runtimes-build",
+    {'name' : "libc-x86_64-debian-dbg-bootstrap-build",
     'tags'  : ["libc"],
     'workernames' : ["libc-x86_64-debian"],
-    'builddir': "libc-x86_64-debian-dbg-runtimes-build",
+    'builddir': "libc-x86_64-debian-dbg-bootstrap-build",
     'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
                     script="libc-linux.py",
                     depends_on_projects=['llvm', 'libc', 'clang', 'clang-tools-extra'],

--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -285,20 +285,21 @@ def getReporters():
             generators = [
                 utils.LLVMDefaultBuildStatusGenerator(
                     builders = [
-                        "libc-x86_64-debian",
-                        "libc-x86_64_debian-dbg",
-                        "libc-x86_64-debian-dbg-bootstrap-build",
-                        "libc-x86_64-debian-dbg-asan",
                         "libc-aarch64-ubuntu-dbg",
-                        "libc-x86_64-windows-dbg",
-                        "libc-arm32-debian-dbg",
                         "libc-aarch64-ubuntu-fullbuild-dbg",
-                        "libc-x86_64-debian-fullbuild-dbg",
-                        "libc-x86_64-debian-gcc-fullbuild-dbg",
-                        "libc-x86_64-debian-fullbuild-dbg-asan",
+                        "libc-arm32-debian-dbg",
                         "libc-riscv64-debian-dbg",
                         "libc-riscv64-debian-fullbuild-dbg",
-                        "libc-x86_64-debian-dbg-lint"])
+                        "libc-x86_64-debian",
+                        "libc-x86_64-debian-dbg-asan",
+                        "libc-x86_64-debian-dbg-bootstrap-build",
+                        "libc-x86_64-debian-dbg-lint",
+                        "libc-x86_64-debian-fullbuild-dbg",
+                        "libc-x86_64-debian-fullbuild-dbg-asan",
+                        "libc-x86_64-debian-gcc-fullbuild-dbg",
+                        "libc-x86_64-windows-dbg",
+                        "libc-x86_64_debian-dbg",
+                    ])
             ]),
         reporters.MailNotifier(
             dumpMailsToLog = True, # TODO: For debug purposes only. Remove this later.

--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -287,7 +287,7 @@ def getReporters():
                     builders = [
                         "libc-x86_64-debian",
                         "libc-x86_64_debian-dbg",
-                        "libc-x86_64-debian-dbg-runtimes-build",
+                        "libc-x86_64-debian-dbg-bootstrap-build",
                         "libc-x86_64-debian-dbg-asan",
                         "libc-aarch64-ubuntu-dbg",
                         "libc-x86_64-windows-dbg",


### PR DESCRIPTION
Before renaming the existing debian-dbg-runtimes-build to
debian-dbg-bootstrap-build, make sure that the new name will be recognized so
that there's no downtime of CI coverage due to renaming the buildbot.

Also remove llvm from the explicit project list; that's not necessary (or may have
been for old hdrgen which has been removed).

Link: https://github.com/llvm/llvm-zorg/pull/325#discussion_r1870167521
