### PR TITLE
Add builder and worker for AIX ppc64 flang bot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2505,6 +2505,34 @@ all += [
                         '-DLLVM_PARALLEL_COMPILE_JOBS=4',
                     ])},
 
+    {'name' : 'ppc64-flang-aix',
+    'tags'  : ["flang", "ppc", "ppc64", "aix"],
+    'collapseRequests' : False,
+    'workernames' : ['ppc64-flang-aix-test'],
+    'builddir': 'ppc64-flang-aix-build',
+    'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                    clean=False,
+                    depends_on_projects=['llvm', 'mlir', 'clang', 'flang', 'compiler-rt'],
+                    checks=['check-flang'],
+                    extra_configure_args=[
+                        '-DLLVM_DEFAULT_TARGET_TRIPLE=powerpc64-ibm-aix',
+                        '-DLLVM_INSTALL_UTILS=ON',
+                        '-DCMAKE_CXX_STANDARD=17',
+                        '-DLLVM_LIT_ARGS=--threads=20 -v --time-tests',
+                        '-DFLANG_ENABLE_WERROR=ON',
+                        '-DLLVM_ENABLE_ASSERTIONS=ON',
+                        "-DPython3_EXECUTABLE:FILEPATH=python3",
+                        "-DLLVM_ENABLE_ZLIB=OFF", "-DLLVM_APPEND_VC_REV=OFF",
+                        "-DLLVM_PARALLEL_LINK_JOBS=2",
+
+                    ],
+                    env={
+                        'CC': 'clang',
+                        'CXX': 'clang++',
+                        'LD': 'lld',
+                        'OBJECT_MODE': '64'
+                    })},
+
 # Builders responsible building Sphinx documentation.
 
     {'name' : "lld-sphinx-docs",

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -116,6 +116,7 @@ def get_all():
 
         # POWER 8 PowerPC AIX 7.2
         create_worker("aix-ppc64", properties={'jobs': 10}, max_builds=1),
+	create_worker("ppc64-flang-aix-test", properties={'jobs': 10}, max_builds=1),
 
         # IBM z13 (s390x), Ubuntu 16.04.2
         create_worker("systemz-1", properties={'jobs': 4, 'vcs_protocol': 'https'}, max_builds=4),

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -116,7 +116,7 @@ def get_all():
 
         # POWER 8 PowerPC AIX 7.2
         create_worker("aix-ppc64", properties={'jobs': 10}, max_builds=1),
-	create_worker("ppc64-flang-aix-test", properties={'jobs': 10}, max_builds=1),
+        create_worker("ppc64-flang-aix-test", properties={'jobs': 10}, max_builds=1),
 
         # IBM z13 (s390x), Ubuntu 16.04.2
         create_worker("systemz-1", properties={'jobs': 4, 'vcs_protocol': 'https'}, max_builds=4),


### PR DESCRIPTION
This patch is for a new builder for flang on powerpc64 AIX. This configuration has been tested on an internal buildbot master. I will follow up with @gkistanova via email to get the password exchange process started.