### PR TITLE
Extend avx512 win job with Intel oneAPI

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -910,6 +910,8 @@ all = [
                     extra_cmake_args=[
                         "-DCMAKE_C_FLAGS='-march=cascadelake'",
                         "-DCMAKE_CXX_FLAGS='-march=cascadelake'",
+                        "-DCMAKE_C_COMPILER='icx.EXE'",
+                        "-DMAKE_CXX_COMPILER='icx.EXE'",
                         "-DLLVM_ENABLE_RUNTIMES=compiler-rt",
                         "-DCOMPILER_RT_BUILD_SANITIZERS=OFF",
                         "-DCOMPILER_RT_BUILD_ORC=OFF",

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -910,8 +910,8 @@ all = [
                     extra_cmake_args=[
                         "-DCMAKE_C_FLAGS='-march=cascadelake'",
                         "-DCMAKE_CXX_FLAGS='-march=cascadelake'",
-                        "-DCMAKE_C_COMPILER='icx.EXE'",
-                        "-DMAKE_CXX_COMPILER='icx.EXE'",
+                        "-DCMAKE_C_COMPILER=icx.EXE",
+                        "-DMAKE_CXX_COMPILER=icx.EXE",
                         "-DLLVM_ENABLE_RUNTIMES=compiler-rt",
                         "-DCOMPILER_RT_BUILD_SANITIZERS=OFF",
                         "-DCOMPILER_RT_BUILD_ORC=OFF",


### PR DESCRIPTION
The reason for the change is to mitigate the failure during compiling when using Intel oneAPI product. 
The check from buildbot will prevent the commit to be merged if the job failed.