### PR TITLE
[Offload] Adds buildbot for CMake cache file

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1932,35 +1932,15 @@ all += [
                         add_openmp_lit_args=["--time-tests", "--timeout 100"],
                         )},
 
-    {'name' : "offload-runtime-openmp-amdgpu",
+    {'name' : "amdgpu-offload-ubuntu-22-cmake-build-only",
     'tags'  : ["openmp"],
     'workernames' : ["rocm-worker-hw-03"],
-    'builddir': "offload-runtime-openmp-amdgpu",
-    'factory' : OpenMPBuilder.getOpenMPCMakeBuildFactory(
-                        clean=True,
-                        enable_runtimes=['openmp', 'offload'],
-                        depends_on_projects=['llvm', 'clang', 'flang', 'lld', 'offload', 'openmp'],
-                        extraCmakeArgs=[
-                            "-DCMAKE_BUILD_TYPE=Release",
-                            "-DCLANG_DEFAULT_LINKER=lld",
-                            "-DLLVM_TARGETS_TO_BUILD=X86;AMDGPU",
-                            "-DLLVM_ENABLE_ASSERTIONS=ON",
-                            "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
-                            "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
-                            ],
-                        env={
-                            'HSA_ENABLE_SDMA':'0',
-                            },
-                        install=True,
-                        testsuite=False,
-                        testsuite_sollvevv=False,
-                        extraTestsuiteCmakeArgs=[
-                            "-DTEST_SUITE_SOLLVEVV_OFFLOADING_CFLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
-                            "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
-                        ],
-                        add_lit_checks=["check-clang", "check-flang", "check-offload"],
-                        add_openmp_lit_args=["--time-tests", "--timeout 100"],
-                    )},
+    'builddir': "bbot-build",
+    'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
+                    script="amdgpu-offload-cmake.py",
+                    checkout_llvm_sources=True,
+                    script_interpreter=None
+                )},
 
     {'name' : "openmp-offload-libc-amdgpu-runtime",
     'tags'  : ["openmp"],

--- a/zorg/buildbot/builders/annotated/amdgpu-offload-cmake.py
+++ b/zorg/buildbot/builders/annotated/amdgpu-offload-cmake.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python
+
+import argparse
+import os
+import subprocess
+import sys
+import traceback
+import util
+from contextlib import contextmanager
+
+
+def main(argv):
+    source_dir = os.path.join("..", "llvm-project")
+    offload_base_dir = os.path.join(source_dir, "offload")
+    of_cmake_cache_base_dir = os.path.join(offload_base_dir, "cmake/caches")
+
+    with step("cmake", halt_on_fail=True):
+        # TODO make the name of the cache file an argument to the script.
+        cmake_cache_file = os.path.join(of_cmake_cache_base_dir, "AMDGPUBot.cmake")
+
+        # Use Ninja as the generator.
+        # The other important settings alrady come from the CMake CMake
+        # cache file inside LLVM
+        cmake_args = ["-GNinja", "-C %s" % cmake_cache_file]
+
+        run_command(["cmake", os.path.join(source_dir, "llvm")] + cmake_args)
+
+    with step("build cmake config"):
+        run_command(["ninja"])
+
+
+@contextmanager
+def step(step_name, halt_on_fail=False):
+    util.report("@@@BUILD_STEP {}@@@".format(step_name))
+    if halt_on_fail:
+        util.report("@@@HALT_ON_FAILURE@@@")
+    try:
+        yield
+    except Exception as e:
+        if isinstance(e, subprocess.CalledProcessError):
+            util.report("{} exited with return code {}.".format(e.cmd, e.returncode))
+        util.report("The build step threw an exception...")
+        traceback.print_exc()
+
+        util.report("@@@STEP_FAILURE@@@")
+    finally:
+        sys.stdout.flush()
+
+
+def run_command(cmd, directory="."):
+    util.report_run_cmd(cmd, cwd=directory)
+
+
+if __name__ == "__main__":
+    sys.path.append(os.path.dirname(__file__))
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
The buildbot uses the `offload/cmake/cache/AMDGPUBot.cmake` file to create the build config. It uses an annotated builder for that and only performs the build step as most of the post-commit issues are build problems and not test errors.

A lot of inspiration was taken from the `libc` annotated builder script in the zorg repository.