### PR TITLE
[AMDGPU][libc] Re-enable batching to keep up

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1965,7 +1965,8 @@ all += [
     {'name' : "openmp-offload-libc-amdgpu-runtime",
     'tags'  : ["openmp"],
     'workernames' : ["omp-vega20-1"],
-    'collapseRequests' : False,
+     # We would like to never collapse, but it seems the load is too high on that system to keep up.
+    'collapseRequests' : True,
     'builddir': "openmp-offload-libc-amdgpu-runtime",
     'factory' : OpenMPBuilder.getOpenMPCMakeBuildFactory(
                         clean=True,


### PR DESCRIPTION
The current config is unable to keep up with the load on that particular bot, meaning that the build queue filled-up and was at several hours. This reverts the introduced "neverCollapse" and does allow collapsing of build requests.