### PR TITLE
Change linker from lld to gold for builder.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1085,7 +1085,7 @@ all = [
                         "-DLLVM_ENABLE_ASSERTIONS=OFF",
                         "-DLLVM_INCLUDE_EXAMPLES=OFF",
                         "-DLLVM_LIT_ARGS=--verbose",
-                        "-DLLVM_USE_LINKER=lld"])},
+                        "-DLLVM_USE_LINKER=gold"])},
 
 # Polly builders.
 


### PR DESCRIPTION
When I originally adder this builder, I'm not sure why I changed the linker to be lld, it should be gold to match our previous instance. This change fixes that.