### PR TITLE
Disable the test category `lldb-server` for lldb-remote-* builders

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3446,7 +3446,8 @@ all += [
                         "LLDB_CAN_USE_LLDB_SERVER"      : "OFF",
                         "LLDB_TEST_USER_ARGS"           : util.Interpolate(
                                                             "--env;ARCH_CFLAGS=-mcpu=cortex-a78;" \
-                                                            "--platform-name;remote-linux"),
+                                                            "--platform-name;remote-linux;" \
+                                                            "--skip-category=lldb-server"),
                     },
                     cmake_options = [
                         "-C", util.Interpolate("%(prop:srcdir_relative)s/clang/cmake/caches/CrossWinToARMLinux.cmake"),
@@ -3573,7 +3574,8 @@ all += [
                         "LLDB_CAN_USE_LLDB_SERVER"      : "OFF",
                         "LLDB_TEST_USER_ARGS"           : util.Interpolate(
                                                             "--env;ARCH_CFLAGS=-mcpu=cortex-a78;" \
-                                                            "--platform-name;remote-linux"),
+                                                            "--platform-name;remote-linux;" \
+                                                            "--skip-category=lldb-server"),
                     },
                     cmake_options = [
                         "-C", util.Interpolate("%(prop:srcdir_relative)s/clang/cmake/caches/CrossWinToARMLinux.cmake"),


### PR DESCRIPTION
API tests llvm-project/lldb/test/API/tools/lldb-server/* with the category `lldb-server` run lldb-server locally on the host with a random port. Sometimes we got errors like
https://lab.llvm.org/buildbot/#/builders/195/builds/3145
https://lab.llvm.org/buildbot/#/builders/197/builds/312
The patch https://github.com/llvm/llvm-project/pull/118222 improved the situation but did not fix it completely.