### PR TITLE
Compile for Neoverse N1 on Linaro's Armv8 bots that are on Mt Jade hardware

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -393,11 +393,11 @@ all = [
                 useTwoStage=True,
                 runTestSuite=True,
                 testsuite_flags=[
-                    '--cppflags', '-mcpu=cortex-a57 -fuse-ld=lld',
+                    '--cppflags', '-mcpu=neoverse-n1 -fuse-ld=lld',
                     '--threads=32', '--build-threads=32'],
                 extra_cmake_args=[
-                    "-DCMAKE_C_FLAGS='-mcpu=cortex-a57'",
-                    "-DCMAKE_CXX_FLAGS='-mcpu=cortex-a57'",
+                    "-DCMAKE_C_FLAGS='-mcpu=neoverse-n1'",
+                    "-DCMAKE_CXX_FLAGS='-mcpu=neoverse-n1'",
                     "-DLLVM_ENABLE_LLD=True"])},
 
     ## AArch64 run test-suite at -O0 (GlobalISel is now default).
@@ -452,11 +452,11 @@ all = [
                         'NO_STOP_MESSAGE':'1', # For Fortran test-suite
                     },
                     testsuite_flags=[
-                        '--cppflags', '-mcpu=cortex-a57',
+                        '--cppflags', '-mcpu=neoverse-n1',
                         '--threads=32', '--build-threads=32'],
                     extra_cmake_args=[
-                        "-DCMAKE_C_FLAGS='-mcpu=cortex-a57'",
-                        "-DCMAKE_CXX_FLAGS='-mcpu=cortex-a57'",
+                        "-DCMAKE_C_FLAGS='-mcpu=neoverse-n1'",
+                        "-DCMAKE_CXX_FLAGS='-mcpu=neoverse-n1'",
                         "-DLLVM_LIT_ARGS='-v'",
                         "-DMLIR_INCLUDE_INTEGRATION_TESTS=True",
                         "-DMLIR_RUN_ARM_SVE_TESTS=True",

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -425,11 +425,11 @@ all = [
                     useTwoStage=True,
                     runTestSuite=True,
                     testsuite_flags=[
-                        '--cppflags', '-mcpu=cortex-a57 -fuse-ld=lld',
+                        '--cppflags', '-mcpu=neoverse-n1 -fuse-ld=lld',
                         '--threads=32', '--build-threads=32'],
                     extra_cmake_args=[
-                        "-DCMAKE_C_FLAGS='-mcpu=cortex-a57'",
-                        "-DCMAKE_CXX_FLAGS='-mcpu=cortex-a57'",
+                        "-DCMAKE_C_FLAGS='-mcpu=neoverse-n1'",
+                        "-DCMAKE_CXX_FLAGS='-mcpu=neoverse-n1'",
                         "-DCOMPILER_RT_BUILD_SANITIZERS=OFF",
                         "-DLLVM_ENABLE_LLD=True",
                         # lld tests cause us to hit thread limits


### PR DESCRIPTION
This reflects the host hardware, rather than the limited subset of features on the Cortex-A57.

```
$ lscpu
Architecture:            aarch64
  CPU op-mode(s):        32-bit, 64-bit
<...>
Vendor ID:               ARM
  Model name:            Neoverse-N1
<...>
    Flags:               fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid
                         asimdrdm lrcpc dcpop asimddp
```

I have also confirmed that the Neoverse V1 (Note: V not N) that is used for Graviton is a superset of these features.

https://github.com/aws/aws-graviton-getting-started/blob/main/c-c%2B%2B.md#enabling-arm-architecture-specific-features

So if we have to move these builds to Graviton 3 at short notice, this will still work (Graviton 4 also ok for AArch64, but it drops the AArch32 mode).