### PR TITLE
Set timeout to 12 hours for clang-stage2-cmake-RgSan

### DIFF
--- a/zorg/jenkins/jobs/jobs/clang-stage2-cmake-RgSan
+++ b/zorg/jenkins/jobs/jobs/clang-stage2-cmake-RgSan
@@ -1,6 +1,8 @@
 pipeline {
     options {
         disableConcurrentBuilds()
+
+        timeout(time: 24, unit: 'HOURS')
     }
 
     parameters {


### PR DESCRIPTION
This will keep the job from hanging if it encounters any spurious infrastructure issues