### PR TITLE
Collapse requests for the flang AIX buildbot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2538,7 +2538,6 @@ all += [
 
     {'name' : 'ppc64-flang-aix',
     'tags'  : ["flang", "ppc", "ppc64", "aix"],
-    'collapseRequests' : False,
     'workernames' : ['ppc64-flang-aix-test'],
     'builddir': 'ppc64-flang-aix-build',
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(


### PR DESCRIPTION
allow collapseRequests for flang AIX bot: https://lab.llvm.org/buildbot/#/builders/201, due to a long build queue. Most aix bots already allow collapseRequests so this would be consistent with existing behaviour.