### PR TITLE
[CI] Add shebang to shim wrapper scripts

### DIFF
--- a/tasks/cmake/caches/util/xcode_sdk.cmake
+++ b/tasks/cmake/caches/util/xcode_sdk.cmake
@@ -27,7 +27,8 @@ if (CMAKE_C_COMPILER)
 
   macro(create_shim VARIABLE TOOLNAME)
     xcrun_find(SDK_TOOL_BIN ${TOOLNAME})
-    file(WRITE ${CMAKE_BINARY_DIR}/${TOOLNAME} "
+    file(WRITE ${CMAKE_BINARY_DIR}/${TOOLNAME} "#!/usr/bin/env bash
+
 # Shim to have the tool use the correct libLTO.dylib
 DYLD_LIBRARY_PATH=\"${COMPILER_DIR}/../lib:$DYLD_LIBRARY_PATH\" ${SDK_TOOL_BIN} \"$@\"
     ")


### PR DESCRIPTION
After the update of the Cmake binary on our CI fleet, the way Cmake handles internal processes has changed and we need to explicitly set the shebang on our wrapper shims to avoid 
```
    Error running link command: Unknown system error -8
```