### PR TITLE
[LNT] Remove brew cmake check

### DIFF
--- a/tasks/lnt-testsuite.dep
+++ b/tasks/lnt-testsuite.dep
@@ -1,2 +1,1 @@
 os_version >= 10.11.6 # Oldest CI nodes are currently 10.11.6
-brew cmake >= 3.6.0 # Need 3.6 for CMAKE_TRY_COMPILE_TARGET_TYPE


### PR DESCRIPTION
We no longer install cmake from brew on our CI