### PR TITLE
[fuchsia] Use llvm-19 on Fuchsia bots

### DIFF
--- a/buildbot/fuchsia/Dockerfile
+++ b/buildbot/fuchsia/Dockerfile
@@ -34,7 +34,7 @@ RUN curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | \
     apt-get update && apt-get install -y --no-install-recommends cmake && \
     rm -rf /var/lib/apt/lists/*
 
-ARG LLVM_VERSION=17
+ARG LLVM_VERSION=19
 
 # Install latest LLVM release.
 RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | \


### PR DESCRIPTION
The Fuchsia toolchain normally builds with FatLTO, and the existing llvm-17 toolchain does not properly support FatLTO compilation. The 17 release does have a FatLTO pipeline, but frontend support in clang was not ready in time for the llvm-17 release.