### PR TITLE
[AMDGPU] Fix CMake cache builder

### DIFF
--- a/zorg/buildbot/builders/annotated/amdgpu-offload-cmake.py
+++ b/zorg/buildbot/builders/annotated/amdgpu-offload-cmake.py
@@ -14,6 +14,12 @@ def main(argv):
     offload_base_dir = os.path.join(source_dir, "offload")
     of_cmake_cache_base_dir = os.path.join(offload_base_dir, "cmake/caches")
 
+    with step("clean build", halt_on_fail=True):
+        # We have to "hard clean" the build directory, since we use a CMake cache
+        # If we do not do this, the resident config will take precedence and changes
+        # to the cache file are ignored.
+        run_command("rm -r *")
+
     with step("cmake", halt_on_fail=True):
         # TODO make the name of the cache file an argument to the script.
         cmake_cache_file = os.path.join(of_cmake_cache_base_dir, "AMDGPUBot.cmake")


### PR DESCRIPTION
We need to clean the build directory to take changes to the CMake cache file have any effect for the actual build config.