### PR TITLE
[AMDGPU][Offload] Clean CMake to let updates take effect

### DIFF
--- a/zorg/buildbot/builders/annotated/amdgpu-offload-cmake.py
+++ b/zorg/buildbot/builders/annotated/amdgpu-offload-cmake.py
@@ -18,7 +18,8 @@ def main(argv):
         # We have to "hard clean" the build directory, since we use a CMake cache
         # If we do not do this, the resident config will take precedence and changes
         # to the cache file are ignored.
-        run_command(["rm", "-r *"])
+        cwd = os.getcwd()
+        utils.clean_dir(cwd)
 
     with step("cmake", halt_on_fail=True):
         # TODO make the name of the cache file an argument to the script.


### PR DESCRIPTION
We want to clean the build directory in order for changes to the in-tree CMake cache file to take effect. Otherwise the local config takes precedence.