### PR TITLE
[CI] Fix broken link in architecture.md

### DIFF
--- a/premerge/architecture.md
+++ b/premerge/architecture.md
@@ -92,5 +92,5 @@ the same instance, forcing containers to share resources.
 
 Those bits are configures in the
 [linux runner configuration](linux_runners_values.yaml) and
-[windows runner configuration](windows_runners_values.yaml).
+[windows runner configuration](windows_runner_values.yaml).
 


### PR DESCRIPTION
arguably we should rename the file instead for consistency, but I'm not quite ready to attempt that yet :)