### PR TITLE
[RISCV] Move clang-riscv-rva23-evl-vec-2stage to annotated builder

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3362,46 +3362,11 @@ all += [
     {'name' : "clang-riscv-rva23-evl-vec-2stage",
     'workernames' : ["rise-clang-riscv-rva23-evl-vec-2stage"],
     'builddir':"clang-riscv-rva23-evl-vec-2stage",
-    'factory' : ClangBuilder.getClangCMakeBuildFactory(
-                clean=True,
-                useTwoStage=True,
-                runTestSuite=False,
-                testStage1=False,
-                checkout_compiler_rt=False,
-                checkout_zorg=True,
-                extra_cmake_args=[
-                    "-DCMAKE_C_COMPILER=clang",
-                    "-DCMAKE_CXX_COMPILER=clang++",
-                    "-DLLVM_ENABLE_LLD=True",
-                    "-DLLVM_TARGETS_TO_BUILD=RISCV",
-                    "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
-                    "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"],
-                extra_stage2_cmake_args=[
-                    util.Interpolate("-DLLVM_NATIVE_TOOL_DIR=%(prop:builddir)s/stage1.install/bin"),
-                    "-DLLVM_BUILD_TESTS=True",
-                    "-DPython3_EXECUTABLE=/usr/bin/python3",
-                    "-DLLVM_HOST_TRIPLE=riscv64-linux-gnu",
-                    util.Interpolate("-DLLVM_EXTERNAL_LIT=%(prop:builddir)s/llvm-zorg/buildbot/riscv-rise/lit-on-qemu")],
-                stage2_toolchain_options=[
-                    "set(CMAKE_SYSTEM_NAME Linux)",
-                    "set(CMAKE_SYSROOT %(prop:builddir)s/../rvsysroot)",
-                    "set(CMAKE_C_COMPILER_TARGET riscv64-linux-gnu)",
-                    "set(CMAKE_CXX_COMPILER_TARGET riscv64-linux-gnu)",
-                    "set(CMAKE_C_FLAGS_INIT \"-march=rva23u64 -mllvm -force-tail-folding-style=data-with-evl -mllvm -prefer-predicate-over-epilogue=predicate-else-scalar-epilogue\")",
-                    "set(CMAKE_CXX_FLAGS_INIT \"-march=rva23u64 -mllvm -force-tail-folding-style=data-with-evl -mllvm -prefer-predicate-over-epilogue=predicate-else-scalar-epilogue\")",
-                    "set(CMAKE_LINKER_TYPE LLD)",
-                    "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)",
-                    "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)",
-                    "set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)",
-                    "set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)"],
-                env={
-                    "BB_IMG_DIR": util.Interpolate("%(prop:builddir)s/.."),
-                    # TODO: Switch to specifying rva23u64 once support is
-                    # available in a released QEMU.
-                    "BB_QEMU_CPU": "rv64,zba=true,zbb=true,zbc=false,zbs=true,zfhmin=true,v=true,vext_spec=v1.0,zkt=true,zvfhmin=true,zvbb=true,zvkt=true,zihintntl=true,zicond=true,zimop=true,zcmop=true,zcb=true,zfa=true,zawrs=true,rvv_ta_all_1s=true,rvv_ma_all_1s=true,rvv_vl_half_avl=true",
-                    "BB_QEMU_SMP": "32",
-                    "BB_QEMU_MEM": "64G"}
-                )},
+    'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
+                    script="rise-riscv-build.sh",
+                    checkout_llvm_sources=False,
+                    script_interpreter=None,
+                    clean=True)},
 
     # Builders similar to used in Buildkite premerge pipeline.
     # Please keep in sync with llvm-project/.ci configurations.

--- a/zorg/buildbot/builders/annotated/rise-riscv-build.sh
+++ b/zorg/buildbot/builders/annotated/rise-riscv-build.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Enable Error tracing
+set -o errtrace
+
+# Print trace for all commands ran before execution
+set -x
+
+ANN_SCRIPT_DIR="$(dirname $0)"
+. ${ANN_SCRIPT_DIR}/buildbot-helper.sh
+
+# Ensure all commands pass, and no dereferencing of unset variables.
+set -eu
+halt_on_failure
+
+# We don't want to build within 'build' (where we start by default).
+cd ..
+rm -rf build
+
+# Set up variables
+LLVM_REVISION="${BUILDBOT_REVISION:-origin/main}"
+
+case "$BUILDBOT_BUILDERNAME" in
+  "clang-riscv-rva23-evl-vec-2stage")
+    TARGET_CFLAGS="-march=rva23u64 -mllvm -force-tail-folding-style=data-with-evl -mllvm -prefer-predicate-over-epilogue=predicate-else-scalar-epilogue"
+    export BB_IMG_DIR=$(pwd)/..
+     # TODO: Switch to specifying rva23u64 once support is available in a
+     # released QEMU.
+    export BB_QEMU_CPU="rv64,zba=true,zbb=true,zbc=false,zbs=true,zfhmin=true,v=true,vext_spec=v1.0,zkt=true,zvfhmin=true,zvbb=true,zvkt=true,zihintntl=true,zicond=true,zimop=true,zcmop=true,zcb=true,zfa=true,zawrs=true,rvv_ta_all_1s=true,rvv_ma_all_1s=true,rvv_vl_half_avl=true"
+    export BB_QEMU_SMP=32
+    export BB_QEMU_MEM="64G"
+    ;;
+  *)
+    echo "Unrecognised builder name"
+    exit 1
+esac
+
+
+# Main builder stages start here
+
+if [ ! -d llvm ]; then
+  build_step "Cloning llvm-project repo"
+  git clone --progress https://github.com/llvm/llvm-project.git llvm
+fi
+
+build_step "Updating llvm-project repo"
+git -C llvm fetch origin
+git -C llvm reset --hard "${LLVM_REVISION}"
+
+# We unconditionally clean (i.e. don't check BUILDBOT_CLOBBER=1) as the script
+# hasn't been tested without cleaning after each build.
+build_step "Cleaning last build"
+rm -rf stage1 stage2
+
+build_step "llvm-project cmake stage 1"
+cmake -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_ASSERTIONS=True \
+  -DLLVM_LIT_ARGS="-v" \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DLLVM_ENABLE_LLD=True \
+  -DLLVM_TARGETS_TO_BUILD="RISCV" \
+  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+  -DLLVM_ENABLE_PROJECTS="lld;clang;llvm" \
+  -B stage1 \
+  -S llvm/llvm
+
+build_step "llvm-project build stage 1"
+cmake --build stage1
+
+build_step "llvm-project cmake stage 2"
+cat - <<EOF > stage1-toolchain.cmake
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSROOT $(pwd)/../rvsysroot)
+set(CMAKE_C_COMPILER_TARGET riscv64-linux-gnu)
+set(CMAKE_CXX_COMPILER_TARGET riscv64-linux-gnu)
+set(CMAKE_C_FLAGS_INIT "$TARGET_CFLAGS")
+set(CMAKE_CXX_FLAGS_INIT "$TARGET_CFLAGS")
+set(CMAKE_LINKER_TYPE LLD)
+set(CMAKE_C_COMPILER $(pwd)/stage1/bin/clang)
+set(CMAKE_CXX_COMPILER $(pwd)/stage1/bin/clang++)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+EOF
+cmake -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_ASSERTIONS=True \
+  -DLLVM_LIT_ARGS="-v" \
+  -DLLVM_NATIVE_TOOL_DIR=$(pwd)/stage1/bin \
+  -DLLVM_BUILD_TESTS=True \
+  -DPython3_EXECUTABLE=/usr/bin/python3 \
+  -DLLVM_EXTERNAL_LIT="$(pwd)/llvm-zorg/buildbot/riscv-rise/lit-on-qemu" \
+  -DLLVM_ENABLE_PROJECTS="lld;clang;clang-tools-extra;llvm" \
+  -DCMAKE_TOOLCHAIN_FILE=$(pwd)/stage1-toolchain.cmake \
+  -DLLVM_HOST_TRIPLE=riscv64-linux-gnu \
+  -S llvm/llvm \
+  -B stage2
+
+build_step "llvm-project build stage 2"
+cmake --build stage2
+
+build_step "llvm-project check-all"
+cmake --build stage2 --target check-all


### PR DESCRIPTION
The intent is for the rest of the RISE RISC-V builders to follow, but this starts the process.

Previously the builders used the framework provided by ClangBuilder.py. As the build has required more customisation (with more to come - such as building the llvm-test-suite with the stage1 compiler which isn't support by ClangBuilder) this is requiring more and more changes to increase configurability of ClangBuilder, but this makes the logic harder to follow and I think we've reached the limit of what's reasonable.

The AnnotatedBuilder infrastructure allows the build logic to just be put in a shell script. The latest version of llvm-zorg is checked out and the script is executed. This has the additional advantage of decoupling script updates from needing to wait for buildmaster redeploys. With that in mind, I've avoided putting any configuration through options or environment variables defined by the builder instantiation in builders.py so there's no need to reason about cases where e.g. a script update was committed but the buildmaster may or may not have been updated with a new builders.py.

rise-riscv-build.sh is written with the philosophy that "A little copying is better than a little dependency." We could look to share more logic, but we'd end up with the same configurability issue as ClangBuilder. Instead, the script provides only the configurability needed for this set of builders.

A future improvement would be to make rise-riscv-build.sh more friendly to running outside of the buildbot environment (e.g. for local testing). This is left to future work, as it's not a regression vs the current approach.

This change has been tested locally along the lines of the instructions I wrote in
<https://llvm.org/docs/HowToAddABuilder.html#testing-a-builder-config-locally>. Something like the following is sufficient to use a local downstream testing llvm-zorg branch for the annotated builder scripts temporarily:

```
--- a/zorg/buildbot/builders/AnnotatedBuilder.py
+++ b/zorg/buildbot/builders/AnnotatedBuilder.py
@@ -77,6 +77,8 @@ def getAnnotatedBuildFactory(
     # Check out zorg so we can run the annotator scripts.
     f.addGetSourcecodeForProject(
         name='update-annotated-scripts',
+        repourl='file:///home/asb/llvm-zorg',
+        branch='synced-worktree',
         project='zorg',
         src_dir='llvm-zorg',
         alwaysUseLatest=True)
```