### PR TITLE
[RISCV] Move clang-riscv-rva20-2stage to annotated builder

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3273,44 +3273,11 @@ all += [
     'tags'  : ["clang"],
     'workernames' : ["rise-clang-riscv-rva20-2stage"],
     'builddir':"clang-riscv-rva20-2stage",
-    'factory' : ClangBuilder.getClangCMakeBuildFactory(
-                clean=True,
-                useTwoStage=True,
-                runTestSuite=False,
-                testStage1=False,
-                checkout_compiler_rt=False,
-                checkout_zorg=True,
-                extra_cmake_args=[
-                    "-DCMAKE_C_COMPILER=clang",
-                    "-DCMAKE_CXX_COMPILER=clang++",
-                    "-DLLVM_ENABLE_LLD=True",
-                    "-DLLVM_TARGETS_TO_BUILD=RISCV",
-                    "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
-                    "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"],
-                extra_stage2_cmake_args=[
-                    util.Interpolate("-DLLVM_NATIVE_TOOL_DIR=%(prop:builddir)s/stage1.install/bin"),
-                    "-DLLVM_BUILD_TESTS=True",
-                    "-DPython3_EXECUTABLE=/usr/bin/python3",
-                    "-DLLVM_HOST_TRIPLE=riscv64-linux-gnu",
-                    util.Interpolate("-DLLVM_EXTERNAL_LIT=%(prop:builddir)s/llvm-zorg/buildbot/riscv-rise/lit-on-qemu")],
-                stage2_toolchain_options=[
-                    "set(CMAKE_SYSTEM_NAME Linux)",
-                    "set(CMAKE_SYSROOT %(prop:builddir)s/../rvsysroot)",
-                    "set(CMAKE_C_COMPILER_TARGET riscv64-linux-gnu)",
-                    "set(CMAKE_CXX_COMPILER_TARGET riscv64-linux-gnu)",
-                    "set(CMAKE_C_FLAGS_INIT '-march=rva20u64')",
-                    "set(CMAKE_CXX_FLAGS_INIT '-march=rva20u64')",
-                    "set(CMAKE_LINKER_TYPE LLD)",
-                    "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)",
-                    "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)",
-                    "set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)",
-                    "set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)"],
-                env={
-                    "BB_IMG_DIR": util.Interpolate("%(prop:builddir)s/.."),
-                    "BB_QEMU_CPU": "rv64,zfa=false,zba=false,zbb=false,zbc=false,zbs=false",
-                    "BB_QEMU_SMP": "32",
-                    "BB_QEMU_MEM": "64G"}
-                )},
+    'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
+                    script="rise-riscv-build.sh",
+                    checkout_llvm_sources=False,
+                    script_interpreter=None,
+                    clean=True)},
 
     ## RISC-V RVA23 profile check-all 2-stage
     {'name' : "clang-riscv-rva23-2stage",

--- a/zorg/buildbot/builders/annotated/rise-riscv-build.sh
+++ b/zorg/buildbot/builders/annotated/rise-riscv-build.sh
@@ -21,6 +21,13 @@ rm -rf build
 LLVM_REVISION="${BUILDBOT_REVISION:-origin/main}"
 
 case "$BUILDBOT_BUILDERNAME" in
+  "clang-riscv-rva20-2stage")
+    TARGET_CFLAGS="-march=rva20u64"
+    export BB_IMG_DIR=$(pwd)/..
+    export BB_QEMU_CPU="rv64,zfa=false,zba=false,zbb=false,zbc=false,zbs=false"
+    export BB_QEMU_SMP=32
+    export BB_QEMU_MEM="64G"
+    ;;
   "clang-riscv-rva23-evl-vec-2stage")
     TARGET_CFLAGS="-march=rva23u64 -mllvm -force-tail-folding-style=data-with-evl -mllvm -prefer-predicate-over-epilogue=predicate-else-scalar-epilogue"
     export BB_IMG_DIR=$(pwd)/..


### PR DESCRIPTION
Followup to #374 (and stacks on top of it), but this time converting the RVA20 builder.