### PR TITLE
[AMDGPU] Remove flaky offload tests from builder

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1948,7 +1948,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_CFLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                         ],
-                        add_lit_checks=["check-clang", "check-llvm", "check-lld", "check-offload"],
+                        add_lit_checks=["check-clang", "check-llvm", "check-lld"],
                         add_openmp_lit_args=["--time-tests", "--timeout 100"],
                         )},
 


### PR DESCRIPTION
Remove running offload tests on this machine, given that there might be something wrong more fundamentally.