### PR TITLE
Enable LLVM_ENABLE_RUNTIMES build of Flang-RT for flang-x86_64-windows

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2522,7 +2522,7 @@ all += [
     'workernames' : ["minipc-ryzen-win"],
     'builddir': "flang-x86_64-windows",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
-                    depends_on_projects=['llvm','mlir','clang','flang'],
+                    depends_on_projects=['llvm','mlir','clang','flang','flang-rt'],
                     checks=['check-flang'],
                     install_dir="flang.install",
                     extra_configure_args=[

--- a/zorg/buildbot/process/factory.py
+++ b/zorg/buildbot/process/factory.py
@@ -7,12 +7,12 @@ from buildbot.plugins import util, steps
 
 _all_runtimes = frozenset([
     "compiler-rt",
+    "flang-rt",
     "libc",
     "libcxx",
     "libcxxabi",
     "libunwind",
     "openmp",
-    "flang-rt",
 ])
 
 class LLVMBuildFactory(BuildFactory):

--- a/zorg/buildbot/process/factory.py
+++ b/zorg/buildbot/process/factory.py
@@ -12,6 +12,7 @@ _all_runtimes = frozenset([
     "libcxxabi",
     "libunwind",
     "openmp",
+    "flang-rt",
 ])
 
 class LLVMBuildFactory(BuildFactory):


### PR DESCRIPTION
While #333 tried to update all buildbots all at once, this starts with updating just one buildbot to test the `LLVM_ENABLE_RUNTIMES=flang-rt` configuration.

The builder is currently running in staging here: https://lab.llvm.org/staging/#/builders/36