### PR TITLE
LLVM_ENABLE_RUNTIMES=flang-rt for ClangBuilder builders

### DIFF
--- a/zorg/buildbot/builders/ClangBuilder.py
+++ b/zorg/buildbot/builders/ClangBuilder.py
@@ -286,6 +286,7 @@ def _getClangCMakeBuildFactory(
         depends_on_projects.append('libunwind')
     if checkout_flang:
         depends_on_projects.append('flang')
+        depends_on_projects.append('flang-rt')
         depends_on_projects.append('mlir')
 
     f = LLVMBuildFactory(


### PR DESCRIPTION
With the option `checkout_flang=True`, ClangBuilder-based builders also compile Flang. Modify ClangBuilder to use `LLVM_ENABLE_RUNTIMES=flang-rt`. This prepares the removal of the "projects" build of the flang runtime in https://github.com/llvm/llvm-project/pull/124126.

Split off from #333

Affected builders:
 * clang-aarch64-full-2stage
 * clang-aarch64-sve-vla
 * clang-aarch64-sve-vla-2stage
 * clang-aarch64-sve-vls
 * clang-aarch64-sve-vls-2stage
 * clang-aarch64-sve2-vla
 * clang-aarch64-sve2-vla-2stage
 * clang-arm64-windows-msvc
 * clang-arm64-windows-msvc-2stage

Affected workers:
 * linaro-clang-aarch64-full-2stage
 * linaro-g3-01
 * linaro-g3-02
 * linaro-g3-03
 * linaro-g3-04
 * linaro-g4-01
 * linaro-g4-02
 * linaro-armv8-windows-msvc-04
 * linaro-armv8-windows-msvc-02

Admins listed for those workers:
 * Linaro Toolchain Working Group <linaro-toolchain@lists.linaro.org>
 * Leandro Lupori <leandro.lupori@linaro.org> 
 * David Spickett <david.spickett@linaro.org> 

Verified locally on x86_64 (with necessary changes) using the instructions at https://llvm.org/docs/HowToAddABuilder.html#testing-a-builder-config-locally. Once those pass, I will remove the draft status.