### PR TITLE
LLVM_ENABLE_RUNTIMES=flang-rt for UnifiedTreeBuilder builders

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2353,8 +2353,8 @@ all += [
     'builddir': "flang-aarch64-dylib",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
-                    checks=['check-flang'],
-                    depends_on_projects=['llvm','mlir','clang','flang','openmp'],
+                    checks=['check-flang','check-flang-rt'],
+                    depends_on_projects=['llvm','mlir','clang','flang','flang-rt','openmp'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DLLVM_BUILD_LLVM_DYLIB=ON",
@@ -2368,8 +2368,8 @@ all += [
     'builddir': "flang-aarch64-sharedlibs",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
-                    checks=['check-flang'],
-                    depends_on_projects=['llvm','mlir','clang','flang','openmp'],
+                    checks=['check-flang','check-flang-rt'],
+                    depends_on_projects=['llvm','mlir','clang','flang','flang-rt','openmp'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DBUILD_SHARED_LIBS=ON",
@@ -2401,8 +2401,8 @@ all += [
     'builddir': "flang-aarch64-debug-reverse-iteration",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
-                    checks=['check-flang'],
-                    depends_on_projects=['llvm','mlir','clang','flang','openmp'],
+                    checks=['check-flang','check-flang-rt'],
+                    depends_on_projects=['llvm','mlir','clang','flang','flang-rt','openmp'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DCMAKE_BUILD_TYPE=Debug",
@@ -2417,8 +2417,8 @@ all += [
     'builddir': "flang-aarch64-libcxx",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
-                    checks=['check-flang'],
-                    depends_on_projects=['llvm','mlir','clang','flang'],
+                    checks=['check-flang','check-flang-rt'],
+                    depends_on_projects=['llvm','mlir','clang','flang','flang-rt'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DLLVM_INSTALL_UTILS=ON",
@@ -2437,8 +2437,8 @@ all += [
     'builddir': "flang-aarch64-release",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
-                    checks=['check-flang'],
-                    depends_on_projects=['llvm','mlir','clang','flang','openmp'],
+                    checks=['check-flang','check-flang-rt'],
+                    depends_on_projects=['llvm','mlir','clang','flang','flang-rt','openmp'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DCMAKE_BUILD_TYPE=Release",
@@ -2452,8 +2452,8 @@ all += [
     'builddir': "flang-aarch64-rel-assert",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
-                    checks=['check-flang'],
-                    depends_on_projects=['llvm','mlir','clang','flang','openmp'],
+                    checks=['check-flang','check-flang-rt'],
+                    depends_on_projects=['llvm','mlir','clang','flang','flang-rt','openmp'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
@@ -2468,8 +2468,8 @@ all += [
     'builddir': "flang-aarch64-latest-gcc",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
-                    checks=['check-flang'],
-                    depends_on_projects=['llvm','mlir','clang','flang','openmp'],
+                    checks=['check-flang','check-flang-rt'],
+                    depends_on_projects=['llvm','mlir','clang','flang','flang-rt','openmp'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=AArch64",
                         "-DLLVM_INSTALL_UTILS=ON",


### PR DESCRIPTION
Add `depends_on_projects=['flang-rt']` and `checks=['check-flang-rt']` to Linaro's builders that are based on UnifiedTreeBuilder. This prepares the removal of the "projects" build of the flang runtime in https://github.com/llvm/llvm-project/pull/124126.

Split off from #333

Affected builders:
 * flang-aarch64-dylib
 * flang-aarch64-sharedlibs
 * flang-aarch64-debug-reverse-iteration
 * flang-aarch64-libcxx
 * flang-aarch64-release
 * flang-aarch64-rel-assert
 * flang-aarch64-latest-gcc

Affected workers:
 * linaro-flang-aarch64-dylib
 * linaro-flang-aarch64-sharedlibs
 * linaro-flang-aarch64-debug-reverse-iteration
 * linaro-flang-aarch64-libcxx
 * linaro-flang-aarch64-release
 * linaro-flang-aarch64-rel-assert
 * linaro-flang-aarch64-latest-gcc

I could locally confirm that `flang-aarch64-dylib` works on a x86_64 host (since I don't have an aarch machine other than a Raspberry Pi readily available)