### PR TITLE
LLVM_ENABLE_RUNTIMES=flang-rt for flang-aarch64-out-of-tree

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2393,6 +2393,9 @@ all += [
                     flang_extra_configure_args=[
                         "-DFLANG_ENABLE_WERROR=ON",
                         "-DCMAKE_BUILD_TYPE=Release",
+                    ],
+                    flang_rt_extra_configure_args=[
+                        "-DCMAKE_BUILD_TYPE=Release",
                     ])},
 
     {'name' : "flang-aarch64-debug-reverse-iteration",

--- a/zorg/buildbot/builders/FlangBuilder.py
+++ b/zorg/buildbot/builders/FlangBuilder.py
@@ -1,12 +1,15 @@
 from zorg.buildbot.commands.CmakeCommand import CmakeCommand
 from zorg.buildbot.process.factory import LLVMBuildFactory
 from zorg.buildbot.builders.UnifiedTreeBuilder import addNinjaSteps, getCmakeWithNinjaBuildFactory
+from buildbot.plugins import util, steps
+import os
 
 def getFlangOutOfTreeBuildFactory(
            checks = None,
            clean = False,
            llvm_extra_configure_args = None,
            flang_extra_configure_args = None,
+           flang_rt_extra_configure_args = None,
            env = None,
            **kwargs):
 
@@ -14,7 +17,9 @@ def getFlangOutOfTreeBuildFactory(
         env = dict()
 
     f = getCmakeWithNinjaBuildFactory(
-            depends_on_projects=['llvm','clang','mlir','openmp'],
+            depends_on_projects=['llvm','clang','mlir','openmp','flang','flang-rt'],
+            enable_projects=['llvm','clang','mlir'],
+            enable_runtimes=['openmp'],
             obj_dir="build_llvm",
             checks=[],
             clean=clean,
@@ -24,6 +29,12 @@ def getFlangOutOfTreeBuildFactory(
 
     if checks is None:
         checks = ['check-all']
+
+    cleanBuildRequested = (
+        lambda step: step.build.getProperty("clean")
+        or step.build.getProperty("clean_obj")
+        or clean
+    )
 
     # Make a local copy of the flang configure args, as we are going to modify that.
     if flang_extra_configure_args:
@@ -52,6 +63,16 @@ def getFlangOutOfTreeBuildFactory(
             LLVMBuildFactory.pathRelativeTo(clang_dir, flang_obj_dir)),
         ])
 
+    f.addStep(
+        steps.RemoveDirectory(
+            name=f"clean-{flang_obj_dir}-dir",
+            dir=flang_obj_dir,
+            haltOnFailure=False,
+            flunkOnFailure=False,
+            doStepIf=cleanBuildRequested,
+        )
+    )
+
     # We can't use addCmakeSteps as that would use the path in f.llvm_srcdir.
     f.addStep(CmakeCommand(name="cmake-configure-flang",
                            haltOnFailure=True,
@@ -69,6 +90,60 @@ def getFlangOutOfTreeBuildFactory(
        checks=checks,
        env=env,
        stage_name="flang",
+       **kwargs)
+
+    ## Build Flang-RT as a standalone runtime
+    flang_rt_obj_dir = "build_flang-rt"
+
+    flang_rt_cmake_args = ["-GNinja"]
+    if flang_rt_extra_configure_args:
+        flang_rt_cmake_args += flang_rt_extra_configure_args
+
+    # Use LLVM from the getCmakeWithNinjaBuildFactory step.
+    flang_rt_cmake_args += [
+        util.Interpolate(f"-DLLVM_BINARY_DIR=%(prop:builddir)s/{f.obj_dir}"),
+        "-DLLVM_ENABLE_RUNTIMES=flang-rt",
+    ]
+
+    # Use the Fortran compiler from the previous step.
+    flang_rt_cmake_args += [
+        util.Interpolate(
+            f"-DCMAKE_Fortran_COMPILER=%(prop:builddir)s/{flang_obj_dir}/bin/flang"
+        ),
+        "-DCMAKE_Fortran_COMPILER_WORKS=ON",
+    ]
+
+    f.addStep(
+        steps.RemoveDirectory(
+            name=f"clean-{flang_rt_obj_dir}-dir",
+            dir=flang_rt_obj_dir,
+            haltOnFailure=False,
+            flunkOnFailure=False,
+            doStepIf=cleanBuildRequested,
+        )
+    )
+
+    f.addStep(
+        CmakeCommand(
+            name="cmake-configure-flang-rt",
+            haltOnFailure=True,
+            description=["CMake", "configure", "Flang-RT"],
+            options=flang_rt_cmake_args,
+            path=LLVMBuildFactory.pathRelativeTo(
+                os.path.join(f.monorepo_dir, "runtimes"), flang_rt_obj_dir
+            ),
+            env=env,
+            workdir=flang_rt_obj_dir,
+            **kwargs,
+        )
+    )
+
+    addNinjaSteps(
+       f,
+       obj_dir=flang_rt_obj_dir,
+       checks=['check-flang-rt'],
+       env=env,
+       stage_name="flang-rt",
        **kwargs)
 
     return f

--- a/zorg/buildbot/builders/UnifiedTreeBuilder.py
+++ b/zorg/buildbot/builders/UnifiedTreeBuilder.py
@@ -16,6 +16,7 @@ import zorg.buildbot.builders.Util as builders_util
 
 def getLLVMBuildFactoryAndPrepareForSourcecodeSteps(
            depends_on_projects = None,
+           enable_projects = "auto",
            enable_runtimes = "auto",
            llvm_srcdir = None,
            src_to_build_dir = None,
@@ -34,6 +35,7 @@ def getLLVMBuildFactoryAndPrepareForSourcecodeSteps(
 
     f = LLVMBuildFactory(
             depends_on_projects=depends_on_projects,
+            enable_projects=enable_projects,
             enable_runtimes=enable_runtimes,
             llvm_srcdir=llvm_srcdir,
             src_to_build_dir=src_to_build_dir,
@@ -56,6 +58,7 @@ def getLLVMBuildFactoryAndPrepareForSourcecodeSteps(
 
 def getLLVMBuildFactoryAndSourcecodeSteps(
            depends_on_projects = None,
+           enable_projects = "auto",
            enable_runtimes = "auto",
            llvm_srcdir = None,
            src_to_build_dir = None,
@@ -66,6 +69,7 @@ def getLLVMBuildFactoryAndSourcecodeSteps(
 
     f = getLLVMBuildFactoryAndPrepareForSourcecodeSteps(
             depends_on_projects=depends_on_projects,
+            enable_projects=enable_projects,
             enable_runtimes=enable_runtimes,
             llvm_srcdir=llvm_srcdir,
             src_to_build_dir=src_to_build_dir,
@@ -254,6 +258,7 @@ def addNinjaSteps(
 
 def getCmakeBuildFactory(
            depends_on_projects = None,
+           enable_projects = "auto",
            enable_runtimes = "auto",
            llvm_srcdir = None,
            src_to_build_dir = None,
@@ -267,6 +272,7 @@ def getCmakeBuildFactory(
 
     f = getLLVMBuildFactoryAndSourcecodeSteps(
             depends_on_projects=depends_on_projects,
+            enable_projects=enable_projects,
             enable_runtimes=enable_runtimes,
             llvm_srcdir=llvm_srcdir,
             src_to_build_dir=src_to_build_dir,
@@ -298,6 +304,7 @@ def getCmakeBuildFactory(
 
 def getCmakeWithNinjaBuildFactory(
            depends_on_projects = None,
+           enable_projects = "auto",
            enable_runtimes = "auto",
            targets = None,
            llvm_srcdir = None,
@@ -335,6 +342,7 @@ def getCmakeWithNinjaBuildFactory(
 
     f = getCmakeBuildFactory(
             depends_on_projects=depends_on_projects,
+            enable_projects=enable_projects,
             enable_runtimes=enable_runtimes,
             llvm_srcdir=llvm_srcdir,
             src_to_build_dir=src_to_build_dir,


### PR DESCRIPTION
Make `FlangBuilder.getFlangOutOfTreeBuildFactory` build the flang-rt runtime as an out-of-tree runtimes build with additional steps.

Fixes some issues with FlangBuilder too:
 * Clears the build directories with the clean_obj flag set. Usually buildbot deletes the build directory whenever a CMakeLists.txt in a depends_on_projects subdirectory changes to get a clean build. Otherwise, an incompatible CMakeCache.txt will carry on forever.
 * Add `flang` and `flang-rt` as depends_on_projects. Otherwise, changes in these subdirectories do not trigger a build. Even worse, breaking commits will be attributed to the next commit in llvm/clang/mlir/openmp, as happed in e.g. https://lab.llvm.org/buildbot/#/builders/53/builds/11759 (commit causing failure was https://github.com/llvm/llvm-project/commit/fe8b323f598393d5a7cf468865c4f60d39cb0718)

This PR is not strictly necessary for https://github.com/llvm/llvm-project/pull/124126, it just wouldn't build the runtime anymore.

Affected builders:
 * flang-aarch64-out-of-tree

Affected workers: 
 * linaro-flang-aarch64-out-of-tree

Verfied locally on x86_64.