### PR TITLE
LLVM_ENABLE_RUNTIMES=flang-rt for OpenMPBuilder builders

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2031,8 +2031,8 @@ all += [
     'builddir': "openmp-offload-amdgpu-clang-flang",
     'factory' : OpenMPBuilder.getOpenMPCMakeBuildFactory(
                         clean=True,
-                        enable_runtimes=['compiler-rt', 'openmp', 'offload'],
-                        depends_on_projects=['llvm','clang','lld', 'offload', 'openmp', 'mlir', 'flang', 'compiler-rt'],
+                        enable_runtimes=['compiler-rt', 'openmp', 'offload', 'flang-rt'],
+                        depends_on_projects=['llvm','clang','lld', 'offload', 'openmp', 'mlir', 'flang', 'flang-rt', 'compiler-rt'],
                         extraCmakeArgs=[
                             "-DCMAKE_BUILD_TYPE=Release",
                             "-DCLANG_DEFAULT_LINKER=lld",
@@ -2061,7 +2061,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_CFLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                         ],
-                        add_lit_checks=["check-flang", "check-offload"],
+                        add_lit_checks=["check-flang", "check-flang-rt", "check-offload"],
                         add_openmp_lit_args=["--time-tests", "--timeout 100"],
                     )},
 
@@ -2073,8 +2073,8 @@ all += [
     'factory' : OpenMPBuilder.getOpenMPCMakeBuildFactory(
                         clean=True,
                         test=False, # we have no GPU avail, skip runtime tests
-                        enable_runtimes=['openmp', 'compiler-rt', 'offload'],
-                        depends_on_projects=['llvm','clang', 'flang', 'lld', 'mlir', 'offload', 'openmp', 'compiler-rt'],
+                        enable_runtimes=['openmp', 'compiler-rt', 'offload', 'flang-rt'],
+                        depends_on_projects=['llvm','clang', 'flang', 'flang-rt', 'lld', 'mlir', 'offload', 'openmp', 'compiler-rt'],
                         extraCmakeArgs=[
                             "-DCMAKE_BUILD_TYPE=Release",
                             "-DCLANG_DEFAULT_LINKER=lld",
@@ -2094,7 +2094,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_CFLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                         ],
-                        add_lit_checks=["check-clang", "check-flang", "check-llvm", "check-lld", "check-mlir"],
+                        add_lit_checks=["check-clang", "check-flang", "check-flang-rt", "check-llvm", "check-lld", "check-mlir"],
                         add_openmp_lit_args=["--time-tests", "--timeout 100"],
                     )},
 
@@ -2105,8 +2105,8 @@ all += [
     'factory' : OpenMPBuilder.getOpenMPCMakeBuildFactory(
                         clean=True,
                         test=True,
-                        enable_runtimes=['openmp', 'compiler-rt', 'offload'],
-                        depends_on_projects=['llvm','clang', 'flang', 'lld', 'mlir', 'offload', 'openmp', 'compiler-rt'],
+                        enable_runtimes=['openmp', 'compiler-rt', 'offload', 'flang-rt'],
+                        depends_on_projects=['llvm','clang', 'flang', 'flang-rt', 'lld', 'mlir', 'offload', 'openmp', 'compiler-rt'],
                         extraCmakeArgs=[
                             "-DCMAKE_BUILD_TYPE=Release",
                             "-DCLANG_DEFAULT_LINKER=lld",
@@ -2127,7 +2127,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_CFLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                         ],
-                        add_lit_checks=["check-clang", "check-flang", "check-llvm", "check-lld", "check-mlir", "check-offload"],
+                        add_lit_checks=["check-clang", "check-flang", "check-flang-rt", "check-llvm", "check-lld", "check-mlir", "check-offload"],
                         add_openmp_lit_args=["--time-tests", "--timeout 100", "--xfail=affinity/format/proc_bind.c"],
                     )},
 
@@ -2138,8 +2138,8 @@ all += [
     'factory' : OpenMPBuilder.getOpenMPCMakeBuildFactory(
                         clean=True,
                         test=True,
-                        enable_runtimes=['openmp', 'compiler-rt', 'offload'],
-                        depends_on_projects=['llvm','clang', 'flang', 'lld', 'mlir', 'offload', 'openmp', 'compiler-rt'],
+                        enable_runtimes=['openmp', 'compiler-rt', 'offload', 'flang-rt'],
+                        depends_on_projects=['llvm','clang', 'flang', 'flang-rt', 'lld', 'mlir', 'offload', 'openmp', 'compiler-rt'],
                         extraCmakeArgs=[
                             "-DCMAKE_BUILD_TYPE=Release",
                             "-DCLANG_DEFAULT_LINKER=lld",
@@ -2160,7 +2160,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_CFLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                         ],
-                        add_lit_checks=["check-clang", "check-flang", "check-llvm", "check-lld", "check-mlir", "check-offload"],
+                        add_lit_checks=["check-clang", "check-flang", "check-flang-rt", "check-llvm", "check-lld", "check-mlir", "check-offload"],
                         add_openmp_lit_args=["--time-tests", "--timeout 100", "--xfail=affinity/format/proc_bind.c"],
                     )},
 


### PR DESCRIPTION
Add `enable_runtimes=['flang-rt']`, `depends_on_projects=['flang-rt']`, and `add_lit_checks=['check-flang-rt']` to all OpenMPBuilder-based builders that build flang. This prepares the removal of the "projects" build of the flang runtime in https://github.com/llvm/llvm-project/pull/124126.

Split off from #333

Affected builders:
 * openmp-offload-amdgpu-clang-flang
 * openmp-offload-sles-build-only
 * openmp-offload-rhel-9_4
 * openmp-offload-rhel-8_8

Affected workers:
 * rocm-worker-hw-01 (staging)
 * rocm-worker-hw-04-sles
 * rocm-worker-hw-04-rhel-9_4 (staging)
 * rocm-worker-hw-04-rhel-8_8 (staging)

Admins listed for those workers:
 * AMD <dl.gcr.lightning.buildbot@amd.com>
