### PR TITLE
Allow Lit to use 'ptxas' tool to validate generated PTX on the NVPTX builders.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3100,6 +3100,8 @@ all += [
                         # TMP/TEMP within the build dir (to utilize a ramdisk).
                         'TMP'        : util.Interpolate("%(prop:builddir)s/build"),
                         'TEMP'       : util.Interpolate("%(prop:builddir)s/build"),
+                        # Allow Lit to use 'ptxas' tool to validate generated PTX.
+                        'LLVM_PTXAS_EXECUTABLE' : "/usr/local/cuda/bin/ptxas",
                     })},
 
     {'name' : "llvm-nvptx64-nvidia-ubuntu",
@@ -3125,6 +3127,8 @@ all += [
                         # TMP/TEMP within the build dir (to utilize a ramdisk).
                         'TMP'        : util.Interpolate("%(prop:builddir)s/build"),
                         'TEMP'       : util.Interpolate("%(prop:builddir)s/build"),
+                        # Allow Lit to use 'ptxas' tool to validate generated PTX.
+                        'LLVM_PTXAS_EXECUTABLE' : "/usr/local/cuda/bin/ptxas",
                     })},
 
     {'name' : "llvm-nvptx-nvidia-win",
@@ -3148,6 +3152,8 @@ all += [
                         # TMP/TEMP within the build dir (to utilize a ramdisk).
                         'TMP'        : util.Interpolate("%(prop:builddir)s/build"),
                         'TEMP'       : util.Interpolate("%(prop:builddir)s/build"),
+                        # Allow Lit to use 'ptxas' tool to validate generated PTX.
+                        'LLVM_PTXAS_EXECUTABLE' : "c:/buildbot/latest-cuda/bin/ptxas.exe",
                     })},
 
     {'name' : "llvm-nvptx64-nvidia-win",
@@ -3171,6 +3177,8 @@ all += [
                         # TMP/TEMP within the build dir (to utilize a ramdisk).
                         'TMP'        : util.Interpolate("%(prop:builddir)s/build"),
                         'TEMP'       : util.Interpolate("%(prop:builddir)s/build"),
+                        # Allow Lit to use 'ptxas' tool to validate generated PTX.
+                        'LLVM_PTXAS_EXECUTABLE' : "c:/buildbot/latest-cuda/bin/ptxas.exe",
                     })},
 
     # flang FortranRuntime CUDA Offload builders.


### PR DESCRIPTION
Specify LLVM_PTXAS_EXECUTABLE environment variable with a full path to 'ptxas' tool from installed NVIDIA CUDA Toolkit. LIT will be automatically check and use this tool to validate PTX during the tests.