### PR TITLE
LLVM_ENABLE_RUNTIMES=flang-rt for ppc64-flang-aix

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2545,8 +2545,8 @@ all += [
     'builddir': 'ppc64-flang-aix-build',
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=False,
-                    depends_on_projects=['llvm', 'mlir', 'clang', 'flang', 'compiler-rt', 'openmp'],
-                    checks=['check-flang'],
+                    depends_on_projects=['llvm', 'mlir', 'clang', 'flang', 'flang-rt', 'compiler-rt', 'openmp'],
+                    checks=['check-flang', 'check-flang-rt'],
                     extra_configure_args=[
                         '-DLLVM_DEFAULT_TARGET_TRIPLE=powerpc64-ibm-aix',
                         '-DLLVM_INSTALL_UTILS=ON',


### PR DESCRIPTION
Add `depends_on_projects=['flang-rt']`, and `checks=['check-flang-rt']` to the ppc64-flang-aix builder. The prepares the removal of the "projects" build of the flang runtime in https://github.com/llvm/llvm-project/pull/124126.

Split off from #333

Affected builders:
 * ppc64-flang-aix

Affected workers:
 * ppc64-flang-aix-test (production)

Admins listed for those workers:
 * LLVM on Power <powerllvm@ca.ibm.com>
 * Mark Danial <mark.danial@ibm.com>
