### PR TITLE
Revert "[GreenDragon] Workaround Stage 2 bots being broken (#163)"

### DIFF
--- a/zorg/jenkins/build.py
+++ b/zorg/jenkins/build.py
@@ -428,7 +428,6 @@ def clang_builder(target):
                                    '-DCLANG_INCLUDE_TESTS=On',
                                    '-DLLVM_INCLUDE_UTILS=On',
                                    '-DCMAKE_MACOSX_RPATH=On',
-                                   '-DLLVM_ENABLE_MODULES=Off', # Workaround Stage 2 Green Dragon being broken
                                    ]
 
             if conf.llvm_enable_runtimes:


### PR DESCRIPTION
This reverts commit 3ed3d915a9d4de7967dd20a35a9a266b09cdba86.

Now that the CI machines have newer Xcode's and more importantly SDKs that contain stable version of libc++, re-enable module build so we can catch breakages from upstream faster.

resolves: rdar://125128256