### PR TITLE
Fix openmp-offload-amdgpu-clang-flang

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2043,7 +2043,6 @@ all += [
                             "-DLLVM_ENABLE_ASSERTIONS=ON",
                             "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                             "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
-                            "-DFLANG_RUNTIME_F128_MATH_LIB=libquadmath",
                             "-DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON",
                             "-DCMAKE_CXX_STANDARD=17",
                             "-DBUILD_SHARED_LIBS=ON",


### PR DESCRIPTION
Since 0ac8f9de5a08472260e0e532123b35feb095114c, [openmp-offload-amdgpu-clang-flang](https://lab.llvm.org/staging/#/builders/105/builds/16994) is failing with
```
CMake Error at /home/botworker/builds/openmp-offload-amdgpu-clang-flang/llvm.src/flang-rt/lib/quadmath/CMakeLists.txt:85 (message):
  FLANG_RUNTIME_F128_MATH_LIB setting requires quadmath.h to be available:
  libquadmath
```

The reason is that flang-rt now is built using Clang (like all LLVM runtimes in a bootstrapping build), instead of gcc. `quadmath.h` is located in gcc's "resource dir" (on my system, it is `/usr/lib/gcc/x86_64-linux-gnu/13/include/quadmath.h`) instead in default paths such as `/usr/include`. Hence, clang cannot find it.

Remove the `FLANG_RUNTIME_F128_MATH_LIB=libquadmath` option since by design it does not work with Clang.

Alterantive approaches:
 * Instead of a bootstrapping build, do a out-of-tree build of flang-rt where we can set `CMAKE_CXX_COMPILER=gcc`.
 * Clang already looks for compatible gcc installation to access its libc files such as `crtbegin.o`. It wouldn't be too far fetched to also add its include dir to Clang's default search path. Otherwise, we need to wait until LLVM gets its own equivalent of [libquadmath](https://gcc.gnu.org/onlinedocs/libquadmath/).


