### PR TITLE
LLVM_ENABLE_RUNTIMES=flang-rt for premerge-monolithic-*

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3352,7 +3352,7 @@ all += [
     'builddir': "premerge-monolithic-windows",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaWithMSVCBuildFactory(
                     vs="autodetect",
-                    depends_on_projects=["clang-tools-extra", "clang", "flang", "flang-rt", "libclc", "lld", "llvm", "mlir", "polly", "pstl"],
+                    depends_on_projects=["clang-tools-extra", "clang", "libclc", "lld", "llvm", "mlir", "polly", "pstl"],
                     checks=["check-all"],
                     install_pip_requirements = True,
                     extra_configure_args=[

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3352,7 +3352,7 @@ all += [
     'builddir': "premerge-monolithic-windows",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaWithMSVCBuildFactory(
                     vs="autodetect",
-                    depends_on_projects=["clang-tools-extra", "clang", "flang", "libclc", "lld", "llvm", "mlir", "polly", "pstl"],
+                    depends_on_projects=["clang-tools-extra", "clang", "flang", "flang-rt", "libclc", "lld", "llvm", "mlir", "polly", "pstl"],
                     checks=["check-all"],
                     install_pip_requirements = True,
                     extra_configure_args=[
@@ -3372,7 +3372,7 @@ all += [
     'workernames': ["premerge-linux-1"],
     'builddir': "premerge-monolithic-linux",
     'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
-                    depends_on_projects=["bolt", "clang", "clang-tools-extra", "compiler-rt", "flang", "libc", "libclc", "lld", "llvm", "mlir", "polly", "pstl"],
+                    depends_on_projects=["bolt", "clang", "clang-tools-extra", "compiler-rt", "flang", "flang-rt", "libc", "libclc", "lld", "llvm", "mlir", "polly", "pstl"],
                     install_pip_requirements = True,
                     extra_configure_args=[
                       "-DCMAKE_BUILD_TYPE=Release",


### PR DESCRIPTION
Update premerge-monolithic-windows and premerge-monolithic-linux to prepare for the removal of the "projects" build of the flang runtime in https://github.com/llvm/llvm-project/pull/124126.

This does not change the actual premerge GitHub action, which is done by https://github.com/llvm/llvm-project/pull/128678

For premerge-monolithic-linux, add flang-rt to the LLVM_ENABLE_RUNTIMES list, indirectly by adding it to `depends_on_projects` which also updated the build scheduler.

For premerge-monolithic-windows, remove building flang to match the actual pre-merge build which disabled building flang on Windows in https://github.com/llvm/llvm-project/commit/e4b424afc4fbfe31ea1876114b4e9232efbf2297. Adding flang-rt would also require compiler-rt (which was always required on Windows, but now there is a regression test for it) and check-compiler-rt is currently failing.

Split off from #333. Verified to work locally using instruction from https://llvm.org/docs/HowToAddABuilder.html#testing-a-builder-config-locally. With the exception of `-gmlt` which seems to be a Google-only extention of Clang.

Affected builders:
 * [premerge-monolithic-windows](https://lab.llvm.org/buildbot/#/builders/35)
 * [premerge-monolithic-linux](https://lab.llvm.org/buildbot/#/builders/153)

Affected workers:
 * [premerge-windows-1](https://lab.llvm.org/buildbot/#/workers/153)
 * [premerge-linux-1](https://lab.llvm.org/buildbot/#/workers/110)

Admins listed for those workers:
 * llvm-premerge-buildbots <llvm-premerge-buildbots@google.com>
 * Mikhail Goncharov <goncharov.mikhail@gmail.com>
