### PR TITLE
Add fast ps5 linux builder, update my build failure notifications and update some descriptions.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -124,6 +124,28 @@ all = [
                         "-DLLVM_TARGETS_TO_BUILD=X86",
                         "-DLLVM_USE_LINKER=gold"])},
 
+    {'name': "llvm-clang-x86_64-sie-ps5-fast",
+    'tags'  : ["clang", "llvm", "clang-tools-extra", "lld", "cross-project-tests"],
+    'collapseRequests': False,
+    'workernames': ["sie-linux-worker4"],
+    'builddir': "llvm-ps5-fast",
+    'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                    depends_on_projects=['llvm','clang','clang-tools-extra','lld','cross-project-tests'],
+                    extra_configure_args=[
+                        "-DCMAKE_C_COMPILER=gcc",
+                        "-DCMAKE_CXX_COMPILER=g++",
+                        "-DCMAKE_BUILD_TYPE=Release",
+                        "-DCLANG_ENABLE_ARCMT=OFF",
+                        "-DCLANG_ENABLE_CLANGD=OFF",
+                        "-DLLVM_BUILD_RUNTIME=OFF",
+                        "-DLLVM_CCACHE_BUILD=ON",
+                        "-DLLVM_INCLUDE_EXAMPLES=OFF",
+                        "-DLLVM_DEFAULT_TARGET_TRIPLE=x86_64-sie-ps5",
+                        "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_LIT_ARGS=--verbose -j100",
+                        "-DLLVM_TARGETS_TO_BUILD=X86",
+                        "-DLLVM_USE_LINKER=gold"])},
+
 # Expensive checks builders.
 
     {'name' : "llvm-clang-x86_64-expensive-checks-ubuntu",

--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -344,10 +344,12 @@ def getReporters():
                 utils.LLVMDefaultBuildStatusGenerator(
                     builders = [
                         "llvm-clang-x86_64-sie-ubuntu-fast",
+                        "llvm-clang-x86_64-sie-ps5-fast",
                         "llvm-clang-x86_64-sie-win",
                         "llvm-clang-x86_64-sie-win-release",
                         "llvm-clang-x86_64-gcc-ubuntu",
                         "llvm-clang-x86_64-gcc-ubuntu-release",
+                        "llvm-clang-x86_64-gcc-ubuntu-no-asserts",
                         "cross-project-tests-sie-ubuntu",
                         "cross-project-tests-sie-ubuntu-dwarf5",
                         "clang-x86_64-linux-abi-test",

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -324,7 +324,7 @@ def get_all():
         create_worker("thinlto-x86-64-bot1", properties={'jobs': 64}, max_builds=1),
         create_worker("thinlto-x86-64-bot2", properties={'jobs': 64}, max_builds=1),
 
-        # Ubuntu 20.04 on AWS, x86_64 PS4 target
+        # Ubuntu 22.04 on AWS, x86_64 PS4 target
         create_worker("sie-linux-worker", properties={'jobs': 40}, max_builds=1),
         # 2012 Mac Mini host, 16GB memory:
         #   - Ubuntu 18.04 in docker container
@@ -336,6 +336,8 @@ def get_all():
         # Ubuntu 20.04 on AWS, AMD EPYC 7R13 shared
         create_worker("sie-linux-worker2", max_builds=1),
         create_worker("sie-linux-worker3", max_builds=1),
+        # Ubuntu 22.04 on AWS, x86_64 PS5 target
+        create_worker("sie-linux-worker4", properties={'jobs': 40}, max_builds=1),
 
         # Windows Server 2019 on AWS, x86_64 PS4 target
         create_worker("sie-win-worker", properties={'jobs': 64}, max_builds=1),


### PR DESCRIPTION
This change adds a new fast linux builder that targets the PS5 (our current fast builder targets PS4), updates the list of bots I am notified about for failures and updates some worker descriptions.