### PR TITLE
Decouple Flang from WoA clang  buildbot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -296,7 +296,6 @@ all = [
                     checks=['check-all', 'check-runtimes'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64",
-                        "-DLLVM_ENABLE_RUNTIMES=compiler-rt;openmp",
                         "-DCLANG_DEFAULT_LINKER=lld",
                         "-DCMAKE_TRY_COMPILE_CONFIGURATION=Release",
                         "-DCOMPILER_RT_BUILD_SANITIZERS=OFF",

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -287,15 +287,16 @@ all = [
 # Clang builders.
 
     {'name': "clang-arm64-windows-msvc",
-    'tags' : ["llvm", "clang", "lld", "flang"],
+    'tags' : ["llvm", "clang", "lld"],
     'workernames' : ["linaro-armv8-windows-msvc-04"],
     'builddir': "clang-arm64-windows-msvc",
-    'factory' : ClangBuilder.getClangCMakeBuildFactory(
-                    vs="manual",
-                    clean=False,
-                    checkout_flang=True,
-                    checkout_lld=True,
-                    extra_cmake_args=[
+    'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                    depends_on_projects=['llvm', 'clang', 'clang-tools-extra',
+                                         'lld', 'compiler-rt', 'openmp'],
+                    checks=['check-all', 'check-runtimes'],
+                    extra_configure_args=[
+                        "-DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64",
+                        "-DLLVM_ENABLE_RUNTIMES=compiler-rt;openmp",
                         "-DCLANG_DEFAULT_LINKER=lld",
                         "-DCMAKE_TRY_COMPILE_CONFIGURATION=Release",
                         "-DCOMPILER_RT_BUILD_SANITIZERS=OFF",


### PR DESCRIPTION
This is a follow up patch from #398 and it removes Flang from the clang-arm64-windows-msvc builder.

This patch also introduces the following changes to clang-arm64-windows-msvc:

1) Switches to UnifiedTreeBuilder
2) Enables LLVM_ENABLE_RUNTIMES=compiler-rt;openmp
3) Restricts DLLVM_TARGETS_TO_BUILD to AArch64, ARM, and X86