### PR TITLE
[CI] Add BuildKite API secret reference

### DIFF
--- a/premerge/main.tf
+++ b/premerge/main.tf
@@ -355,6 +355,11 @@ data "google_secret_manager_secret_version" "metrics_grafana_metrics_userid" {
   secret = "llvm-premerge-metrics-grafana-metrics-userid"
 }
 
+data "google_secret_manager_secret_version" "metrics_buildkite_token" {
+  secret = "llvm-premerge-metrics-buildkite-graphql-token"
+}
+
+
 resource "kubernetes_namespace" "metrics" {
   metadata {
     name = "metrics"
@@ -371,6 +376,7 @@ resource "kubernetes_secret" "metrics_secrets" {
     "github-token"           = data.google_secret_manager_secret_version.metrics_github_pat.secret_data
     "grafana-api-key"        = data.google_secret_manager_secret_version.metrics_grafana_api_key.secret_data
     "grafana-metrics-userid" = data.google_secret_manager_secret_version.metrics_grafana_metrics_userid.secret_data
+    "buildkite-token"        = data.google_secret_manager_secret_version.metrics_buildkite_token.secret_data
   }
 
   type = "Opaque"

--- a/premerge/metrics_deployment.yaml
+++ b/premerge/metrics_deployment.yaml
@@ -34,6 +34,11 @@ spec:
             secretKeyRef:
               name: metrics-secrets
               key: grafana-metrics-userid
+        - name: BUILDKITE_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: metrics-secrets
+              key: buildkite-token
         resources:
           requests:
             cpu: "250m"


### PR DESCRIPTION
The metrics container only logs Github workflows. Since we want to compare the performance of the GCP based CI to BuildKite, it would be convenient to have the BuildKite metrics along the GCP metrics in Grafana.

This change references a newly added GCP secret the metrics container will be able to use to read BuildKite data.