### PR TITLE
LLVM_ENABLE_RUNTIMES=flang-rt for ppc64le-flang-rhel-clang

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2503,8 +2503,8 @@ all += [
     'builddir': 'ppc64le-flang-rhel-clang-build',
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
-                    depends_on_projects=['llvm', 'mlir', 'clang', 'flang','openmp'],
-                    checks=['check-flang'],
+                    depends_on_projects=['llvm', 'mlir', 'clang', 'flang','flang-rt','openmp'],
+                    checks=['check-flang','check-flang-rt'],
                     extra_configure_args=[
                         '-DLLVM_TARGETS_TO_BUILD=PowerPC',
                         '-DLLVM_INSTALL_UTILS=ON',


### PR DESCRIPTION
Add `depends_on_projects=['flang-rt']`, and `checks=['check-flang-rt']` to the ppc64le-flang-rhel-clang builder. The prepares the removal of the "projects" build of the flang runtime in https://github.com/llvm/llvm-project/pull/124126.

Split off from #333

Affected builders:
 * [ppc64le-flang-rhel-clang](https://lab.llvm.org/buildbot/#/builders/157)

Affected workers:
 * [ppc64le-flang-rhel-test](https://lab.llvm.org/buildbot/#/workers/152) (production)

Admins listed for those workers:
 * LLVM on Power <powerllvm@ca.ibm.com>
