### PR TITLE
LLVM_ENABLE_RUNTIMES=flang-rt for amdgpu-offload-*

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1961,7 +1961,7 @@ all += [
     'builddir': "amdgpu-offload-ubuntu-22-cmake-build-only",
     'collapseRequests' : False,
     'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
-                    depends_on_projects=["llvm", "clang", "flang", "mlir", "lld", "compiler-rt", "libcxx", "libcxxabi", "openmp", "offload", "libunwind"],
+                    depends_on_projects=["llvm", "clang", "flang", "flang-rt", "mlir", "lld", "compiler-rt", "libcxx", "libcxxabi", "openmp", "offload", "libunwind"],
                     script="amdgpu-offload-cmake.py",
                     checkout_llvm_sources=True,
                     script_interpreter=None
@@ -1973,7 +1973,7 @@ all += [
     'builddir': "amdgpu-offload-rhel-9-cmake-build-only",
     'collapseRequests' : False,
     'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
-                    depends_on_projects=["llvm", "clang", "flang", "mlir", "lld", "compiler-rt", "libcxx", "libcxxabi", "openmp", "offload", "libunwind"],
+                    depends_on_projects=["llvm", "clang", "flang", "flang-rt", "mlir", "lld", "compiler-rt", "libcxx", "libcxxabi", "openmp", "offload", "libunwind"],
                     script="amdgpu-offload-cmake.py",
                     checkout_llvm_sources=True,
                     script_interpreter=None
@@ -1985,7 +1985,7 @@ all += [
     'builddir': "amdgpu-offload-rhel-8-cmake-build-only",
     'collapseRequests' : False,
     'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
-                    depends_on_projects=["llvm", "clang", "flang", "mlir", "lld", "compiler-rt", "libcxx", "libcxxabi", "offload", "openmp", "libunwind"],
+                    depends_on_projects=["llvm", "clang", "flang", "flang-rt", "mlir", "lld", "compiler-rt", "libcxx", "libcxxabi", "offload", "openmp", "libunwind"],
                     script="amdgpu-offload-cmake.py",
                     checkout_llvm_sources=True,
                     script_interpreter=None


### PR DESCRIPTION
Add `depends_on_projects=['flang-rt']`, and `checks=['check-flang-rt']` to the ppc64le-flang-rhel-clang builder. The prepares the removal of the "projects" build of the flang runtime in https://github.com/llvm/llvm-project/pull/124126.

The corresponding change in the LLVM repository is https://github.com/llvm/llvm-project/pull/129692

Affected builders (production):
 * [amdgpu-offload-ubuntu-22-cmake-build-only](https://lab.llvm.org/buildbot/#/builders/203)
 * [amdgpu-offload-rhel-9-cmake-build-only](https://lab.llvm.org/buildbot/#/builders/205)
 * [amdgpu-offload-rhel-8-cmake-build-only](https://lab.llvm.org/buildbot/#/builders/204)

Affected workers (production):
 * [rocm-docker-ubu-22](https://lab.llvm.org/buildbot/#/workers/162)
 * [rocm-docker-rhel-9](https://lab.llvm.org/buildbot/#/workers/163)
 * [rocm-docker-rhel-8](https://lab.llvm.org/buildbot/#/workers/164)

Admins listed for those workers:
 * AMD <dl.gcr.lightning.buildbot@amd.com>
