### PR TITLE
[AMDGPU] Change CWD from within tmp directory

### DIFF
--- a/zorg/buildbot/builders/annotated/amdgpu-offload-cmake.py
+++ b/zorg/buildbot/builders/annotated/amdgpu-offload-cmake.py
@@ -19,7 +19,11 @@ def main(argv):
         # If we do not do this, the resident config will take precedence and changes
         # to the cache file are ignored.
         cwd = os.getcwd()
+        tdir = tempfile.mkdtemp()
+        os.chdir(tdir)
         util.clean_dir(cwd)
+        os.chdir(cwd)
+        util.rmtree(tdir)
 
     with step("cmake", halt_on_fail=True):
         # TODO make the name of the cache file an argument to the script.


### PR DESCRIPTION
As pointed out in https://github.com/llvm/llvm-zorg/pull/402 the former solution deleted the CWD from within that directory, rendering the state quite useless and resulting in errors on execution.

The approach in here creates a temp directory, changes to it, removes the old CWD, recreates it, and changes back to that directory. I opted for this solution as, oddly enough, I had some trouble removing the
  enumerated list of files in the buildtree.