### PR TITLE
[openmp-offload-amdgpu-clang-flang] Re-add FLANG_RUNTIME_F128_MATH_LIB

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2077,6 +2077,7 @@ all += [
                             "-DLLVM_ENABLE_ASSERTIONS=ON",
                             "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                             "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
+                            "-DFLANG_RUNTIME_F128_MATH_LIB=libquadmath",
                             "-DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON",
                             "-DCMAKE_CXX_STANDARD=17",
                             "-DBUILD_SHARED_LIBS=ON",


### PR DESCRIPTION
The option was removed in #395. After https://github.com/llvm/llvm-project/pull/130411, the option should now work even when compiling flang-rt with Clang.