### PR TITLE
Add a new build bot to test key instructions feature.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1055,6 +1055,25 @@ all = [
                         "-DLLVM_USE_LINKER=gold",
                         "-DLLVM_ENABLE_WERROR=OFF"])},
 
+    {'name': "llvm-clang-key-instructions",
+    'tags'  : ["llvm", "clang", "compiler-rt", "lld", "cross-project-tests"],
+    'workernames': ["sie-linux-worker5"],
+    'builddir': "llvm-ki",
+    'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                    depends_on_projects=['llvm','clang','compiler-rt','lld','cross-project-tests'],
+                    extra_configure_args=[
+                        "-DCMAKE_C_COMPILER=gcc",
+                        "-DCMAKE_CXX_COMPILER=g++",
+                        "-DCMAKE_BUILD_TYPE=Release",
+                        "-DCLANG_ENABLE_CLANGD=OFF",
+                        "-DLLVM_BUILD_RUNTIME=ON",
+                        "-DLLVM_BUILD_TESTS=ON",
+                        "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_EXPERIMENTAL_KEY_INSTRUCTIONS=ON",
+                        "-DLLVM_INCLUDE_EXAMPLES=OFF",
+                        "-DLLVM_LIT_ARGS=--verbose",
+                        "-DLLVM_USE_LINKER=gold"])},
+
     {'name': "llvm-clang-x86_64-darwin",
     'tags'  : ["llvm", "clang", "clang-tools-extra", "lld", "cross-project-tests"],
     'workernames': ["doug-worker-3"],

--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -355,7 +355,8 @@ def getReporters():
                         "clang-x86_64-linux-abi-test",
                         "llvm-clang-x86_64-darwin",
                         "llvm-clang-aarch64-darwin",
-                        "llvm-clang-aarch64-darwin-release"])
+                        "llvm-clang-aarch64-darwin-release",
+                        "llvm-clang-key-instructions"])
             ]),
         reporters.MailNotifier(
             fromaddr = status_email_fromaddr,
@@ -367,16 +368,6 @@ def getReporters():
                         "llvm-clang-x86_64-sie-ubuntu-fast",
                         "llvm-clang-x86_64-sie-win",
                         "llvm-clang-x86_64-gcc-ubuntu"])
-            ]),
-        reporters.MailNotifier(
-            fromaddr=status_email_fromaddr,
-            sendToInterestedUsers = False,
-            extraRecipients = [
-                "jeremy.morse.llvm@gmail.com"],
-            generators = [
-                utils.LLVMDefaultBuildStatusGenerator(
-                    builders = [
-                        "llvm-new-debug-iterators"])
             ]),
         reporters.MailNotifier(
             dumpMailsToLog = True, # TODO: For debug purposes only. Remove this later.
@@ -486,7 +477,8 @@ def getReporters():
                 utils.LLVMDefaultBuildStatusGenerator(
                     builders = [
                         "cross-project-tests-sie-ubuntu",
-                        "llvm-clang-x86_64-sie-win"])
+                        "llvm-clang-x86_64-sie-win",
+                        "llvm-clang-key-instructions"])
             ]),
         reporters.MailNotifier(
             fromaddr = status_email_fromaddr,

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -339,6 +339,8 @@ def get_all():
         create_worker("sie-linux-worker3", max_builds=1),
         # Ubuntu 22.04 on AWS, x86_64 PS5 target
         create_worker("sie-linux-worker4", properties={'jobs': 40}, max_builds=1),
+        # Ubuntu 22.04 on AWS
+        create_worker("sie-linux-worker5", max_builds=1),
 
         # Windows Server 2019 on AWS, x86_64 PS4 target
         create_worker("sie-win-worker", properties={'jobs': 64}, max_builds=1),


### PR DESCRIPTION
 - Adds a new builder llvm-clang-key-instructions
 - Adds a new worker sie-linux-worker5
 - Removes a no longer needed Mail Notifier for a decomissioned builder
 - Adds email notification to myself and Orlando for the new key instructions build bot