### PR TITLE
[AMDGPU] Adjust xfail tests

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1944,7 +1944,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                         ],
                         add_lit_checks=['check-offload'],
-                        add_openmp_lit_args=["--time-tests", "--timeout 100"],
+                        add_openmp_lit_args=["--time-tests", "--timeout 100", "--xfail=affinity/format/proc_bind.c"],
                     )},
 
     {'name' : "openmp-offload-amdgpu-runtime-2",


### PR DESCRIPTION
The containerized runner is executing on a certain CPU set. This seems to confuse the specific test and makes it fail.
xfail it therefore.