### PR TITLE
Update setup of LNT to handle python 3.12+

### DIFF
--- a/zorg/buildbot/builders/ClangBuilder.py
+++ b/zorg/buildbot/builders/ClangBuilder.py
@@ -615,6 +615,12 @@ def _getClangCMakeBuildFactory(
                                description='recreating sandbox',
                                workdir='test',
                                env=env))
+        f.addStep(ShellCommand(name='install lnt dependencies',
+                               command=[python, '-m', 'pip', 'install', 'setuptools'],
+                               haltOnFailure=True,
+                               description='install lnt dependencies',
+                               workdir='test/sandbox',
+                               env=env))
         f.addStep(ShellCommand(name='setup lit',
                                command=[python, lnt_setup, 'develop'],
                                haltOnFailure=True,


### PR DESCRIPTION
Virtualenv in python 3.12+ no longer installs setuptools by default, see [1].  This patch adds a "pip install setuptools" step to ClangBuilder.py.

Note that running
$ VIRTUALENV_SETUPTOOLS=bundle virtualenv sandbox
will install an older/incompatible version of setuptools, at least on Ubuntu 24.04 system.

[1] https://virtualenv.pypa.io/en/latest/user_guide.html#seeders