### PR TITLE
AIX: Default SANITIZER_DISABLE_SYMBOLIZER_PATH_SEARCH to ON

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2632,7 +2632,7 @@ all += [
                         "-DPython3_EXECUTABLE:FILEPATH=python3",
                         "-DLLVM_ENABLE_ZLIB=OFF", "-DLLVM_APPEND_VC_REV=OFF",
                         "-DLLVM_PARALLEL_LINK_JOBS=2",
-
+                        "-DSANITIZER_DISABLE_SYMBOLIZER_PATH_SEARCH:BOOL=ON",
                     ],
                     env={
                         'CC': 'clang',

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -780,7 +780,8 @@ all = [
                         "-DPython3_EXECUTABLE:FILEPATH=python3",
                         "-DLLVM_ENABLE_ZLIB=OFF", "-DLLVM_APPEND_VC_REV=OFF",
                         "-DLLVM_PARALLEL_LINK_JOBS=2",
-                        "-DLLVM_ENABLE_WERROR=ON"]),
+                        "-DLLVM_ENABLE_WERROR=ON",
+                        "-DSANITIZER_DISABLE_SYMBOLIZER_PATH_SEARCH:BOOL=ON"]),
     'env' : {'OBJECT_MODE': '64'}},
 
     {'name' : "clang-s390x-linux",


### PR DESCRIPTION
llvm/llvm-project#129012 added a new CMake flag. This flag is used by IBM's downstream builds.

This patch sets the flag on the community buildbot for AIX to ensure upstream coverage and visibility.