### PR TITLE
[CI] Bump CI Container Version

### DIFF
--- a/premerge/linux_runners_values.yaml
+++ b/premerge/linux_runners_values.yaml
@@ -18,7 +18,7 @@ template:
       premerge-platform: linux
     containers:
     - name: runner
-      image: ghcr.io/llvm/ci-ubuntu-22.04-agent:latest
+      image: ghcr.io/llvm/ci-ubuntu-24.04-agent:latest
       command: ["/home/gha/actions-runner/run.sh"]
       resources:
         # If we don't set the CPU request high-enough here, 2 runners might


### PR DESCRIPTION
We recently bumped the CI container from Ubuntu 22.04 to 24.04 in the monorepo. This patch bumps the version here to keep up with the updates, especially given that the bump means the 22.04 version is not really supported/maintained upstream anymore.