### PR TITLE
[libc][AMDGPU] Add libc to the runtimes list

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1953,7 +1953,7 @@ all += [
     'builddir': "openmp-offload-amdgpu-runtime-2",
     'factory' : OpenMPBuilder.getOpenMPCMakeBuildFactory(
                         clean=True,
-                        enable_runtimes=['compiler-rt', 'libunwind', 'libcxx', 'libcxxabi', 'openmp', 'offload'],
+                        enable_runtimes=['compiler-rt', 'libunwind', 'libc', 'libcxx', 'libcxxabi', 'openmp', 'offload'],
                         depends_on_projects=['llvm','clang','lld', 'offload', 'openmp', 'compiler-rt', 'libunwind', 'libcxx', 'libcxxabi', 'libc'],
                         extraCmakeArgs=[
                             "-DCMAKE_BUILD_TYPE=Release",


### PR DESCRIPTION
It appears that if something is contained in the `depends_on_project` list but is not explicitly mentioned as an `enable_runtimes`, while also an explicit `enable_runtimes` list is passed to the unified tree builder, that component is auto-added as an `LLVM_ENABLE_PROJECTS`. This is wrong in the case of libc.

Wile we only care about the version being built for AMDGPU, this appears to be the easiest fix to unblock our libc bot.