### PR TITLE
presubmit: remove version fix on github PAT secret

### DIFF
--- a/premerge/main.tf
+++ b/premerge/main.tf
@@ -342,9 +342,6 @@ resource "helm_release" "grafana-k8s-monitoring" {
 
 data "google_secret_manager_secret_version" "metrics_github_pat" {
   secret = "llvm-premerge-metrics-github-pat"
-  # TODO(boomanaiden154): Remove this once the latest version is not destroyed
-  # and we do not need this anymore.
-  version = "4"
 }
 
 data "google_secret_manager_secret_version" "metrics_grafana_api_key" {


### PR DESCRIPTION
The version was fixed, which prevents us from updating the secret in one step.
PAT token was about to expire, needed regen.