### PR TITLE
[fuchsia] Downgrade cmake from latest to release from Ubuntu jammy

### DIFF
--- a/buildbot/fuchsia/Dockerfile
+++ b/buildbot/fuchsia/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
     ca-certificates \
     ccache \
+    cmake \
     curl \
     dumb-init \
     git \
@@ -26,13 +27,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
+# TODO(zeroomega): Temporarily switch back to cmake from Ubuntu to avoid
+#                  build errors on baremetal runtimes.
 # Install latest CMake release.
-RUN curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | \
-    gpg --dearmor -o /usr/share/keyrings/kitware-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main" | \
-    tee /etc/apt/sources.list.d/kitware.list && \
-    apt-get update && apt-get install -y --no-install-recommends cmake && \
-    rm -rf /var/lib/apt/lists/*
+# RUN curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | \
+#    gpg --dearmor -o /usr/share/keyrings/kitware-archive-keyring.gpg && \
+#    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main" | \
+#    tee /etc/apt/sources.list.d/kitware.list && \
+#    apt-get update && apt-get install -y --no-install-recommends cmake && \
+#    rm -rf /var/lib/apt/lists/*
 
 ARG LLVM_VERSION=19
 


### PR DESCRIPTION
The CMake 4.0 no longer allow adding a shared library target when
the target platform is a baremetal platform. This change downgrades
the cmake from 4.0 to jammy release (3.22) to mitigate this issue.
