### PR TITLE
Fix flang-aarch64-libcxx builder

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2489,6 +2489,9 @@ all += [
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
                         "-DLLVM_ENABLE_LIBCXX=On",
                         "-DCMAKE_BUILD_TYPE=Release",
+                        "-DLLVM_RUNTIME_TARGETS=aarch64-unknown-linux-gnu",
+                        "-DRUNTIMES_aarch64-unknown-linux-gnu_CMAKE_CXX_COMPILER='c++'",
+                        "-DRUNTIMES_aarch64-unknown-linux-gnu_CMAKE_C_COMPILER='cc'"
                         ])},
 
     {'name' : "flang-aarch64-release",

--- a/zorg/buildbot/builders/FlangBuilder.py
+++ b/zorg/buildbot/builders/FlangBuilder.py
@@ -138,10 +138,22 @@ def getFlangOutOfTreeBuildFactory(
         )
     )
 
+    # 'check-flang-rt' becomes 'check-flang-rt-<target>' when a runtime target
+    # is specified.
+    check_flang_rt = 'check-flang-rt'
+    for arg in llvm_extra_configure_args:
+        if arg.find("DLLVM_RUNTIME_TARGETS") != -1:
+            targets = arg.split('=', 1)[1]
+            # Currently only one target is supported.
+            if not targets or targets.find(";") != -1:
+                break
+            check_flang_rt += '-' + targets
+            break
+
     addNinjaSteps(
        f,
        obj_dir=flang_rt_obj_dir,
-       checks=['check-flang-rt'],
+       checks=[check_flang_rt],
        env=env,
        stage_name="flang-rt",
        **kwargs)


### PR DESCRIPTION
After flang-rt, flang-aarch64-libcxx builder started to fail.
Before it, llvm libraries, flang and its runtime were built with the
host compiler, but now flang runtime is built with the stage 1 clang.
The problem is that the C++ library of these compilers may be
incompatible. The linked issue has more details.

To avoid this issue, build flang-rt with the host compiler.

Fixes https://github.com/llvm/llvm-project/issues/135381
