### PR TITLE
[Fuchsia] Install libxml2 development package

### DIFF
--- a/buildbot/fuchsia/Dockerfile
+++ b/buildbot/fuchsia/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     dumb-init \
     git \
     gpg \
+    libxml2-dev \
     lsb-release \
     ninja-build \
     python-is-python3 \


### PR DESCRIPTION
This is required by llvm-mt as of
https://github.com/llvm/llvm-project/pull/134631.