### PR TITLE
Clean build directory in cmake monolithic windows

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3450,6 +3450,7 @@ all += [
                     depends_on_projects=["clang-tools-extra", "clang", "libclc", "lld", "llvm", "mlir", "polly", "pstl"],
                     checks=["check-all"],
                     install_pip_requirements = True,
+                    clean = True,
                     extra_configure_args=[
                         "-DCMAKE_BUILD_TYPE=Release",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",


### PR DESCRIPTION
https://discourse.llvm.org/t/possible-issue-with-premerge-monolithic-windows/86070 showed some issues due to a dirty cache. We should be cleaning the build directory after each build and letting sccache handle all of the caching

This is for the old infrastructure which should be turned down in a couple weeks, but it's a simple enough patch in the mean time.