### PR TITLE
[CI] Refactor GKE cluster creation into a module

### DIFF
--- a/premerge/gke_cluster/main.tf
+++ b/premerge/gke_cluster/main.tf
@@ -1,0 +1,92 @@
+resource "google_container_cluster" "llvm_premerge" {
+  name     = var.cluster_name
+  location = var.region
+
+  # We can't create a cluster with no node pool defined, but we want to only use
+  # separately managed node pools. So we create the smallest possible default
+  # node pool and immediately delete it.
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  # Set the networking mode to VPC Native to enable IP aliasing, which is required
+  # for adding windows nodes to the cluster.
+  networking_mode = "VPC_NATIVE"
+  ip_allocation_policy {}
+}
+
+resource "google_container_node_pool" "llvm_premerge_linux_service" {
+  name       = "llvm-premerge-linux-service"
+  location   = var.region
+  cluster    = google_container_cluster.llvm_premerge.name
+  node_count = 3
+
+  node_config {
+    machine_type = "e2-highcpu-4"
+  }
+}
+
+resource "google_container_node_pool" "llvm_premerge_linux" {
+  name               = "llvm-premerge-linux"
+  location           = var.region
+  cluster            = google_container_cluster.llvm_premerge.name
+  initial_node_count = 0
+
+  autoscaling {
+    total_min_node_count = 0
+    total_max_node_count = 8
+  }
+
+  node_config {
+    machine_type = "n2-standard-64"
+    taint {
+      key    = "premerge-platform"
+      value  = "linux"
+      effect = "NO_SCHEDULE"
+    }
+    labels = {
+      "premerge-platform" : "linux"
+    }
+    disk_size_gb = 200
+    # Terraform wants to recreate the node pool everytime whe running
+    # terraform apply unless we explicitly set this.
+    # TODO(boomanaiden154): Look into why terraform is doing this so we do
+    # not need this hack.
+    resource_labels = {
+      "goog-gke-node-pool-provisioning-model" = "on-demand"
+    }
+  }
+}
+
+resource "google_container_node_pool" "llvm_premerge_windows" {
+  name               = "llvm-premerge-windows"
+  location           = var.region
+  cluster            = google_container_cluster.llvm_premerge.name
+  initial_node_count = 0
+
+  autoscaling {
+    total_min_node_count = 0
+    total_max_node_count = 16
+  }
+
+  # We do not set a taint for the windows nodes as kubernetes by default sets
+  # a node.kubernetes.io/os taint for windows nodes.
+  node_config {
+    machine_type = "n2-standard-32"
+    labels = {
+      "premerge-platform" : "windows"
+    }
+    image_type = "WINDOWS_LTSC_CONTAINERD"
+    # Add a script that runs on the initial boot to disable Windows Defender.
+    # Windows Defender causes an increase in test times by approximately an
+    # order of magnitude.
+    metadata = {
+      "sysprep-specialize-script-ps1" = "Set-MpPreference -DisableRealtimeMonitoring $true"
+      # Terraform wants to recreate the node pool everytime whe running
+      # terraform apply unless we explicitly set this.
+      # TODO(boomanaiden154): Look into why terraform is doing this so we do
+      # not need this hack.
+      "disable-legacy-endpoints" = "true"
+    }
+    disk_size_gb = 200
+  }
+}

--- a/premerge/gke_cluster/outputs.tf
+++ b/premerge/gke_cluster/outputs.tf
@@ -1,0 +1,15 @@
+output "endpoint" {
+  value = google_container_cluster.llvm_premerge.endpoint
+}
+
+output "client_certificate" {
+  value = google_container_cluster.llvm_premerge.master_auth.0.client_certificate
+}
+
+output "client_key" {
+  value = google_container_cluster.llvm_premerge.master_auth.0.client_key
+}
+
+output "cluster_ca_certificate" {
+  value = google_container_cluster.llvm_premerge.master_auth.0.cluster_ca_certificate
+}

--- a/premerge/gke_cluster/variables.tf
+++ b/premerge/gke_cluster/variables.tf
@@ -1,0 +1,9 @@
+variable "cluster_name" {
+  description = "The name of the cluster"
+  type        = string
+}
+
+variable "region" {
+  description = "The region to run the cluster in"
+  type        = string
+}

--- a/premerge/main.tf
+++ b/premerge/main.tf
@@ -43,106 +43,41 @@ resource "local_file" "terraform_state" {
 
 data "google_client_config" "current" {}
 
-resource "google_container_cluster" "llvm_premerge" {
-  name     = var.cluster_name
-  location = "us-central1-a"
-
-  # We can't create a cluster with no node pool defined, but we want to only use
-  # separately managed node pools. So we create the smallest possible default
-  # node pool and immediately delete it.
-  remove_default_node_pool = true
-  initial_node_count       = 1
-
-  # Set the networking mode to VPC Native to enable IP aliasing, which is required
-  # for adding windows nodes to the cluster.
-  networking_mode = "VPC_NATIVE"
-  ip_allocation_policy {}
+module "premerge_cluster" {
+  source       = "./gke_cluster"
+  cluster_name = "llvm-premerge-prototype"
+  region       = "us-central1-a"
 }
 
-resource "google_container_node_pool" "llvm_premerge_linux_service" {
-  name       = "llvm-premerge-linux-service"
-  location   = "us-central1-a"
-  cluster    = google_container_cluster.llvm_premerge.name
-  node_count = 3
-
-  node_config {
-    machine_type = "e2-highcpu-4"
-  }
+# TODO(boomanaiden154): Remove these moved blocks once we have finished
+# updating everything to use the new module.
+moved {
+  from = google_container_cluster.llvm_premerge
+  to   = module.premerge_cluster.google_container_cluster.llvm_premerge
 }
 
-resource "google_container_node_pool" "llvm_premerge_linux" {
-  name               = "llvm-premerge-linux"
-  location           = "us-central1-a"
-  cluster            = google_container_cluster.llvm_premerge.name
-  initial_node_count = 0
-
-  autoscaling {
-    total_min_node_count = 0
-    total_max_node_count = 8
-  }
-
-  node_config {
-    machine_type = "n2-standard-64"
-    taint {
-      key    = "premerge-platform"
-      value  = "linux"
-      effect = "NO_SCHEDULE"
-    }
-    labels = {
-      "premerge-platform" : "linux"
-    }
-    disk_size_gb = 200
-    # Terraform wants to recreate the node pool everytime whe running
-    # terraform apply unless we explicitly set this.
-    # TODO(boomanaiden154): Look into why terraform is doing this so we do
-    # not need this hack.
-    resource_labels = {
-      "goog-gke-node-pool-provisioning-model" = "on-demand"
-    }
-  }
+moved {
+  from = google_container_node_pool.llvm_premerge_linux
+  to   = module.premerge_cluster.google_container_node_pool.llvm_premerge_linux
 }
 
-resource "google_container_node_pool" "llvm_premerge_windows" {
-  name               = "llvm-premerge-windows"
-  location           = "us-central1-a"
-  cluster            = google_container_cluster.llvm_premerge.name
-  initial_node_count = 0
+moved {
+  from = google_container_node_pool.llvm_premerge_linux_service
+  to   = module.premerge_cluster.google_container_node_pool.llvm_premerge_linux_service
+}
 
-  autoscaling {
-    total_min_node_count = 0
-    total_max_node_count = 16
-  }
-
-  # We do not set a taint for the windows nodes as kubernetes by default sets
-  # a node.kubernetes.io/os taint for windows nodes.
-  node_config {
-    machine_type = "n2-standard-32"
-    labels = {
-      "premerge-platform" : "windows"
-    }
-    image_type = "WINDOWS_LTSC_CONTAINERD"
-    # Add a script that runs on the initial boot to disable Windows Defender.
-    # Windows Defender causes an increase in test times by approximately an
-    # order of magnitude.
-    metadata = {
-      "sysprep-specialize-script-ps1" = "Set-MpPreference -DisableRealtimeMonitoring $true"
-      # Terraform wants to recreate the node pool everytime whe running
-      # terraform apply unless we explicitly set this.
-      # TODO(boomanaiden154): Look into why terraform is doing this so we do
-      # not need this hack.
-      "disable-legacy-endpoints" = "true"
-    }
-    disk_size_gb = 200
-  }
+moved {
+  from = google_container_node_pool.llvm_premerge_windows
+  to   = module.premerge_cluster.google_container_node_pool.llvm_premerge_windows
 }
 
 provider "helm" {
   kubernetes {
-    host                   = google_container_cluster.llvm_premerge.endpoint
+    host                   = module.premerge_cluster.endpoint
     token                  = data.google_client_config.current.access_token
-    client_certificate     = base64decode(google_container_cluster.llvm_premerge.master_auth.0.client_certificate)
-    client_key             = base64decode(google_container_cluster.llvm_premerge.master_auth.0.client_key)
-    cluster_ca_certificate = base64decode(google_container_cluster.llvm_premerge.master_auth.0.cluster_ca_certificate)
+    client_certificate     = base64decode(module.premerge_cluster.client_certificate)
+    client_key             = base64decode(module.premerge_cluster.client_key)
+    cluster_ca_certificate = base64decode(module.premerge_cluster.cluster_ca_certificate)
   }
 }
 
@@ -163,10 +98,10 @@ data "google_secret_manager_secret_version" "grafana_token" {
 }
 
 provider "kubernetes" {
-  host  = "https://${google_container_cluster.llvm_premerge.endpoint}"
+  host  = "https://${module.premerge_cluster.endpoint}"
   token = data.google_client_config.current.access_token
   cluster_ca_certificate = base64decode(
-    google_container_cluster.llvm_premerge.master_auth[0].cluster_ca_certificate,
+    module.premerge_cluster.cluster_ca_certificate
   )
 }
 


### PR DESCRIPTION
This patch refactors GKE cluster creation into a module. This enables reuse
later on when we want to create a new cluster in a different region for a
HA setup.
