### PR TITLE
[s390x] Make stage 2 builder use clean builds

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -805,9 +805,10 @@ all = [
     'builddir': "clang-s390x-linux-multistage",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     jobs=4,
-                    clean=False,
+                    clean=True,
                     checkout_lld=False,
                     useTwoStage=True,
+                    testStage1=False,
                     stage1_config='Release',
                     stage2_config='Release',
                     extra_cmake_args=[


### PR DESCRIPTION
Use clean builds for the s390x multistage builder as was done for Linaro in https://github.com/llvm/llvm-zorg/pull/306.  This will enable collapsing build requests to help the builder keep up.

As further speed-up, skip the stage 1 testing, as is already done for most other multistage builders.