### PR TITLE
Update configuration for llvm-clang-x86_64-expensive-checks-ubuntu* builders

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -152,24 +152,34 @@ all = [
     'tags'  : ["llvm", "expensive-checks"],
     'workernames' : ["as-builder-4"],
     'builddir': "expensive-checks",
-    'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
-                    depends_on_projects=["llvm", "lld"],
-                    clean=True,
-                    extra_configure_args=[
-                        "-DLLVM_CCACHE_BUILD=ON",
-                        "-DLLVM_ENABLE_EXPENSIVE_CHECKS=ON",
-                        "-DLLVM_ENABLE_WERROR=OFF",
-                        "-DLLVM_USE_SPLIT_DWARF=ON",
-                        "-DLLVM_USE_LINKER=gold",
-                        "-DCMAKE_BUILD_TYPE=Debug",
-                        "-DCMAKE_CXX_FLAGS=-U_GLIBCXX_DEBUG -Wno-misleading-indentation",
-                        "-DLLVM_LIT_ARGS=-vv --time-tests"],
-                    env={
-                        'CCACHE_DIR' : util.Interpolate("%(prop:builddir)s/ccache-db"),
+    'factory' : UnifiedTreeBuilder.getCmakeExBuildFactory(
+                    depends_on_projects = [
+                        'llvm',
+                        'lld',
+                    ],
+                    clean = True,
+                    checks = [
+                        "check-all"
+                    ],
+                    cmake_definitions = {
+                        "LLVM_CCACHE_BUILD"             : "ON",
+                        "LLVM_ENABLE_EXPENSIVE_CHECKS"  : "ON",
+                        "LLVM_ENABLE_WERROR"            : "OFF",
+                        "LLVM_USE_LINKER"               : "lld-21",
+                        "LLVM_LIT_ARGS"                 : "-vv --time-tests",
+                        "CMAKE_BUILD_TYPE"              : "Release",
+                        "CMAKE_CXX_FLAGS"               : "-U_GLIBCXX_DEBUG -Wno-misleading-indentation",
+                    },
+                    env = {
+                        'CC'            : "clang-21",
+                        'CXX'           : "clang++-21",
+                        'CCACHE_DIR'    : util.Interpolate("%(prop:builddir)s/ccache-db"),
                         # TMP/TEMP within the build dir (to utilize a ramdisk).
-                        'TMP'        : util.Interpolate("%(prop:builddir)s/build"),
-                        'TEMP'       : util.Interpolate("%(prop:builddir)s/build"),
-                    })},
+                        'TMP'           : util.Interpolate("%(prop:builddir)s/build"),
+                        'TEMP'          : util.Interpolate("%(prop:builddir)s/build"),
+                    },
+                )
+        },
 
     {'name' : "llvm-clang-x86_64-expensive-checks-win",
     'tags'  : ["llvm", "expensive-checks"],

--- a/buildbot/osuosl/master/config/release_builders.py
+++ b/buildbot/osuosl/master/config/release_builders.py
@@ -50,21 +50,31 @@ all = [
     'tags'  : ["llvm", "expensive-checks"],
     'workernames' : ["as-builder-4-rel"],
     'builddir': "llvm-clang-x86_64-expensive-checks-ubuntu-rel",
-    'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
-                    depends_on_projects=["llvm", "lld"],
-                    clean=True,
-                    extra_configure_args=[
-                        "-DLLVM_CCACHE_BUILD=ON",
-                        "-DLLVM_ENABLE_EXPENSIVE_CHECKS=ON",
-                        "-DLLVM_ENABLE_WERROR=OFF",
-                        "-DLLVM_USE_SPLIT_DWARF=ON",
-                        "-DLLVM_USE_LINKER=gold",
-                        "-DCMAKE_BUILD_TYPE=Debug",
-                        "-DCMAKE_CXX_FLAGS=-U_GLIBCXX_DEBUG -Wno-misleading-indentation",
-                        "-DLLVM_LIT_ARGS=-vv --time-tests"],
-                    env={
-                        'CCACHE_DIR' : util.Interpolate("%(prop:builddir)s/ccache-db"),
-                    })},
+    'factory' : UnifiedTreeBuilder.getCmakeExBuildFactory(
+                    depends_on_projects = [
+                        'llvm',
+                        'lld',
+                    ],
+                    clean = True,
+                    checks = [
+                        "check-all"
+                    ],
+                    cmake_definitions = {
+                        "LLVM_CCACHE_BUILD"             : "ON",
+                        "LLVM_ENABLE_EXPENSIVE_CHECKS"  : "ON",
+                        "LLVM_ENABLE_WERROR"            : "OFF",
+                        "LLVM_USE_LINKER"               : "lld-21",
+                        "LLVM_LIT_ARGS"                 : "-vv --time-tests",
+                        "CMAKE_BUILD_TYPE"              : "Release",
+                        "CMAKE_CXX_FLAGS"               : "-U_GLIBCXX_DEBUG -Wno-misleading-indentation",
+                    },
+                    env = {
+                        'CC'            : "clang-21",
+                        'CXX'           : "clang++-21",
+                        'CCACHE_DIR'    : util.Interpolate("%(prop:builddir)s/ccache-db"),
+                    },
+                )
+        },
 
     {'name' : "llvm-clang-x86_64-expensive-checks-debian-release",
     'tags'  : ["llvm", "expensive-checks"],


### PR DESCRIPTION
* switch to clang-21/lld-21 instead of gcc/ld.gold to speed up the builds and avoid the ld.gold liner warnings related with unsupported DWARF version.
* switch to release build to speed up the builds because of clang/llvm table-gen tool.

Also moved to 'UnifiedTreeBuilder.getCmakeExBuildFactory' factory.