### PR TITLE
Skip LNT submission

### DIFF
--- a/tasks/utils/lnt_submit.sh
+++ b/tasks/utils/lnt_submit.sh
@@ -1,11 +1,13 @@
 echo "@@@ LNT Submit @@@"
 
-if [ -n "${SUBMIT_URL:=}" -a -n "${SUBMIT_NAME:=}" ]; then
-    LNT_RESULT_URL="$(lnt submit "${SUBMIT_URL}" "${WORKSPACE}/lnt-sandbox/report.json")"
-    # Jenkins builds look for this message:
-    echo "Results available at: ${LNT_RESULT_URL}"
-else
-    echo 1>&2 "Skipping submission: SUBMIT_URL/SUBMIT_NAME not defined"
-fi
+echo "Skipping LNT submission temporarily until a permanent LNT server is configured"
+
+#if [ -n "${SUBMIT_URL:=}" -a -n "${SUBMIT_NAME:=}" ]; then
+#    LNT_RESULT_URL="$(lnt submit "${SUBMIT_URL}" "${WORKSPACE}/lnt-sandbox/report.json")"
+#    # Jenkins builds look for this message:
+#    echo "Results available at: ${LNT_RESULT_URL}"
+#else
+#    echo 1>&2 "Skipping submission: SUBMIT_URL/SUBMIT_NAME not defined"
+#fi
 
 echo "@@@@@@@"


### PR DESCRIPTION
Skip LNT submission so that the jobs aren't reporting failure status. There is not a stable LNT server setup as of right now

This will allow us to at least get build status from the green dragon LNT jobs