### PR TITLE
[GreenDragon] Bump Clang Stage 1 RA Build timeout to 120min

### DIFF
--- a/zorg/jenkins/jobs/jobs/clang-stage1-RA
+++ b/zorg/jenkins/jobs/jobs/clang-stage1-RA
@@ -62,7 +62,7 @@ pipeline {
                 MACOSX_DEPLOYMENT_TARGET="13.6"
             }
             steps {
-                timeout(90) {
+                timeout(120) {
                     withCredentials([string(credentialsId: 's3_resource_bucket', variable: 'S3_BUCKET')]) {
                         sh '''
                         set -u


### PR DESCRIPTION
There are recent timeouts for 90min. Extend the timeout to make sure the job can finish.