### PR TITLE
[CI] Make US West cluster use SSDs for Windows nodes

### DIFF
--- a/premerge/gke_cluster/main.tf
+++ b/premerge/gke_cluster/main.tf
@@ -96,6 +96,7 @@ resource "google_container_node_pool" "llvm_premerge_windows" {
       "disable-legacy-endpoints" = "true"
     }
     disk_size_gb = 200
+    disk_type = var.windows_disk_type
     # Terraform wants to recreate the node pool everytime whe running
     # terraform apply unless we explicitly set this.
     # TODO(boomanaiden154): Look into why terraform is doing this so we do

--- a/premerge/gke_cluster/variables.tf
+++ b/premerge/gke_cluster/variables.tf
@@ -23,3 +23,9 @@ variable "service_node_pool_locations" {
   type        = list(any)
   default     = null
 }
+
+variable "windows_disk_type" {
+  description = "The GCP disk type to use for the windows node boot disks"
+  type = string
+  default = "pd-balanced"
+}

--- a/premerge/main.tf
+++ b/premerge/main.tf
@@ -62,6 +62,10 @@ module "premerge_cluster_us_west" {
   linux_machine_type          = "n2d-standard-64"
   windows_machine_type        = "n2d-standard-32"
   service_node_pool_locations = ["us-west1-a"]
+  # TODO(boomanaiden154): Remove this once the experiment is over, either
+  # reverting to how everything was before or making this the default within
+  # the gke_cluster module.
+  windows_disk_type = "pd-ssd"
 }
 
 provider "helm" {


### PR DESCRIPTION
We have seen some decent performance improvements using SSDs for windows nodes particularly in regards to container image pull times (about 30%). This patch parameterizes gke_cluster to enable setting the window_disk_type on one cluster so we can run an A/B test to make sure the expected gains translate to production.