### PR TITLE
[CI] Migrate all windows node pools to pd-ssd

### DIFF
--- a/premerge/gke_cluster/main.tf
+++ b/premerge/gke_cluster/main.tf
@@ -96,7 +96,7 @@ resource "google_container_node_pool" "llvm_premerge_windows" {
       "disable-legacy-endpoints" = "true"
     }
     disk_size_gb = 200
-    disk_type = var.windows_disk_type
+    disk_type = "pd-ssd"
     # Terraform wants to recreate the node pool everytime whe running
     # terraform apply unless we explicitly set this.
     # TODO(boomanaiden154): Look into why terraform is doing this so we do

--- a/premerge/gke_cluster/variables.tf
+++ b/premerge/gke_cluster/variables.tf
@@ -23,9 +23,3 @@ variable "service_node_pool_locations" {
   type        = list(any)
   default     = null
 }
-
-variable "windows_disk_type" {
-  description = "The GCP disk type to use for the windows node boot disks"
-  type = string
-  default = "pd-balanced"
-}

--- a/premerge/main.tf
+++ b/premerge/main.tf
@@ -62,10 +62,6 @@ module "premerge_cluster_us_west" {
   linux_machine_type          = "n2d-standard-64"
   windows_machine_type        = "n2d-standard-32"
   service_node_pool_locations = ["us-west1-a"]
-  # TODO(boomanaiden154): Remove this once the experiment is over, either
-  # reverting to how everything was before or making this the default within
-  # the gke_cluster module.
-  windows_disk_type = "pd-ssd"
 }
 
 provider "helm" {


### PR DESCRIPTION
This migrates the other windows node pool in us-central1-a to pd-ssd boot disks as well. We saw some small performance improvements from doing this (~5%). Less than expected, but significant enough to ship.