### PR TITLE
[GreenDragon] Extend lit timeout for sanitizer bot

### DIFF
--- a/zorg/jenkins/build.py
+++ b/zorg/jenkins/build.py
@@ -307,7 +307,7 @@ def cmake_builder(target):
         cmake_cmd += ['-DCMAKE_CXX_COMPILER_LAUNCHER=' + conf.sccache_path]
 
     timeout_flag = '--timeout=' + str(conf.timeout)
-    lit_flags = ['--xunit-xml-output=testresults.xunit.xml', '-v', '-vv', timeout_flag]
+    lit_flags = ['--xunit-xml-output=testresults.xunit.xml', '-v', '-vv', '--time-tests', timeout_flag]
     if conf.max_parallel_tests:
         lit_flags += ['-j', conf.max_parallel_tests]
     cmake_cmd += ['-DLLVM_LIT_ARGS={}'.format(' '.join(lit_flags))]
@@ -448,7 +448,7 @@ def clang_builder(target):
                                       '-DCMAKE_CXX_COMPILER=' + conf.CC() + "++"])
 
             timeout_flag = '--timeout=' + str(conf.timeout)
-            lit_flags = ['--xunit-xml-output=testresults.xunit.xml', '-v', '-vv', timeout_flag]
+            lit_flags = ['--xunit-xml-output=testresults.xunit.xml', '-v', '-vv', '--time-tests', timeout_flag]
 
             if conf.max_parallel_tests:
                 lit_flags += ['-j', conf.max_parallel_tests]

--- a/zorg/jenkins/jobs/jobs/clang-stage2-cmake-RgSan
+++ b/zorg/jenkins/jobs/jobs/clang-stage2-cmake-RgSan
@@ -103,7 +103,7 @@ pipeline {
                            --projects="clang;clang-tools-extra" \
                            --cmake-flag='-DLLVM_USE_SANITIZER=Address;Undefined' \
                            --cmake-flag="-DLIBCXX_INCLUDE_TESTS=OFF" \
-                           --timeout=1800 \
+                           --timeout=2400 \
                            --cmake-flag="-DPython3_EXECUTABLE=$(which python)"
                    '''
                 }


### PR DESCRIPTION
`fsanitizer.c` test from clang sometimes hits the individial tests timeout on ASAN + UBSAN bot. Increase the timeout for lit on the bot. Also prints slow tests time on all Darwin bots.