### PR TITLE
[CI] Remove Buildkite Token from metrics container

### DIFF
--- a/premerge/main.tf
+++ b/premerge/main.tf
@@ -158,10 +158,6 @@ data "google_secret_manager_secret_version" "metrics_grafana_metrics_userid" {
   secret = "llvm-premerge-metrics-grafana-metrics-userid"
 }
 
-data "google_secret_manager_secret_version" "metrics_buildkite_token" {
-  secret = "llvm-premerge-metrics-buildkite-graphql-token"
-}
-
 resource "kubernetes_namespace" "metrics" {
   metadata {
     name = "metrics"
@@ -179,7 +175,6 @@ resource "kubernetes_secret" "metrics_secrets" {
     "github-token"           = data.google_secret_manager_secret_version.metrics_github_pat.secret_data
     "grafana-api-key"        = data.google_secret_manager_secret_version.metrics_grafana_api_key.secret_data
     "grafana-metrics-userid" = data.google_secret_manager_secret_version.metrics_grafana_metrics_userid.secret_data
-    "buildkite-token"        = data.google_secret_manager_secret_version.metrics_buildkite_token.secret_data
   }
 
   type       = "Opaque"

--- a/premerge/metrics_deployment.yaml
+++ b/premerge/metrics_deployment.yaml
@@ -34,11 +34,6 @@ spec:
             secretKeyRef:
               name: metrics-secrets
               key: grafana-metrics-userid
-        - name: BUILDKITE_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: metrics-secrets
-              key: buildkite-token
         resources:
           requests:
             cpu: "250m"


### PR DESCRIPTION
Now that buildkite has been sunsetted, we no longer need to keep track of the Buildkite workflows. https://github.com/llvm/llvm-project/pull/143049 does this on the metrics container side. This patch adjusts the deployment to those changes. Note that patch needs to land first before this can be applied.