### PR TITLE
Linaro / Windows: Use LLVM_CCACHE_BUILD instead of CMAKE_CXX_COMPILER_LAUNCHER

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -331,8 +331,7 @@ all = [
                         "-DCLANG_DEFAULT_LINKER=lld",
                         "-DCMAKE_TRY_COMPILE_CONFIGURATION=Release",
                         "-DCOMPILER_RT_BUILD_SANITIZERS=OFF",
-                        "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
-                        "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"])},
+                        "-DLLVM_CCACHE_BUILD=ON"])},
 
     ## ARMv8 check-all
     {'name' : "clang-armv8-quick",
@@ -665,8 +664,7 @@ all = [
                     extra_cmake_args=[
                         "-DCLANG_DEFAULT_LINKER=lld",
                         "-DCMAKE_TRY_COMPILE_CONFIGURATION=Release",
-                        "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
-                        "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
+                        "-DLLVM_CCACHE_BUILD=ON",
                         "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"])},
 
     {'name' : 'clang-x64-windows-msvc',
@@ -1448,8 +1446,7 @@ all = [
                     clean=True,
                     test=True,
                     extra_cmake_args=[
-                        "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
-                        "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
+                        "-DLLVM_CCACHE_BUILD=ON",
                         # Hardware breakpoints and watchpoints are not yet supported,
                         # https://github.com/llvm/llvm-project/issues/80665.
                         '-DLLDB_TEST_USER_ARGS=--skip-category=watchpoint',
@@ -2656,8 +2653,7 @@ all += [
                         "-DCLANG_DEFAULT_LINKER=lld",
                         "-DCMAKE_TRY_COMPILE_CONFIGURATION=Release",
                         "-DCOMPILER_RT_BUILD_SANITIZERS=OFF",
-                        "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
-                        "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache"])},
+                        "-DLLVM_CCACHE_BUILD=ON"])},
 
     {'name' : 'ppc64-flang-aix',
     'tags'  : ["flang", "ppc", "ppc64", "aix"],


### PR DESCRIPTION
There's nothing wrong with the latter - except that LLVM_CCACHE_BUILD knows that it should not be enabling pre-compiled headers on Windows.

See https://github.com/llvm/llvm-project/pull/136856

We had a contributor report an issue with this, and it only got fixed when someone randomly managed to update the right files for an unrelated change.

```
/Fdtools\flang\lib\Parser\CMakeFiles\FortranParser.dir\FortranParser.pdb
-c -- C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/lib/Parser/preprocessor.cpp
fatal error: file
'C:\Users\tcwg\llvm-worker\flang-arm64-windows-msvc\llvm-project\llvm\include\llvm\Support\Compiler.h'
has been modified since the precompiled header
'C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Parser/CMakeFiles/FortranParser.dir/./cmake_pch.cxx.pch'
was built: size changed (was 26948, now 27102)
note: please rebuild precompiled header
'C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Parser/CMakeFiles/FortranParser.dir/./cmake_pch.cxx.pch'
1 error generated.
```

This sounds like a known issue, and if we use LLVM_CCACHE_BUILD, precompiled headers will be disabled. This is fine, our bots weren't relying on this anyway.

As far as I could tell we don't customise the ccache install at all either, so the defaults are all fine for us.

I've applied this to all 4 Windows bots:
clang-arm64-windows-msvc
clang-arm64-windows-msvc-2stage
flang-arm64-windows-msvc
lldb-aarch64-windows

The problem is with flang specifically, but we might as well standardise across them all.