### PR TITLE
[BOLT] Set nfc-tests once

### DIFF
--- a/zorg/buildbot/builders/BOLTBuilder.py
+++ b/zorg/buildbot/builders/BOLTBuilder.py
@@ -79,15 +79,24 @@ def getBOLTCmakeBuildFactory(
     addNinjaSteps(
         f,
         targets=targets,
-        checks=checks,
+        checks = None if is_nfc else checks,
         env=env,
         **kwargs)
 
+    """
+    In NFC mode we conditionally run tests only when the llvm-bolt binary has
+    changed between the previous and current revision. We skipped passing checks
+    to addNinjaSteps, so we add those checks below, along with the conditional
+    logic.
+    """
     if is_nfc:
         f.addSteps([
             ShellCommand(
                 name='nfc-check-setup',
-                command=[f"../{f.monorepo_dir}/bolt/utils/nfc-check-setup.py"],
+                command=[
+                        f"../{f.monorepo_dir}/bolt/utils/nfc-check-setup.py",
+                        "--switch-back"
+                        ],
                 description=('Setup NFC testing'),
                 warnOnFailure=True,
                 haltOnFailure=False,
@@ -113,9 +122,8 @@ def getBOLTCmakeBuildFactory(
                 descriptionDone=["NFC-Mode unique IDs in binaries"],
                 env=env),
             ShellCommand(
-                name='check-bolt-different',
-                command=('find -name timing.log -delete; '
-                         'rm -f .llvm-bolt.diff; '
+                name='nfc-check-bolt-different',
+                command=('rm -f .llvm-bolt.diff; '
                          'cmp -s bin/llvm-bolt.old bin/llvm-bolt.new || '
                          'touch .llvm-bolt.diff'),
                 description=('Check if llvm-bolt binaries are different and '
@@ -124,15 +132,12 @@ def getBOLTCmakeBuildFactory(
                 env=env),
             LitTestCommand(
                 name='nfc-check-bolt',
-                command=['bin/llvm-lit', '-sv', '-j4',
-                         # bolt-info will always mismatch in NFC mode
-                         '--xfail=bolt-info.test',
-                         'tools/bolt/test'],
+                command=["ninja", "check-bolt"],
                 description=["running", "NFC", "check-bolt"],
                 descriptionDone=["NFC", "check-bolt", "completed"],
                 warnOnFailure=True,
                 haltOnFailure=False,
-                flunkOnFailure=False,
+                flunkOnFailure=True,
                 doStepIf=FileExists('build/.llvm-bolt.diff'),
                 env=env),
             LitTestCommand(
@@ -143,7 +148,7 @@ def getBOLTCmakeBuildFactory(
                 descriptionDone=["NFC", "check-large-bolt", "completed"],
                 warnOnFailure=True,
                 haltOnFailure=False,
-                flunkOnFailure=False,
+                flunkOnFailure=True,
                 doStepIf=FileExists('build/.llvm-bolt.diff'),
                 env=env),
             ])

--- a/zorg/buildbot/builders/UnifiedTreeBuilder.py
+++ b/zorg/buildbot/builders/UnifiedTreeBuilder.py
@@ -233,17 +233,18 @@ def addNinjaSteps(
     else:
         check_env = env or {}
 
-    for check in checks:
-        f.addStep(LitTestCommand(name=trunc50("test-%s-%s" % (step_name, check)),
-                                 command=['ninja', check],
-                                 description=[
-                                   "Test", "just", "built", "components", "for",
-                                   check,
-                                 ],
-                                 env=check_env,
-                                 workdir=obj_dir,
-                                 **kwargs # Pass through all the extra arguments.
-                                 ))
+    if checks:
+        for check in checks:
+            f.addStep(LitTestCommand(name=trunc50("test-%s-%s" % (step_name, check)),
+                                    command=['ninja', check],
+                                    description=[
+                                    "Test", "just", "built", "components", "for",
+                                    check,
+                                    ],
+                                    env=check_env,
+                                    workdir=obj_dir,
+                                    **kwargs # Pass through all the extra arguments.
+                                    ))
 
     # Install just built components
     if install_dir:


### PR DESCRIPTION
When setting up the nfc-mode tests, avoid adding an extra pair of in-tree and
out-of-tree tests that were unconditional. This was previously done with
addNinjaSteps. Instead, add those later and make them conditional on llvm-bolt
being modified.
    
Since tests are now only added by BOLTBuilder:
- `ninja` runs the in-tree tests to correctly build dependencies.
- flunkOnFailure is set to update the build status on failures.

Some nits:
- the '--switch-back' flag is used (from nfc-check-setup.py).
- a 'nfc-' prefix is appended to 'check-bolt-different' step
- remove timing.log cleanup