### PR TITLE
Some cmake flag fixes to arm32 qemu bot setup.

### DIFF
--- a/zorg/buildbot/builders/annotated/libc-linux.py
+++ b/zorg/buildbot/builders/annotated/libc-linux.py
@@ -120,8 +120,8 @@ def main(argv):
             cmake_args.append('-DLLVM_LIBC_MPFR_INSTALL_PATH={}/gmp+mpfr/'.format(os.getenv('HOME')))
 
         if arm32_build and qemu_build:
-            cmake_args.append('-DCMAKE_TARGET_TRIPLE=arm-linux-gnueabihf')
-            cmake_args.append('-DLIBC_TEST_COMPILE_OPTIONS_DEFAULT="-static"')
+            cmake_args.append('-DLIBC_TARGET_TRIPLE=arm-linux-gnueabihf')
+            cmake_args.append('-DLIBC_TEST_COMPILE_OPTIONS_DEFAULT=-static')
 
         if bootstrap_build:
             cmake_root = 'llvm'


### PR DESCRIPTION
Remove quotes from -static flag so clang doesn't read it as a file name. Also fix error in LIBC_TARGET_TRIPLE flag.