### PR TITLE
Do not run "check-runtimes" if "check-all" will be also be run

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -325,7 +325,7 @@ all = [
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     depends_on_projects=['llvm', 'clang', 'clang-tools-extra',
                                          'lld', 'compiler-rt', 'openmp'],
-                    checks=['check-all', 'check-runtimes'],
+                    checks=['check-all'],
                     extra_configure_args=[
                         "-DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64",
                         "-DCLANG_DEFAULT_LINKER=lld",
@@ -727,7 +727,7 @@ all = [
     'factory' : TestSuiteBuilder.getTestSuiteBuildFactory(
                     depends_on_projects=["llvm", "clang", "clang-tools-extra",
                                          "compiler-rt"],
-                    checks=['check-all', 'check-runtimes'],
+                    checks=['check-all'],
                     extra_configure_args=[
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
                         "-DCMAKE_BUILD_TYPE=Release",
@@ -741,7 +741,7 @@ all = [
     'builddir': "clang-ppc64le-multistage",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=False,
-                    checks=['check-all', 'check-runtimes'],
+                    checks=['check-all'],
                     checkout_lld=False,
                     useTwoStage=True,
                     stage1_config='Release',
@@ -759,7 +759,7 @@ all = [
     'factory' : TestSuiteBuilder.getTestSuiteBuildFactory(
                     depends_on_projects=["llvm", "clang", "clang-tools-extra",
                                          "lld", "compiler-rt"],
-                    checks=['check-runtimes', 'check-all'],
+                    checks=['check-all'],
                     extra_configure_args=[
                         "-DLLVM_ENABLE_ASSERTIONS=On",
                         "-DCMAKE_C_COMPILER=clang",


### PR DESCRIPTION
For a long time, at least since https://github.com/llvm/llvm-project/commit/f39a971d821097df1936469b3fd5ba6a9b8e4b69, the runtimes tests have been part of check-all.

I only noticed this the other day when our bot failed the same test twice.

https://lab.llvm.org/buildbot/#/builders/161/builds/6483

The same thing happened on some ppc bots:
https://lab.llvm.org/buildbot/#/builders/145/builds/7641 https://lab.llvm.org/buildbot/#/builders/95/builds/14342

This is because they run the targets separately:
ninja check-all
ninja check-runtimes

So I have removed the check-runtimes target from these.

clang-ppc64le-linux-multistage didn't run the test twice: https://lab.llvm.org/buildbot/#/builders/76/builds/10353

(twice per stage that is)

Because it runs the tests as: ninja check-all check-runtimes

And ninja knows that one is part of the other.

I've removed check-runtimes from that bot anyway, just for clarity. The tests will still be run as part of check-all.