### PR TITLE
Temporary disable the LLDB DAP tests for Windows/x86_64 targets (lldb-x86_64-win).

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1485,6 +1485,7 @@ all = [
                         "LLDB_ENABLE_LZMA"              : "OFF",
                         "LLDB_ENABLE_LIBXML2"           : "OFF",
                         "LLDB_CAN_USE_LLDB_SERVER"      : "ON",
+                        "LLDB_TEST_USER_ARGS"           : "--skip-category=lldb-dap",
                     },
                     env = {
                         'LLDB_USE_LLDB_SERVER' : "1",


### PR DESCRIPTION
Until fixes for the issues. See more for details here https://discourse.llvm.org/t/reliability-of-the-lldb-dap-tests/86125/21