### PR TITLE
[RISCV] Add additional RISC-V 2-stage cross-compile and test under qemu-system configs

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3474,6 +3474,39 @@ all += [
                     script_interpreter=None,
                     clean=True)},
 
+    ## RISC-V RVA23 profile with zvl512b check-all 2-stage
+    ## (cross-compile and then test under qemu-system).
+    {'name' : "clang-riscv-rva23-zvl512b-2stage",
+    'workernames' : ["rise-worker-2"],
+    'builddir':"clang-riscv-rva23-zvl512b-2stage",
+    'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
+                    script="rise-riscv-build.sh",
+                    checkout_llvm_sources=False,
+                    script_interpreter=None,
+                    clean=True)},
+
+    ## RISC-V RVA23 profile with zvl1024b check-all 2-stage
+    ## (cross-compile and then test under qemu-system).
+    {'name' : "clang-riscv-rva23-zvl1024b-2stage",
+    'workernames' : ["rise-worker-3"],
+    'builddir':"clang-riscv-rva23-zvl1024b-2stage",
+    'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
+                    script="rise-riscv-build.sh",
+                    checkout_llvm_sources=False,
+                    script_interpreter=None,
+                    clean=True)},
+
+    ## RISC-V -mcpu=spacemit-x60 with -mrvv-vector-bits=zvl check-all 2-stage
+    ## (cross-compile and then test under qemu-system).
+    {'name' : "clang-riscv-x60-mrvv-vec-bits-2stage",
+    'workernames' : ["rise-worker-4"],
+    'builddir':"clang-riscv-x60-mrvv-vec-bits-2stage",
+    'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
+                    script="rise-riscv-build.sh",
+                    checkout_llvm_sources=False,
+                    script_interpreter=None,
+                    clean=True)},
+
     # Builders similar to used in Buildkite premerge pipeline.
     # Please keep in sync with llvm-project/.ci configurations.
 

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -402,6 +402,9 @@ def get_all():
         create_worker("rise-clang-riscv-rva23-mrvv-vec-bits-2stage", properties={'jobs' : 16}, max_builds=1),
         create_worker("rise-clang-riscv-rva23-evl-vec-2stage", properties={'jobs' : 16}, max_builds=1),
         create_worker("rise-worker-1", properties={'jobs' : 32}, max_builds=1),
+        create_worker("rise-worker-2", properties={'jobs' : 32}, max_builds=1),
+        create_worker("rise-worker-3", properties={'jobs' : 32}, max_builds=1),
+        create_worker("rise-worker-4", properties={'jobs' : 32}, max_builds=1),
 
         # FIXME: A placeholder for annoying worker which nobody could stop.
         # adding it avoid logs spammed by failed authentication for that worker.

--- a/zorg/buildbot/builders/annotated/rise-riscv-build.sh
+++ b/zorg/buildbot/builders/annotated/rise-riscv-build.sh
@@ -31,9 +31,30 @@ case "$BUILDBOT_BUILDERNAME" in
   "clang-riscv-rva23-evl-vec-2stage")
     TARGET_CFLAGS="-march=rva23u64 -mllvm -force-tail-folding-style=data-with-evl -mllvm -prefer-predicate-over-epilogue=predicate-else-scalar-epilogue"
     export BB_IMG_DIR=$(pwd)/..
-     # TODO: Switch to specifying rva23u64 once support is available in a
-     # released QEMU.
+     # TODO: Switch to specifying rva23u64 once qemu on the builder is
+     # upgraded to a version that recognises it.
     export BB_QEMU_CPU="rv64,zba=true,zbb=true,zbc=false,zbs=true,zfhmin=true,v=true,vext_spec=v1.0,zkt=true,zvfhmin=true,zvbb=true,zvkt=true,zihintntl=true,zicond=true,zimop=true,zcmop=true,zcb=true,zfa=true,zawrs=true,rvv_ta_all_1s=true,rvv_ma_all_1s=true,rvv_vl_half_avl=true"
+    export BB_QEMU_SMP=32
+    export BB_QEMU_MEM="64G"
+    ;;
+  "clang-riscv-rva23-zvl512b-2stage")
+    TARGET_CFLAGS="-march=rva23u64_zvl512b"
+    export BB_IMG_DIR=$(pwd)/..
+    export BB_QEMU_CPU="rva23u64,vlen=512,rvv_ta_all_1s=true,rvv_ma_all_1s=true,rvv_vl_half_avl=true"
+    export BB_QEMU_SMP=32
+    export BB_QEMU_MEM="64G"
+    ;;
+  "clang-riscv-rva23-zvl1024b-2stage")
+    TARGET_CFLAGS="-march=rva23u64_zvl1024b"
+    export BB_IMG_DIR=$(pwd)/..
+    export BB_QEMU_CPU="rva23u64,vlen=1024,rvv_ta_all_1s=true,rvv_ma_all_1s=true,rvv_vl_half_avl=true"
+    export BB_QEMU_SMP=32
+    export BB_QEMU_MEM="64G"
+    ;;
+  "clang-riscv-x60-mrvv-vec-bits-2stage")
+    TARGET_CFLAGS="-mcpu=spacemit-x60 -mrvv-vector-bits=zvl"
+    export BB_IMG_DIR=$(pwd)/..
+    export BB_QEMU_CPU="rva22u64,v=true,zbc=true,zbkc=true,zfh=true,zicond=true,zvkt=true,vlen=256,rvv_ta_all_1s=true,rvv_ma_all_1s=true,rvv_vl_half_avl=true"
     export BB_QEMU_SMP=32
     export BB_QEMU_MEM="64G"
     ;;


### PR DESCRIPTION
This adds:
* rva23 with zvl512b
* rva23 with zvl1024b
* -mcpu=spacemit-x60 with -mrvv-vector-bits=zvl (this config also gives zvl256b coverage)