### PR TITLE
[flang] Add dependency for out-of-tree flang on compiler-rt

### DIFF
--- a/zorg/buildbot/builders/FlangBuilder.py
+++ b/zorg/buildbot/builders/FlangBuilder.py
@@ -19,7 +19,7 @@ def getFlangOutOfTreeBuildFactory(
     f = getCmakeWithNinjaBuildFactory(
             depends_on_projects=['llvm','clang','mlir','openmp','flang','flang-rt'],
             enable_projects=['llvm','clang','mlir'],
-            enable_runtimes=['openmp'],
+            enable_runtimes=['openmp', 'compiler-rt'],
             obj_dir="build_llvm",
             checks=[],
             clean=clean,


### PR DESCRIPTION
flang on AArch64 now always depends on compiler-rt so it needs to be
built in the main LLVM build for the out-of-tree flang bots.
