### PR TITLE
[GHA] Add workflow to build container for operational metrics

### DIFF
--- a/.github/workflows/build-operations-metrics-container.yml
+++ b/.github/workflows/build-operations-metrics-container.yml
@@ -1,0 +1,79 @@
+name: Build Operations Metrics Container
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/build-operations-metrics-container.yml
+      - 'llvm-ops-metrics/ops-container/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/build-operations-metrics-container.yml
+      - '.llvm-ops-metrics/ops-container/**'
+
+jobs:
+  build-operations-metrics-container:
+    if: github.repository_owner == 'llvm'
+    runs-on: ubuntu-24.04
+    outputs:
+      container-name: ${{ steps.vars.outputs.container-name }}
+      container-name-tag: ${{ steps.vars.outputs.container-name-tag }}
+      container-filename: ${{ steps.vars.outputs.container-filename }}
+    steps:
+      - name: Checkout LLVM Zorg
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: llvm-ops-metrics/ops-container
+      - name: Write Variables
+        id: vars
+        run: |
+          tag=`date +%s`
+          container_name="ghcr.io/$GITHUB_REPOSITORY_OWNER/operations-metrics"
+          echo "container-name=$container_name" >> $GITHUB_OUTPUT
+          echo "container-name-tag=$container_name:$tag" >> $GITHUB_OUTPUT
+          echo "container-filename=$(echo $container_name:$tag  | sed -e 's/\//-/g' -e 's/:/-/g').tar" >> $GITHUB_OUTPUT
+      - name: Build Container
+        working-directory: ./llvm-ops-metrics/ops-container
+        run: |
+          podman build -t ${{ steps.vars.outputs.container-name-tag }} -f Dockerfile .
+      # Save the container so we have it in case the push fails.  This also
+      # allows us to separate the push step into a different job so we can
+      # maintain minimal permissions while building the container.
+      - name: Save Container Image
+        run: |
+          podman save  ${{ steps.vars.outputs.container-name-tag }} >  ${{ steps.vars.outputs.container-filename }}
+      - name: Upload Container Image
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: container
+          path: ${{ steps.vars.outputs.container-filename }}
+          retention-days: 14
+
+  push-metrics-container:
+    if: github.event_name == 'push'
+    needs:
+      - build-operations-metrics-container
+    permissions:
+      packages: write
+    runs-on: ubuntu-24.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Download Container Image
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: container
+      - name: Push Container
+        run: |
+          podman load -i ${{ needs.build-operations-metrics-container.outputs.container-filename }}
+          podman tag ${{ needs.build-operations-metrics-container.outputs.container-name-tag }} ${{ needs.build-operations-metrics-container.outputs.container-name }}:latest
+          podman login -u ${{ github.actor }} -p $GITHUB_TOKEN ghcr.io
+          podman push ${{ needs.build-operations-metrics-container.outputs.container-name-tag }}
+          podman push ${{ needs.build-operations-metrics-container.outputs.container-name }}:latest
+


### PR DESCRIPTION
Add a GItHub Action workflow that builds the operational metrics container defined in `llvm-ops-metrics/ops-container`  (#483) and pushes it to the GitHub container registry.

This container scrapes [llvm-project](https://github.com/llvm/llvm-project) for new commits & their associated reviews at a daily cadence and exports that data to Grafana for visualization.

This workflow definition closely follows the workflow for building the [premerge metrics container in llvm-project](https://github.com/llvm/llvm-project/blob/main/.github/workflows/build-metrics-container.yml)

