### PR TITLE
Remove PSTL from the monolithic builders

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3608,7 +3608,7 @@ all += [
     'builddir': "premerge-monolithic-windows",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaWithMSVCBuildFactory(
                     vs="autodetect",
-                    depends_on_projects=["clang-tools-extra", "clang", "libclc", "lld", "llvm", "mlir", "polly", "pstl"],
+                    depends_on_projects=["clang-tools-extra", "clang", "libclc", "lld", "llvm", "mlir", "polly"],
                     checks=["check-all"],
                     install_pip_requirements = True,
                     clean = True,
@@ -3629,7 +3629,7 @@ all += [
     'workernames': ["premerge-linux-1"],
     'builddir': "premerge-monolithic-linux",
     'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
-                    depends_on_projects=["bolt", "clang", "clang-tools-extra", "compiler-rt", "flang", "flang-rt", "libc", "libclc", "lld", "llvm", "mlir", "polly", "pstl"],
+                    depends_on_projects=["bolt", "clang", "clang-tools-extra", "compiler-rt", "flang", "flang-rt", "libc", "libclc", "lld", "llvm", "mlir", "polly"],
                     install_pip_requirements = True,
                     extra_configure_args=[
                       "-DCMAKE_BUILD_TYPE=Release",


### PR DESCRIPTION
This directory was removed in
https://github.com/llvm/llvm-project/commit/f8ed45611b75ecac1d459aa6ae3b7051d435abe6