### PR TITLE
[GHA] Fix typo in path for triggering metrics container build

### DIFF
--- a/.github/workflows/build-operations-metrics-container.yml
+++ b/.github/workflows/build-operations-metrics-container.yml
@@ -15,7 +15,7 @@ on:
       - main
     paths:
       - .github/workflows/build-operations-metrics-container.yml
-      - '.llvm-ops-metrics/ops-container/**'
+      - 'llvm-ops-metrics/ops-container/**'
 
 jobs:
   build-operations-metrics-container:


### PR DESCRIPTION
Follows up on #484 and removes an extra `.` from one of the pull request paths 