### PR TITLE
[BOLT] Add sanity check for frozen llvm-bolt

### DIFF
--- a/zorg/buildbot/builders/BOLTBuilder.py
+++ b/zorg/buildbot/builders/BOLTBuilder.py
@@ -206,7 +206,7 @@ def getBOLTCmakeBuildFactory(
             # Lower scheduling priority, as above.
             LitTestCommand(
                 name='nfc-check-large-bolt',
-                command=('nice -n 5 bin/llvm-lit -sv -j2 tools/bolttests'),
+                command=('nice -n 5 bin/llvm-lit -v -j2 tools/bolttests'),
                 description=["running", "NFC", "check-large-bolt"],
                 descriptionDone=["NFC", "check-large-bolt", "completed"],
                 warnOnFailure=True,

--- a/zorg/buildbot/builders/BOLTBuilder.py
+++ b/zorg/buildbot/builders/BOLTBuilder.py
@@ -188,7 +188,7 @@ def getBOLTCmakeBuildFactory(
             # relevant source code changes are detected.
             LitTestCommand(
                 name='nfc-check-bolt',
-                command=("LIT_OPTS='-j2' ninja check-bolt"),
+                command=("LIT_OPTS='-j2' nice -n 5 ninja check-bolt"),
                 description=["running", "NFC", "check-bolt"],
                 descriptionDone=["NFC", "check-bolt", "completed"],
                 warnOnFailure=True,
@@ -199,8 +199,7 @@ def getBOLTCmakeBuildFactory(
             # Run out-of-tree large tests if the llvm-bolt binary has changed.
             LitTestCommand(
                 name='nfc-check-large-bolt',
-                command=['bin/llvm-lit', '-sv', '-j2',
-                         'tools/bolttests'],
+                command=('nice -n 5 bin/llvm-lit -sv -j2 tools/bolttests'),
                 description=["running", "NFC", "check-large-bolt"],
                 descriptionDone=["NFC", "check-large-bolt", "completed"],
                 warnOnFailure=True,

--- a/zorg/buildbot/builders/BOLTBuilder.py
+++ b/zorg/buildbot/builders/BOLTBuilder.py
@@ -103,7 +103,7 @@ def getBOLTCmakeBuildFactory(
         boltOld = "bin/llvm-bolt.old"
 
         f.addSteps([
-            # Cleanup binaries and markers from previous NFC-mode runs.
+            # Cleanup old/new binaries and markers from previous NFC-mode runs.
             ShellCommand(
                 name='clean-nfc-check',
                 command=(
@@ -114,7 +114,9 @@ def getBOLTCmakeBuildFactory(
                 haltOnFailure=False,
                 flunkOnFailure=False,
                 env=env),
-            # Build the current and previous revision of llvm-bolt.
+            # Build the current and previous revision of llvm-bolt as
+            # llvm-bolt.new and llvm-bolt.old. Also, creates a marker to force
+            # in-tree tests in case additional source code changes are detected.
             ShellCommand(
                 name='nfc-check-setup',
                 command=[
@@ -189,7 +191,7 @@ def getBOLTCmakeBuildFactory(
             # Run in-tree tests if the llvm-bolt binary has changed, or if
             # relevant source code changes are detected. Lower scheduling
             # priority with nice to reduce CPU contention in virtualized
-            # environments.
+            # environments. This step relinks the llvm-bolt binary if needed.
             LitTestCommand(
                 name='nfc-check-bolt',
                 command=("nice -n 5 ninja check-bolt"),

--- a/zorg/buildbot/builders/BOLTBuilder.py
+++ b/zorg/buildbot/builders/BOLTBuilder.py
@@ -130,6 +130,16 @@ def getBOLTCmakeBuildFactory(
                 haltOnFailure=False,
                 flunkOnFailure=False,
                 env=env),
+            ShellCommand(
+                name='llvm-bolt-version-check',
+                command=(f"{boltNew} --version"),
+                description=('Check that llvm-bolt binary passes a simple test'
+                             'before proceeding with testing.'),
+                descriptionDone=["llvm-bolt --version"],
+                haltOnFailure=True,
+                flunkOnFailure=True,
+                maxTime=30,
+                env=env),
             # Validate that NFC-mode comparison is meaningful by checking:
             # - the old and new binaries exist
             # - no unique IDs are embedded in the binaries
@@ -154,6 +164,7 @@ def getBOLTCmakeBuildFactory(
                 haltOnFailure=False,
                 warnOnFailure=True,
                 warnOnWarnings=True,
+                maxTime=20,
                 decodeRC={0: SUCCESS, 1: FAILURE, 2: WARNINGS},
                 descriptionDone=["NFC-Mode Validation"],
                 env=env),
@@ -177,7 +188,7 @@ def getBOLTCmakeBuildFactory(
             # relevant source code changes are detected.
             LitTestCommand(
                 name='nfc-check-bolt',
-                command=["ninja", "check-bolt"],
+                command=("LIT_OPTS='-j2' ninja check-bolt"),
                 description=["running", "NFC", "check-bolt"],
                 descriptionDone=["NFC", "check-bolt", "completed"],
                 warnOnFailure=True,


### PR DESCRIPTION
Some patches can cause the llvm-bolt binary to hang, which stalls or fails the test pipeline.

Add a simple sanity check that runs:
```
llvm-bolt --version
```

with a 30-second timeout. If the command does not complete in time, flunk the build.

Also, sets maxTime for nfc-check-validation and reduce the number of lit workers for in-tree tests.