### PR TITLE
Enable OpenMP and Add new WoA 2stage worker

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -653,7 +653,7 @@ all = [
 
     {'name' : "clang-arm64-windows-msvc-2stage",
     'tags'  : ["clang"],
-    'workernames' : ["linaro-armv8-windows-msvc-02"],
+    'workernames' : ["linaro-armv8-windows-msvc-02", "linaro-armv8-windows-msvc-03"],
     'builddir': "clang-arm64-windows-msvc-2stage",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     vs="manual",
@@ -665,6 +665,7 @@ all = [
                         "-DCLANG_DEFAULT_LINKER=lld",
                         "-DCMAKE_TRY_COMPILE_CONFIGURATION=Release",
                         "-DLLVM_CCACHE_BUILD=ON",
+                        "-DLLVM_ENABLE_RUNTIMES=openmp",
                         "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"])},
 
     {'name' : 'clang-x64-windows-msvc',

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -47,9 +47,10 @@ def get_all():
         create_worker("linaro-g4-01", max_builds=1),
         create_worker("linaro-g4-02", max_builds=1),
 
-        # AArch64 Windows Microsoft Surface X Pro
+        # Windows Dev Kit 2023, Snapdragon® 8cx Gen 3 
         create_worker("linaro-armv8-windows-msvc-01", max_builds=1),
         create_worker("linaro-armv8-windows-msvc-02", max_builds=1),
+        create_worker("linaro-armv8-windows-msvc-03", max_builds=1),
         create_worker("linaro-armv8-windows-msvc-04", max_builds=1),
         create_worker("linaro-armv8-windows-msvc-05", max_builds=1),
 


### PR DESCRIPTION
This patch introduces the following changes:

1. A new AArch64 Windows worker linaro-armv8-windows-msvc-03 for clang-arm64-windows-msvc-2stage builder.

3. The OpenMP is enabled for the clang-arm64-windows-msvc-2stage builder via -DLLVM_ENABLE_RUNTIMES=openmp CMake flag.