### PR TITLE
[CI] Double Linux Runner Counts

### DIFF
--- a/premerge/gke_cluster/main.tf
+++ b/premerge/gke_cluster/main.tf
@@ -41,7 +41,7 @@ resource "google_container_node_pool" "llvm_premerge_linux" {
 
   autoscaling {
     total_min_node_count = 0
-    total_max_node_count = 8
+    total_max_node_count = 16
   }
 
   node_config {

--- a/premerge/linux_runners_values.yaml
+++ b/premerge/linux_runners_values.yaml
@@ -2,7 +2,7 @@ githubConfigUrl: "https://github.com/llvm"
 githubConfigSecret: "github-token"
 
 minRunners: 0
-maxRunners: 8
+maxRunners: 16
 
 runnerGroup: ${ runner_group_name }
 


### PR DESCRIPTION
This patch doubles the Linux Runner Counts from 8 per cluster to 16 per cluster for a total of 32. We recently were able to get some more quota to allow for this.