### PR TITLE
[CI] Setup Daemonset to Modify ASLR Sysctl Values

### DIFF
--- a/premerge/premerge_resources/main.tf
+++ b/premerge/premerge_resources/main.tf
@@ -315,3 +315,7 @@ resource "helm_release" "grafana-k8s-monitoring" {
 
   depends_on = [kubernetes_namespace.grafana]
 }
+
+resource "kubernetes_manifest" "sysctl-daemonset" {
+  manifest = yamldecode(file("sysctl_daemonset.yaml"))
+}

--- a/premerge/sysctl_daemonset.yaml
+++ b/premerge/sysctl_daemonset.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sysctl-config-ds
+  namespace: kube-system
+  labels:
+    k8s-app: sysctl-config
+spec:
+  selector:
+    matchLabels:
+      name: sysctl-config
+  template:
+    metadata:
+      labels:
+        name: sysctl-config
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: llvm-premerge-libcxx
+      containers:
+      - name: sysctl-configure-init
+        image: alpine
+        command:
+        - /bin/sh
+        - -c
+        - |
+          sysctl vm.mmap_rnd_bits=28 \
+          && sleep 31536000000
+          # the sleep is basically forever, to prevent DaemonSet termination
+        securityContext:
+          runAsUser: 0
+          privileged: true
+          readOnlyRootFilesystem: false
+          allowPrivilegeEscalation: true


### PR DESCRIPTION
This patch adds a Daemonset to the clusters that will perform the necessary sysctl call to adjust the vm.mmap_rnd_bits value. This is necessary to pass the libcxx msan and tsan tests. The daemonset is currently only setup on the libcxx nodes as we have not needed to configure the values anywhere else so far.

We cannot do this in a startup script because GKE uses the GCE VM instance startup script options to run its own configuration. We also cannot just the GKE system configuration as it does not have support for setting vm.mmap_rnd_bits. A privileged daemonset works just fine.