### PR TITLE
[llvm-zorg] Fix various issues with the libcxx premerge runner configs.

### DIFF
--- a/premerge/libcxx_runners_values.yaml
+++ b/premerge/libcxx_runners_values.yaml
@@ -17,11 +17,11 @@ template:
       value: "linux-libcxx"
       effect: "NoSchedule"
     nodeSelector:
-      premerge-platform-libcxx: linux
+      premerge-platform-libcxx: linux-libcxx
     containers:
     - name: runner
       image: ${ runner_image }
-      command: ["/home/gha/actions-runner/run.sh"]
+      command: ["/home/runner/run.sh"]
       resources:
         # If we don't set the CPU request high-enough here, 2 runners might
         # be scheduled on the same pod, meaning 2 jobs, and they will starve

--- a/premerge/premerge_resources/variables.tf
+++ b/premerge/premerge_resources/variables.tf
@@ -57,7 +57,7 @@ variable "runner_group_name" {
 
 variable "libcxx_runner_image" {
   type = string
-  default = "ghcr.io/llvm/libcxx-linux-builder:b060022103f51d8ca1dad84122ef73927c86512"
+  default = "ghcr.io/llvm/libcxx-linux-builder:b060022103f551d8ca1dad84122ef73927c86512"
 }
 
 variable "libcxx_release_runner_image" {
@@ -68,5 +68,5 @@ variable "libcxx_release_runner_image" {
 # Same value as libcxx_runner_image at this time.
 variable "libcxx_next_runner_image" {
   type = string
-  default = "ghcr.io/llvm/libcxx-linux-builder:b060022103f51d8ca1dad84122ef73927c86512"
+  default = "ghcr.io/llvm/libcxx-linux-builder:b060022103f551d8ca1dad84122ef73927c86512"
 }


### PR DESCRIPTION
- Correct container image name (was missing a digit)
- Fix container image path to run.sh
- Update nodeSelector to use linux-libcxx rather than linux.