### PR TITLE
[CI] Add Terraform resources for daily CronJob that processes LLVM commits

### DIFF
--- a/premerge/gke_cluster/main.tf
+++ b/premerge/gke_cluster/main.tf
@@ -32,7 +32,7 @@ resource "google_container_node_pool" "llvm_premerge_linux_service" {
     machine_type = "e2-highcpu-4"
 
     workload_metadata_config {
-        mode = "GKE_METADATA"
+      mode = "GKE_METADATA"
     }
     # Terraform wants to recreate the node pool everytime whe running
     # terraform apply unless we explicitly set this.

--- a/premerge/gke_cluster/main.tf
+++ b/premerge/gke_cluster/main.tf
@@ -30,6 +30,10 @@ resource "google_container_node_pool" "llvm_premerge_linux_service" {
 
   node_config {
     machine_type = "e2-highcpu-4"
+
+    workload_metadata_config {
+        mode = "GKE_METADATA"
+    }
     # Terraform wants to recreate the node pool everytime whe running
     # terraform apply unless we explicitly set this.
     # TODO(boomanaiden154): Look into why terraform is doing this so we do

--- a/premerge/main.tf
+++ b/premerge/main.tf
@@ -275,27 +275,6 @@ resource "google_service_account_iam_binding" "workload_identity_binding" {
   ]
 }
 
-# The container for scraping LLVM commits needs persistent storage
-# for a local check-out of llvm/llvm-project
-resource "kubernetes_persistent_volume_claim" "operational_metrics_pvc" {
-  metadata {
-    name      = "operational-metrics-pvc"
-    namespace = "operational-metrics"
-  }
-
-  spec {
-    access_modes = ["ReadWriteOnce"]    
-    resources {
-      requests = {
-        storage = "20Gi"
-      }
-    }
-    storage_class_name = "standard-rwo"  
-  }
-  
-  depends_on = [kubernetes_namespace.operational_metrics]
-}
-
 resource "kubernetes_secret" "operational_metrics_secrets" {
   metadata {
     name      = "operational-metrics-secrets"
@@ -319,7 +298,6 @@ resource "kubernetes_manifest" "operational_metrics_cronjob" {
 
   depends_on = [
     kubernetes_namespace.operational_metrics,
-    kubernetes_persistent_volume_claim.operational_metrics_pvc,
     kubernetes_secret.operational_metrics_secrets,
     kubernetes_service_account.operational_metrics_ksa,
   ]

--- a/premerge/main.tf
+++ b/premerge/main.tf
@@ -234,14 +234,14 @@ resource "google_service_account" "operational_metrics_gsa" {
 resource "google_project_iam_binding" "bigquery_jobuser_binding" {
   project = google_service_account.operational_metrics_gsa.project
   role    = "roles/bigquery.jobUser"
-  
+
   members = [
-   "serviceAccount:${google_service_account.operational_metrics_gsa.email}",
+    "serviceAccount:${google_service_account.operational_metrics_gsa.email}",
   ]
 
   depends_on = [google_service_account.operational_metrics_gsa]
 }
-    
+
 resource "kubernetes_namespace" "operational_metrics" {
   metadata {
     name = "operational-metrics"
@@ -251,8 +251,8 @@ resource "kubernetes_namespace" "operational_metrics" {
 
 resource "kubernetes_service_account" "operational_metrics_ksa" {
   metadata {
-    name        = "operational-metrics-ksa"
-    namespace   = "operational-metrics"
+    name      = "operational-metrics-ksa"
+    namespace = "operational-metrics"
     annotations = {
       "iam.gke.io/gcp-service-account" = google_service_account.operational_metrics_gsa.email
     }
@@ -264,7 +264,7 @@ resource "kubernetes_service_account" "operational_metrics_ksa" {
 resource "google_service_account_iam_binding" "workload_identity_binding" {
   service_account_id = google_service_account.operational_metrics_gsa.name
   role               = "roles/iam.workloadIdentityUser"
-  
+
   members = [
     "serviceAccount:${google_service_account.operational_metrics_gsa.project}.svc.id.goog[operational-metrics/operational-metrics-ksa]",
   ]

--- a/premerge/operational_metrics_cronjob.yaml
+++ b/premerge/operational_metrics_cronjob.yaml
@@ -16,10 +16,6 @@ spec:
           serviceAccountName: operational-metrics-ksa
           nodeSelector:
             iam.gke.io/gke-metadata-server-enabled: "true"
-          volumes:
-          - name: metrics-volume
-            persistentVolumeClaim:
-              claimName: operational-metrics-pvc
           containers:
           - name: process-llvm-commits
             image: ghcr.io/llvm/operations-metrics:latest
@@ -39,9 +35,6 @@ spec:
                 secretKeyRef:
                   name: operational-metrics-secrets
                   key: grafana-metrics-userid
-            volumeMounts:
-            - name: metrics-volume
-              mountPath: "/data"
             resources:
               requests:
                 cpu: "250m"

--- a/premerge/operational_metrics_cronjob.yaml
+++ b/premerge/operational_metrics_cronjob.yaml
@@ -1,0 +1,52 @@
+# operational_metrics_cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: operational-metrics-cronjob
+  namespace: operational-metrics
+spec:
+  # Midnight PDT
+  schedule: "0 7 * * *"
+  timeZone: "Etc/UTC"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: operational-metrics-ksa
+          nodeSelector:
+            iam.gke.io/gke-metadata-server-enabled: "true"
+          volumes:
+          - name: metrics-volume
+            persistentVolumeClaim:
+              claimName: operational-metrics-pvc
+          containers:
+          - name: process-llvm-commits
+            image: ghcr.io/llvm/operations-metrics:latest
+            env:
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: operational-metrics-secrets
+                  key: github-token
+            - name: GRAFANA_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: operational-metrics-secrets
+                  key: grafana-api-key
+            - name: GRAFANA_METRICS_USERID
+              valueFrom:
+                secretKeyRef:
+                  name: operational-metrics-secrets
+                  key: grafana-metrics-userid
+            volumeMounts:
+            - name: metrics-volume
+              mountPath: "/data"
+            resources:
+              requests:
+                cpu: "250m"
+                memory: "256Mi"
+              limits:
+                cpu: "1"
+                memory: "512Mi"
+          restartPolicy: OnFailure


### PR DESCRIPTION
These resources are for a CronJob that executes the container at `ghcr.io/llvm/operations-metrics:latest` on a daily basis (07:00 UTC), which will scrape daily metrics regarding LLVM's commit volume and upload them for visualization in Grafana.

Changes were made to the already existing terraform files since many of the same resources are being reused anyway. This way we can keep all relevant changes in the same place instead of having two separate terraform directories that access and modify shared resources.

Since the container needs access to the BigQuery Google Cloud API, IAM and K8S service accounts were used to grant that access via Workload Identity Federation for GKE. More details at https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity