### PR TITLE
[CI] Version pin providers

### DIFF
--- a/zorg/buildbot/builders/annotated/amdgpu-offload-cmake.py
+++ b/zorg/buildbot/builders/annotated/amdgpu-offload-cmake.py
@@ -9,8 +9,21 @@ import util
 import tempfile
 from contextlib import contextmanager
 
+def add_argument_parser():
+    ap = argparse.ArgumentParser()
+
+    # Arugment for CMake file.
+    default_cmake_file = "AMDGPUBot.cmake"
+    ap.add_argument('--cmake-file', type=str, default=default_cmake_file,
+                   help=f'CMake file to use (default: {default_cmake_file})')
+
+    return ap
 
 def main(argv):
+    ap = add_argument_parser()
+    args, _ = ap.parse_known_args()
+
+    cmake_file = args.cmake_file
     source_dir = os.path.join("..", "llvm-project")
     offload_base_dir = os.path.join(source_dir, "offload")
     of_cmake_cache_base_dir = os.path.join(offload_base_dir, "cmake/caches")
@@ -27,8 +40,7 @@ def main(argv):
         util.rmtree(tdir)
 
     with step("cmake", halt_on_fail=True):
-        # TODO make the name of the cache file an argument to the script.
-        cmake_cache_file = os.path.join(of_cmake_cache_base_dir, "AMDGPUBot.cmake")
+        cmake_cache_file = os.path.join(of_cmake_cache_base_dir, cmake_file)
 
         # Use Ninja as the generator.
         # The other important settings alrady come from the CMake CMake

--- a/zorg/buildbot/builders/annotated/rise-riscv-build.sh
+++ b/zorg/buildbot/builders/annotated/rise-riscv-build.sh
@@ -72,7 +72,7 @@ if [ ! -d llvm ]; then
 fi
 
 build_step "Updating llvm-project repo"
-git -C llvm fetch origin
+git -C llvm fetch --prune origin
 git -C llvm reset --hard "${LLVM_REVISION}"
 
 # We unconditionally clean (i.e. don't check BUILDBOT_CLOBBER=1) as the script
@@ -142,7 +142,7 @@ if [ ! -d llvm-test-suite ]; then
 fi
 
 build_step "Updating llvm-test-suite repo"
-git -C llvm-test-suite fetch origin
+git -C llvm-test-suite fetch --prune origin
 git -C llvm-test-suite reset --hard origin/main
 
 build_step "llvm-test-suite cmake"

--- a/zorg/buildbot/builders/annotated/rise-riscv-gauntlet-build.sh
+++ b/zorg/buildbot/builders/annotated/rise-riscv-gauntlet-build.sh
@@ -39,7 +39,7 @@ if [ ! -d llvm-project ]; then
 fi
 
 build_step "Updating llvm-project repo"
-git -C llvm-project fetch origin
+git -C llvm-project fetch --prune origin
 git -C llvm-project reset --hard "${LLVM_REVISION}"
 
 if [ ! -d llvm-test-suite ]; then
@@ -48,7 +48,7 @@ if [ ! -d llvm-test-suite ]; then
 fi
 
 build_step "Updating llvm-test-suite repo"
-git -C llvm-test-suite fetch origin
+git -C llvm-test-suite fetch --prune origin
 git -C llvm-test-suite reset --hard origin/main
 
 # We unconditionally clean (i.e. don't check BUILDBOT_CLOBBER=1) as the script


### PR DESCRIPTION
This patch version pins providers and bumps the google provider to
v6.43.0. We need to bump the Google provider so that we can set the windows OS
version on windows node pools for the switch to server 2022. This also pins
some other providers as hashicorp/helm in particular has breaking changes in v3
which terraform init -upgrade will install before this patch.
