### PR TITLE
[Github] Make litmus-tests workflow only run for push events on main

### DIFF
--- a/.github/workflows/litmus-tests.yml
+++ b/.github/workflows/litmus-tests.yml
@@ -1,6 +1,10 @@
 name: llvm-zorg testing
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
Without this change the workflow will run twice on stacked PRs as there is a push event to the repo and a pull_request event. Not a big deal, but a slight annoyance that is an easy fix.