### PR TITLE
[CI] Setup Buckets for Sccache

### DIFF
--- a/premerge/gke_cluster/main.tf
+++ b/premerge/gke_cluster/main.tf
@@ -143,17 +143,17 @@ resource "google_container_node_pool" "llvm_premerge_windows_2022" {
 }
 
 resource "google_storage_bucket" "object_cache_linux" {
-  name = format("%s-object-cache-linux", var.cluster_name)
+  name     = format("%s-object-cache-linux", var.cluster_name)
   location = var.region
 
   uniform_bucket_level_access = true
-  public_access_prevention = "enforced"
+  public_access_prevention    = "enforced"
 }
 
 resource "google_storage_bucket" "object_cache_windows" {
-  name = format("%s-object-cache-windows", var.cluster_name)
+  name     = format("%s-object-cache-windows", var.cluster_name)
   location = var.region
 
   uniform_bucket_level_access = true
-  public_access_prevention = "enforced"
+  public_access_prevention    = "enforced"
 }

--- a/premerge/gke_cluster/main.tf
+++ b/premerge/gke_cluster/main.tf
@@ -141,3 +141,19 @@ resource "google_container_node_pool" "llvm_premerge_windows_2022" {
     }
   }
 }
+
+resource "google_storage_bucket" "object_cache_linux" {
+  name = format("%s-object-cache-linux", var.cluster_name)
+  location = var.region
+
+  uniform_bucket_level_access = true
+  public_access_prevention = "enforced"
+}
+
+resource "google_storage_bucket" "object_cache_windows" {
+  name = format("%s-object-cache-windows", var.cluster_name)
+  location = var.region
+
+  uniform_bucket_level_access = true
+  public_access_prevention = "enforced"
+}


### PR DESCRIPTION
This patch sets up GCS Buckets for sccache remote caching. We set up one for
Linux and one for Windows in each cluster. This creates some separation which
might help slightly with security. We want to have the buckets in the same
region as the machines to ensure uploads/downloads are as low latency as
possible which is helped significantly when the compute and storage are
colocated.
