### PR TITLE
Increase timeout for clang-sparc64-linux to 1800 seconds

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -846,6 +846,7 @@ all = [
     'builddir': 'clang-sparc64-linux',
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=False,
+                    timeout=1800,
                     runTestSuite=True,
                     checkout_clang_tools_extra=False,
                     checkout_compiler_rt=False,


### PR DESCRIPTION
The builds for clang-sparc64-linux currently fail with a timeout during the linking stage, so lets increase the timeout to 1800 seconds which is the timeout also used on the builder clang-solaris11-sparcv9.