### PR TITLE
Add another email to the list of notifications for my bots.

### DIFF
--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -343,7 +343,8 @@ def getReporters():
         reporters.MailNotifier(
             fromaddr = status_email_fromaddr,
             sendToInterestedUsers = False,
-            extraRecipients = ["douglas.yung@sony.com"],
+            extraRecipients = ["douglas.yung@sony.com",
+                               "douglasyung.llvm@gmail.com" ],
             generators = [
                 utils.LLVMDefaultBuildStatusGenerator(
                     builders = [


### PR DESCRIPTION
Currently the email notifications go to my work address, but since some of the bots I manage are self-hosted, it would be useful to get notifications to a personal email so I don't have to check my work email to see them. This adds a personal email so that I can get notifications there as well of problems.