### PR TITLE
[CI] Pass Bucket Names Through to Runner Pods

### DIFF
--- a/premerge/linux_runners_values.yaml
+++ b/premerge/linux_runners_values.yaml
@@ -44,4 +44,10 @@ template:
         limits:
           cpu: 64
           memory: "256Gi"
-
+      env:
+      # We pass the GCS bucket name in as an environment variable as it is
+      # different per cluster. We do not directly pass this to sccache
+      # through the SCCACHE_GCS_BUCKET variable so that we can control how
+      # sccache is caching directly in the workflow.
+      - name: CACHE_GCS_BUCKET
+        value: ${ cache_gcs_bucket }

--- a/premerge/premerge_resources/main.tf
+++ b/premerge/premerge_resources/main.tf
@@ -152,7 +152,7 @@ resource "helm_release" "github_actions_runner_set_linux" {
   chart      = "gha-runner-scale-set"
 
   values = [
-    "${templatefile("linux_runners_values.yaml", { runner_group_name : var.runner_group_name })}"
+    "${templatefile("linux_runners_values.yaml", { runner_group_name : var.runner_group_name, cache_gcs_bucket : format("%s-object-cache-linux", var.cluster_name) })}"
   ]
 
   depends_on = [
@@ -170,7 +170,7 @@ resource "helm_release" "github_actions_runner_set_windows_2022" {
   chart      = "gha-runner-scale-set"
 
   values = [
-    "${templatefile("windows_2022_runner_values.yaml", { runner_group_name : var.runner_group_name })}"
+    "${templatefile("windows_2022_runner_values.yaml", { runner_group_name : var.runner_group_name, cache_gcs_bucket : format("%s-object-cache-windows", var.cluster_name) })}"
   ]
 
   depends_on = [

--- a/premerge/windows_2022_runner_values.yaml
+++ b/premerge/windows_2022_runner_values.yaml
@@ -33,6 +33,12 @@ template:
         env:
           - name: DISABLE_RUNNER_UPDATE
             value: "true"
+          # We pass the GCS bucket name in as an environment variable as it is
+          # different per cluster. We do not directly pass this to sccache
+          # through the SCCACHE_GCS_BUCKET variable so that we can control how
+          # sccache is caching directly in the workflow.
+          - name: CACHE_GCS_BUCKET
+            value: ${ cache_gcs_bucket }
         # Add a volume/mount it to C:/_work so that we can use more than 20GB
         # of space. Windows containers default to only having 20GB of scratch
         # space and there is no way to configure this through kubernetes


### PR DESCRIPTION
This patch passes the per-cluster bucket names through to the runner pods in a custom env variable. This allows for configuring sccache inside the workflow to use the GCS buckets.