### PR TITLE
[CI] Disable Soft Delete on GCS Buckets

### DIFF
--- a/premerge/gke_cluster/main.tf
+++ b/premerge/gke_cluster/main.tf
@@ -171,6 +171,10 @@ resource "google_storage_bucket" "object_cache_linux" {
 
   uniform_bucket_level_access = true
   public_access_prevention    = "enforced"
+
+  soft_delete_policy {
+    retention_duration_seconds = 0
+  }
 }
 
 resource "google_storage_bucket" "object_cache_windows" {
@@ -179,6 +183,10 @@ resource "google_storage_bucket" "object_cache_windows" {
 
   uniform_bucket_level_access = true
   public_access_prevention    = "enforced"
+
+  soft_delete_policy {
+    retention_duration_seconds = 0
+  }
 }
 
 resource "google_service_account" "object_cache_linux_gsa" {


### PR DESCRIPTION
This patch disable soft deletion on the GCS Buckets used to cache object files.
Soft deletion is a feature on GCS buckets where when files are deleted they
are kept around for some duration of time (~7 days by default) in a "soft"
deleted state before being fully deleted. Given we do not really lose anything
by deleting object files and can easily regenerate them, it does not make sense
to pay for storing them for an additional seven days. By the end of the time they
will be long outdated.
