### PR TITLE
[CI] Add Lifecycle Rules to GCS Buckets

### DIFF
--- a/premerge/linux_runners_values.yaml
+++ b/premerge/linux_runners_values.yaml
@@ -11,7 +11,7 @@ template:
     annotations:
       cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
   spec:
-    serviceAccount: linux-runners-ksa
+    serviceAccountName: linux-runners-ksa
     tolerations:
     - key: "premerge-platform"
       operator: "Equal"

--- a/premerge/linux_runners_values.yaml
+++ b/premerge/linux_runners_values.yaml
@@ -11,6 +11,7 @@ template:
     annotations:
       cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
   spec:
+    serviceAccount: linux-runners-ksa
     tolerations:
     - key: "premerge-platform"
       operator: "Equal"

--- a/premerge/windows_2022_runner_values.yaml
+++ b/premerge/windows_2022_runner_values.yaml
@@ -11,7 +11,7 @@ template:
     annotations:
       cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
   spec:
-    serviceAccount: windows-runners-ksa
+    serviceAccountName: windows-runners-ksa
     tolerations:
     - key: "node.kubernetes.io/os"
       operator: "Equal"

--- a/premerge/windows_2022_runner_values.yaml
+++ b/premerge/windows_2022_runner_values.yaml
@@ -11,6 +11,7 @@ template:
     annotations:
       cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
   spec:
+    serviceAccount: windows-runners-ksa
     tolerations:
     - key: "node.kubernetes.io/os"
       operator: "Equal"


### PR DESCRIPTION
This patch adds lifecycle rules to the GCS buckets to delete old objects.
We do not want to keep object files around for very long as they quickly
become out of date. GCS does not keep track of the last time a file was
fetched, so we have to rely on the creation date. The granularity for when
to delete an object can only be specified in days, so we set it to one
day for now.
