### PR TITLE
Merge clang-armv7-lnt into clang-armv7-2stage

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -344,21 +344,6 @@ all = [
                     checkout_lld=False,
                     extra_cmake_args=["-DLLVM_TARGETS_TO_BUILD='ARM'"])},
 
-    # ARMv7 LNT test-suite in test-only mode
-    {'name' : "clang-armv7-lnt",
-    'tags'  : ["clang"],
-    'workernames' : ["linaro-clang-armv7-lnt"],
-    'builddir': "clang-armv7-lnt",
-    'factory' : ClangBuilder.getClangCMakeBuildFactory(
-                    clean=False,
-                    checkout_compiler_rt=False,
-                    checkout_lld=False,
-                    checks=[],
-                    runTestSuite=True,
-                    testsuite_flags=[
-                        '--cppflags', '-mcpu=cortex-a15 -marm',
-                        '--threads=32', '--build-threads=32'])},
-
     ## ARMv7 check-all 2-stage
     {'name' : "clang-armv7-2stage",
     'tags'  : ["clang"],
@@ -369,7 +354,11 @@ all = [
                     checkout_compiler_rt=False,
                     checkout_lld=False,
                     useTwoStage=True,
-                    testStage1=False,
+                    testStage1=True,
+                    runTestSuite=True,
+                    testsuite_flags=[
+                        '--cppflags', '-mcpu=cortex-a15 -marm',
+                        '--threads=32', '--build-threads=32']
                     extra_cmake_args=[
                         "-DCMAKE_C_FLAGS='-mcpu=cortex-a15 -marm'",
                         "-DCMAKE_CXX_FLAGS='-mcpu=cortex-a15 -marm'"])},

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -358,7 +358,7 @@ all = [
                     runTestSuite=True,
                     testsuite_flags=[
                         '--cppflags', '-mcpu=cortex-a15 -marm',
-                        '--threads=32', '--build-threads=32']
+                        '--threads=32', '--build-threads=32'],
                     extra_cmake_args=[
                         "-DCMAKE_C_FLAGS='-mcpu=cortex-a15 -marm'",
                         "-DCMAKE_CXX_FLAGS='-mcpu=cortex-a15 -marm'"])},

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -16,7 +16,6 @@ def get_all():
         create_worker("as-worker-4", properties={'jobs' : 24}, max_builds=2),
 
         # ARMv7/ARMv8 Linaro workers
-        create_worker("linaro-clang-armv7-lnt", max_builds=1),
         create_worker("linaro-clang-armv7-2stage", max_builds=1),
         create_worker("linaro-clang-armv7-global-isel", max_builds=1),
         create_worker("linaro-clang-armv7-vfpv3-2stage", max_builds=1),


### PR DESCRIPTION
This removes the single stage test suite bot, then adds stage 1 check and final test suite run to the 2 stage bot.

Which is the equivalent but 1 fewer worker. It'll slow down the 2 stage builds a bit but there's no a lot of activity in the 32-bit Arm area anyway, so I don't think it's a problem.