### PR TITLE
[CI] Add maintenance window to premerge clusters

### DIFF
--- a/premerge/gke_cluster/main.tf
+++ b/premerge/gke_cluster/main.tf
@@ -19,6 +19,16 @@ resource "google_container_cluster" "llvm_premerge" {
   workload_identity_config {
     workload_pool = "llvm-premerge-checks.svc.id.goog"
   }
+
+  # We prefer that maintenance is done on weekends betwee 02:00 and 05:00
+  # UTC when commit traffic is low to avoid interruptions.
+  maintenance_policy {
+    recurring_window {
+      start_time = "2025-07-24T02:00:00Z"
+      end_time   = "2025-07-24T05:00:00Z"
+      recurrence = "FREQ=WEEKLY;BYDAY=SA,SU"
+    }
+  }
 }
 
 resource "google_container_node_pool" "llvm_premerge_linux_service" {

--- a/premerge/gke_cluster/main.tf
+++ b/premerge/gke_cluster/main.tf
@@ -20,7 +20,7 @@ resource "google_container_cluster" "llvm_premerge" {
     workload_pool = "llvm-premerge-checks.svc.id.goog"
   }
 
-  # We prefer that maintenance is done on weekends betwee 02:00 and 05:00
+  # We prefer that maintenance is done on weekends between 02:00 and 05:00
   # UTC when commit traffic is low to avoid interruptions.
   maintenance_policy {
     recurring_window {


### PR DESCRIPTION
This patch adds an explicit maintenance window to the premerge clusters. This is in response to some control plane upgrades that we recieved notice of that will prevent access to the k8s control plane for ~15 minutes which means we will not be able to start new jobs. We should have this anyways though as the current node upgrade strategy also breaks jobs.