### PR TITLE
[CI] Increase resource allocation for operational metrics cronjob

### DIFF
--- a/premerge/operational_metrics_cronjob.yaml
+++ b/premerge/operational_metrics_cronjob.yaml
@@ -38,8 +38,8 @@ spec:
             resources:
               requests:
                 cpu: "250m"
-                memory: "256Mi"
+                memory: "1.75Gi"
               limits:
-                cpu: "1"
-                memory: "512Mi"
+                cpu: "2"
+                memory: "2Gi"
           restartPolicy: OnFailure


### PR DESCRIPTION
The cronjob for scraping llvm-project commit data consistently fails due to running out of memory. `git clone https://github.com/llvm/llvm-project.git` consistently uses around 1.5 GiB of RAM, which is well above both the request and limit currently set for the cronjob.  Thus, the job is repeatedly killed more memory than is allocated.

Increasing the resource allocation should get this cronjob running as intended. ]