### PR TITLE
[CI] Remove old premerge bots

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3536,50 +3536,6 @@ all += [
                     script_interpreter=None,
                     clean=True)},
 
-    # Builders similar to used in Buildkite premerge pipeline.
-    # Please keep in sync with llvm-project/.ci configurations.
-
-    # See https://github.com/llvm/llvm-project/blob/main/.ci/monolithic-windows.sh.
-    {'name' : "premerge-monolithic-windows",
-    'tags'  : ["premerge"],
-    'workernames' : ["premerge-windows-1"],
-    'builddir': "premerge-monolithic-windows",
-    'factory' : UnifiedTreeBuilder.getCmakeWithNinjaWithMSVCBuildFactory(
-                    vs="autodetect",
-                    depends_on_projects=["clang-tools-extra", "clang", "libclc", "lld", "llvm", "mlir", "polly"],
-                    checks=["check-all"],
-                    install_pip_requirements = True,
-                    clean = True,
-                    extra_configure_args=[
-                        "-DCMAKE_BUILD_TYPE=Release",
-                        "-DLLVM_ENABLE_ASSERTIONS=ON",
-                        "-DLLVM_BUILD_EXAMPLES=ON",
-                        "-DCOMPILER_RT_BUILD_LIBFUZZER=OFF",
-                        "-DLLVM_LIT_ARGS=-v",
-                        "-DMLIR_ENABLE_BINDINGS_PYTHON=ON",
-                        "-DCOMPILER_RT_BUILD_ORC=OFF",
-                        "-DCMAKE_C_COMPILER_LAUNCHER=sccache",
-                        "-DCMAKE_CXX_COMPILER_LAUNCHER=sccache"])},
-    # See https://github.com/llvm/llvm-project/blob/main/.ci/monolithic-linux.sh.
-    {'name': "premerge-monolithic-linux",
-    'tags'  : ["premerge"],
-    'collapseRequests': False,
-    'workernames': ["premerge-linux-1"],
-    'builddir': "premerge-monolithic-linux",
-    'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
-                    depends_on_projects=["bolt", "clang", "clang-tools-extra", "compiler-rt", "flang", "flang-rt", "libc", "libclc", "lld", "llvm", "mlir", "polly"],
-                    install_pip_requirements = True,
-                    extra_configure_args=[
-                      "-DCMAKE_BUILD_TYPE=Release",
-                      "-DLLVM_ENABLE_ASSERTIONS=ON",
-                      "-DLLVM_BUILD_EXAMPLES=ON",
-                      "-DCOMPILER_RT_BUILD_LIBFUZZER=OFF",
-                      "-DMLIR_ENABLE_BINDINGS_PYTHON=ON",
-                      "-DLLVM_LIT_ARGS=-v",
-                      "-DLLVM_ENABLE_LLD=ON",
-                      "-DCMAKE_CXX_FLAGS=-gmlt",
-                      "-DLLVM_CCACHE_BUILD=ON"])},
-
 ]
 
 # LLDB remote-linux builder env variables.

--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -553,16 +553,6 @@ def getReporters():
         reporters.MailNotifier(
             fromaddr = status_email_fromaddr,
             sendToInterestedUsers = False,
-            extraRecipients = ["llvm-premerge-buildbots@google.com", "joker.eph@gmail.com"],
-            generators = [
-                utils.LLVMDefaultBuildStatusGenerator(
-                    builders = [
-                        "premerge-monolithic-windows",
-                        "premerge-monolithic-linux"])
-            ]),
-        reporters.MailNotifier(
-            fromaddr = status_email_fromaddr,
-            sendToInterestedUsers = False,
             extraRecipients = ["szakharin@nvidia.com"],
             generators = [
                 utils.LLVMDefaultBuildStatusGenerator(

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -406,11 +406,4 @@ def get_all():
         # FIXME: A placeholder for annoying worker which nobody could stop.
         # adding it avoid logs spammed by failed authentication for that worker.
         create_worker("mlir-ubuntu-worker0"),
-
-        # Linux builder matching Buildkite pre-merge checks configuration.
-        create_worker("premerge-linux-1", max_builds=1, missing_timeout=300,
-                      notify_on_missing="llvm-premerge-buildbots@google.com"),
-        # Windows builder matching Buildkite pre-merge checks configuration.
-        create_worker("premerge-windows-1", max_builds=1, missing_timeout=300,
-                      notify_on_missing="llvm-premerge-buildbots@google.com"),
         ]


### PR DESCRIPTION
This patch removes the old LLVM premerge bots from llvm-zorg in preparation
for adding in the new ones.
