### PR TITLE
[Bot][HIP] Add prune to git fetch step for hip bot

### DIFF
--- a/zorg/buildbot/builders/annotated/hip-build.sh
+++ b/zorg/buildbot/builders/annotated/hip-build.sh
@@ -52,7 +52,7 @@ if [ ! -d "${LLVM_ROOT}" ]; then
 fi
 
 build_step "Updating llvm-project repo"
-git -C "${LLVM_ROOT}" fetch origin
+git -C "${LLVM_ROOT}" fetch --prune origin
 git -C "${LLVM_ROOT}" reset --hard "${LLVM_REVISION}"
 }
 
@@ -64,7 +64,7 @@ if [ ! -d "${TESTSUITE_ROOT}" ]; then
 fi
 
 build_step "Updating llvm-test-suite repo"
-git -C "${TESTSUITE_ROOT}" fetch origin
+git -C "${TESTSUITE_ROOT}" fetch --prune origin
 git -C "${TESTSUITE_ROOT}" reset --hard origin/main
 }
 


### PR DESCRIPTION
We saw that this bot was broken due to branch name conflict when running git fetch. Adding --prune to prevent such issue.