### PR TITLE
[CI] Add BigQuery JobUser role binding for querying operational metrics

### DIFF
--- a/premerge/main.tf
+++ b/premerge/main.tf
@@ -231,6 +231,17 @@ resource "google_service_account" "operational_metrics_gsa" {
   display_name = "Operational Metrics GSA"
 }
 
+resource "google_project_iam_binding" "bigquery_jobuser_binding" {
+  project = google_service_account.operational_metrics_gsa.project
+  role    = "roles/bigquery.jobUser"
+
+  members = [
+    "serviceAccount:${google_service_account.operational_metrics_gsa.email}",
+  ]
+
+  depends_on = [google_service_account.operational_metrics_gsa]
+}
+
 resource "kubernetes_namespace" "operational_metrics" {
   metadata {
     name = "operational-metrics"


### PR DESCRIPTION
This change reintroduces a BigQuery role binding that was removed in #525. Now that our CronJob is also querying past data to determine the number of unique LLVM contributors over time, we must grant the associated service account `roles/bigquery.JobUser` so that the BigQuery client can create query jobs.

This is the error without this binding:

```
google.api_core.exceptions.Forbidden: 403 POST: Access Denied: User does not have bigquery.jobs.create 
permission in project llvm-premerge-checks.
```