### PR TITLE
[CI] Convert dispatch_jobs.py into an annotated builder

### DIFF
--- a/premerge/buildbot/dispatch_job.py
+++ b/premerge/buildbot/dispatch_job.py
@@ -13,6 +13,7 @@ import time
 import dateutil
 import datetime
 import json
+import os
 
 import kubernetes
 
@@ -154,6 +155,7 @@ def main(commit_sha: str, platform: str):
     namespace = PLATFORM_TO_NAMESPACE[platform]
     latest_time = datetime.datetime.min
     v1_api = kubernetes.client.CoreV1Api()
+    print("@@@BUILD_STEP Build/Test@@@")
     while True:
         try:
             pod_finished, latest_time = print_logs(
@@ -173,7 +175,10 @@ def main(commit_sha: str, platform: str):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        logging.fatal("Expected usage is dispatch_job.py {commit SHA} {platform}")
+    if len(sys.argv) != 2:
+        logging.fatal("Expected usage is dispatch_job.py {platform}")
         sys.exit(1)
-    main(sys.argv[1], sys.argv[2])
+    if "BUILDBOT_REVISION" not in os.environ:
+        logging.fatal("Expected to have BUILDBOT_REVISION environment variable set.")
+        sys.exit(1)
+    main(sys.argv[1], os.environ["BUILDBOT_REVISION"])


### PR DESCRIPTION
This script should be used directly as an annotated builder and this script sets
it up to do so. There are two main changes:

1. We print out a build step command. The monolithic scripts will eventually need
to be upgraded to print out more fine grained build step information.
2. We take in a BUILDBOT_REVISION rather than the SHA on the command line.
Passing the commit SHA along on the command line is complicated while
BUILDBOT_REVISION is set by default for all annotated builders.
