### PR TITLE
[CI] Stop counting commit authors are reviewers

### DIFF
--- a/llvm-ops-metrics/ops-container/process_llvm_commits.py
+++ b/llvm-ops-metrics/ops-container/process_llvm_commits.py
@@ -192,6 +192,10 @@ def query_for_reviews(
         for review in pull_request["reviews"]["nodes"]
     ])
 
+    # There are cases where the commit author is counted as a reviewer. This is
+    # against what we want to measure, so remove them from the set of reviewers.
+    commit_info.reviewers.discard(commit_info.commit_author)
+
   return list(new_commits.values())
 
 


### PR DESCRIPTION
When a pull request author comments on their own pull request, it counts as a review and is captured when we query the GraphQL API for reviewers of a pull request. We shouldn't be counting self-reviews when collecting LLVM metrics, so this change removes the author of a commit from the set of reviewers.