### PR TITLE
[CI] Double RAM in Service Pool

### DIFF
--- a/premerge/gke_cluster/main.tf
+++ b/premerge/gke_cluster/main.tf
@@ -39,7 +39,7 @@ resource "google_container_node_pool" "llvm_premerge_linux_service" {
   node_locations = var.service_node_pool_locations
 
   node_config {
-    machine_type = "e2-highcpu-4"
+    machine_type = "e2-standard-4"
 
     workload_metadata_config {
       mode = "GKE_METADATA"


### PR DESCRIPTION
The operational metrics CronJob was having trouble scheduling due to memory pressure. Change from highcpu instances to standard instances which increases the amount of RAM from 4GB to 16GB per instance. This costs slightly more, but the difference is negligible. If we end up being that concerned, we can use custom sized instances and move to only 8GB of RAM, but for now this should be fine.