### PR TITLE
[CI] Bump libcxx next runner image to 77cb09

### DIFF
--- a/premerge/premerge_resources/variables.tf
+++ b/premerge/premerge_resources/variables.tf
@@ -69,10 +69,9 @@ variable "libcxx_release_runner_image" {
   default = "ghcr.io/llvm/libcxx-linux-builder:16f046281bf1a11d344eac1bc44d11f3e50e3b5d"
 }
 
-# Same value as libcxx_runner_image at this time.
 variable "libcxx_next_runner_image" {
   type    = string
-  default = "ghcr.io/llvm/libcxx-linux-builder:16f046281bf1a11d344eac1bc44d11f3e50e3b5d"
+  default = "ghcr.io/llvm/libcxx-linux-builder:77cb0980bcc2675b27d08141526939423fa0be76"
 }
 
 variable "linux_runners_namespace_name" {


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/153035 we have a new runner image that should theoretically work. Set the next runner set to use it so we can start testing.