### PR TITLE
[CI] Bump Object Age at Deletion to 7 Days

### DIFF
--- a/premerge/gke_cluster/main.tf
+++ b/premerge/gke_cluster/main.tf
@@ -247,7 +247,7 @@ resource "google_storage_bucket" "object_cache_linux" {
       type = "Delete"
     }
     condition {
-      age = 1
+      age = 7
     }
   }
 }
@@ -268,7 +268,7 @@ resource "google_storage_bucket" "object_cache_windows" {
       type = "Delete"
     }
     condition {
-      age = 1
+      age = 7
     }
   }
 }


### PR DESCRIPTION
Currently we delete cached build artifacts after one day. This patch bumps that to seven days. We are using very little storage currently (15-20GB) per bucket, so bumping this should have a negligible impact on cost. This also allows for builds that are not run as often (like those on the release branch) to have a warm cache when they are run again, assuming they are run at a reasonable cadence.