### PR TITLE
[CI] Bump libc++ container version

### DIFF
--- a/premerge/premerge_resources/variables.tf
+++ b/premerge/premerge_resources/variables.tf
@@ -61,7 +61,7 @@ variable "runner_group_name" {
 
 variable "libcxx_runner_image" {
   type    = string
-  default = "ghcr.io/llvm/libcxx-linux-builder:4fd41c4afbc76ead0c46e80990f616d21dd983f6"
+  default = "ghcr.io/llvm/libcxx-linux-builder:36d31b0c008b2716329b5c9990f583decf919819"
 }
 
 variable "libcxx_release_runner_image" {
@@ -71,7 +71,7 @@ variable "libcxx_release_runner_image" {
 
 variable "libcxx_next_runner_image" {
   type    = string
-  default = "ghcr.io/llvm/libcxx-linux-builder:4fd41c4afbc76ead0c46e80990f616d21dd983f6"
+  default = "ghcr.io/llvm/libcxx-linux-builder:36d31b0c008b2716329b5c9990f583decf919819"
 }
 
 variable "linux_runners_namespace_name" {


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/4fd41c4afbc76ead0c46e80990f616d21dd983f6 updated the runner version in the container. Bump to that to take advantage of the runner vesion update. Bump both the next runner set and the existing runner set given we are currently running all jobs on the next runner set. This is safe to bump given this was a runner only version bump.