### PR TITLE
[PGO] Add Profcheck Buildbot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3558,6 +3558,24 @@ all += [
                     checkout_llvm_sources=False,
                     extra_args=["Windows"],
                     depends_on_projects=["clang-tools-extra", "clang", "libclc", "lld", "llvm", "mlir", "polly"])},
+    
+    # Builders for the profcheck configuration
+    # These workers run builds with LLVM_ENABLE_PROFCHECK=ON to ensure
+    # that profile information is propagated correctly.
+    {'name' : "profcheck",
+     'workernames' : ["profcheck-b1", "profcheck-b2"],
+     'builddir': "profcheck-build",
+     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                     clean=True,
+                     depends_on_projects=['llvm'],
+                     extra_configure_args=[
+                         "-DCMAKE_BUILD_TYPE=Release",
+                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
+                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
+                         "-DLLVM_ENABLE_ASSERTIONS=ON",
+                         "-DLLVM_LIT_ARGS='--exclude-xfail'",
+                         "-DLLVM_ENABLE_PROFCHECK=ON",
+                     ])},
 ]
 
 # LLDB remote-linux builder env variables.

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -413,6 +413,12 @@ def get_all():
         create_worker("premerge-us-west-linux", properties={'jobs': 64}, max_builds=3),
         create_worker("premerge-us-west-windows", properties={'jobs': 64}, max_builds=3),
 
+        # Workers for the profcheck configuration
+        # These workers run builds with LLVM_ENABLE_PROFCHECK=ON to ensure
+        # that profile information is propagated correctly.
+        create_worker("profcheck-b1", properties={'jobs': 64}, max_builds=1),
+        create_worker("profcheck-b2", properties={'jobs': 64}, max_builds=1),
+
         # FIXME: A placeholder for annoying worker which nobody could stop.
         # adding it avoid logs spammed by failed authentication for that worker.
         create_worker("mlir-ubuntu-worker0"),


### PR DESCRIPTION
This patch adds the infrastructure for a buildbot for the profcheck configuration (LLVM_ENABLE_PROFCHECK=ON). This patch does not yet add machinery for excluding currently failing tests/other tests that we want to ignore.

Issue #147390