### PR TITLE
[CI] Terraform Plumbing for GCS Caching in Buildbot

### DIFF
--- a/premerge/buildbot_deployment.yaml
+++ b/premerge/buildbot_deployment.yaml
@@ -26,6 +26,8 @@ spec:
             secretKeyRef:
               name: ${ secret_name }
               key: password
+        - name: BUILDBOT_REGION
+          value: ${ buildbot_region }
         resources:
           requests:
             memory: "512Mi"

--- a/premerge/gke_cluster/main.tf
+++ b/premerge/gke_cluster/main.tf
@@ -283,6 +283,9 @@ resource "google_service_account" "object_cache_windows_gsa" {
   display_name = format("%s Windows Object Cache Service Account", var.region)
 }
 
+# TODO(boomanaiden154): Restrict the permissions of the two IAM bindings
+# below so that the PR runs can only read from the cache to help prevent
+# cache poisoning.
 resource "google_storage_bucket_iam_binding" "linux_bucket_binding" {
   bucket = google_storage_bucket.object_cache_linux.name
   role   = "roles/storage.objectUser"
@@ -332,5 +335,67 @@ resource "google_service_account_iam_binding" "windows_bucket_gsa_workload_bindi
 
   depends_on = [
     google_service_account.object_cache_windows_gsa,
+  ]
+}
+
+resource "google_service_account" "object_cache_linux_buildbot_gsa" {
+  account_id   = format("%s-linux-buildbot", var.gcs_bucket_location)
+  display_name = format("%s Linux Object Cache Buildbot Service Account", var.region)
+}
+
+resource "google_service_account" "object_cache_windows_buildbot_gsa" {
+  account_id   = format("%s-windows-buildbot", var.gcs_bucket_location)
+  display_name = format("%s Windows Object Cache Buildbot Service Account", var.region)
+}
+
+resource "google_storage_bucket_iam_binding" "linux_bucket_buildbot_binding" {
+  bucket = google_storage_bucket.object_cache_linux.name
+  role   = "roles/storage.objectUser"
+  members = [
+    format("serviceAccount:%s", google_service_account.object_cache_linux_buildbot_gsa.email),
+  ]
+
+  depends_on = [
+    google_storage_bucket.object_cache_linux,
+    google_service_account.object_cache_linux_buildbot_gsa,
+  ]
+}
+
+resource "google_storage_bucket_iam_binding" "windows_bucket_buildbot_binding" {
+  bucket = google_storage_bucket.object_cache_windows.name
+  role   = "roles/storage.objectUser"
+  members = [
+    format("serviceAccount:%s", google_service_account.object_cache_windows_buildbot_gsa.email),
+  ]
+
+  depends_on = [
+    google_storage_bucket.object_cache_windows,
+    google_service_account.object_cache_windows_buildbot_gsa
+  ]
+}
+
+resource "google_service_account_iam_binding" "linux_bucket_buildbot_gsa_workload_binding" {
+  service_account_id = google_service_account.object_cache_linux_buildbot_gsa.name
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "serviceAccount:${google_service_account.object_cache_linux_buildbot_gsa.project}.svc.id.goog[llvm-premerge-linux-buildbot/buildbot-gcs-ksa]",
+  ]
+
+  depends_on = [
+    google_service_account.object_cache_linux_buildbot_gsa,
+  ]
+}
+
+resource "google_service_account_iam_binding" "windows_bucket_buildbot_gsa_workload_binding" {
+  service_account_id = google_service_account.object_cache_windows_buildbot_gsa.name
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "serviceAccount:${google_service_account.object_cache_windows_buildbot_gsa.project}.svc.id.goog[llvm-premerge-windows-2022-buildbot/buildbot-gcs-ksa]",
+  ]
+
+  depends_on = [
+    google_service_account.object_cache_windows_buildbot_gsa,
   ]
 }

--- a/premerge/premerge_resources/main.tf
+++ b/premerge/premerge_resources/main.tf
@@ -329,6 +329,15 @@ resource "kubernetes_role_binding" "linux_buildbot_role_binding" {
   depends_on = [kubernetes_role.linux_buildbot_role, kubernetes_service_account.linux_buildbot_ksa]
 }
 
+resource "kubernetes_service_account" "linux_buildbot_gcs_ksa" {
+  metadata {
+    name      = "buildbot-gcs-ksa"
+    namespace = "llvm-premerge-linux-buildbot"
+  }
+
+  depends_on = [kubernetes_namespace.llvm_premerge_linux_buildbot]
+}
+
 resource "kubernetes_manifest" "linux_buildbot_deployment" {
   manifest = yamldecode(templatefile("buildbot_deployment.yaml", { buildbot_name : var.linux_buildbot_name, buildbot_namespace : "llvm-premerge-linux-buildbot", secret_name : "linux-buildbot-password" }))
 
@@ -378,6 +387,15 @@ resource "kubernetes_role_binding" "windows_2022_buildbot_role_binding" {
   }
 
   depends_on = [kubernetes_role.windows_2022_buildbot_role, kubernetes_service_account.windows_2022_buildbot_ksa]
+}
+
+resource "kubernetes_service_account" "windows_2022_buildbot_gcs_ksa" {
+  metadata {
+    name      = "buildbot-gcs-ksa"
+    namespace = "llvm-premerge-windows-2022-buildbot"
+  }
+
+  depends_on = [kubernetes_namespace.llvm_premerge_windows_2022_buildbot]
 }
 
 resource "kubernetes_manifest" "windows_buildbot_deployment" {

--- a/premerge/premerge_resources/main.tf
+++ b/premerge/premerge_resources/main.tf
@@ -339,7 +339,7 @@ resource "kubernetes_service_account" "linux_buildbot_gcs_ksa" {
 }
 
 resource "kubernetes_manifest" "linux_buildbot_deployment" {
-  manifest = yamldecode(templatefile("buildbot_deployment.yaml", { buildbot_name : var.linux_buildbot_name, buildbot_namespace : "llvm-premerge-linux-buildbot", secret_name : "linux-buildbot-password" }))
+  manifest = yamldecode(templatefile("buildbot_deployment.yaml", { buildbot_name : var.linux_buildbot_name, buildbot_namespace : "llvm-premerge-linux-buildbot", secret_name : "linux-buildbot-password", buildbot_region : var.cluster_name }))
 
   depends_on = [kubernetes_namespace.llvm_premerge_linux_buildbot, kubernetes_secret.linux_buildbot_password]
 }
@@ -399,7 +399,7 @@ resource "kubernetes_service_account" "windows_2022_buildbot_gcs_ksa" {
 }
 
 resource "kubernetes_manifest" "windows_buildbot_deployment" {
-  manifest = yamldecode(templatefile("buildbot_deployment.yaml", { buildbot_name : var.windows_buildbot_name, buildbot_namespace : "llvm-premerge-windows-2022-buildbot", secret_name : "windows-buildbot-password" }))
+  manifest = yamldecode(templatefile("buildbot_deployment.yaml", { buildbot_name : var.windows_buildbot_name, buildbot_namespace : "llvm-premerge-windows-2022-buildbot", secret_name : "windows-buildbot-password", buildbot_region : var.cluster_name }))
 
   depends_on = [kubernetes_namespace.llvm_premerge_windows_2022_buildbot, kubernetes_secret.windows_2022_buildbot_password]
 }


### PR DESCRIPTION
Add all of the service accounts/IAM bindings needed for GCS caching in the
buildbot namespaces. Use separate service accounts in case we want to
restrict the permissions between the PR checks and postcommit buildbots
differently.
