### PR TITLE
[CI] Update dispatch_job.py to setup sccache

### DIFF
--- a/premerge/premerge_resources/variables.tf
+++ b/premerge/premerge_resources/variables.tf
@@ -61,7 +61,7 @@ variable "runner_group_name" {
 
 variable "libcxx_runner_image" {
   type    = string
-  default = "ghcr.io/llvm/libcxx-linux-builder:16f046281bf1a11d344eac1bc44d11f3e50e3b5d"
+  default = "ghcr.io/llvm/libcxx-linux-builder:36d31b0c008b2716329b5c9990f583decf919819"
 }
 
 variable "libcxx_release_runner_image" {
@@ -71,7 +71,7 @@ variable "libcxx_release_runner_image" {
 
 variable "libcxx_next_runner_image" {
   type    = string
-  default = "ghcr.io/llvm/libcxx-linux-builder:77cb0980bcc2675b27d08141526939423fa0be76"
+  default = "ghcr.io/llvm/libcxx-linux-builder:36d31b0c008b2716329b5c9990f583decf919819"
 }
 
 variable "linux_runners_namespace_name" {

--- a/zorg/buildbot/builders/annotated/hip-build.sh
+++ b/zorg/buildbot/builders/annotated/hip-build.sh
@@ -71,6 +71,12 @@ git -C "${TESTSUITE_ROOT}" reset --hard origin/main
 # Start building LLVM, Clang, Lld, clang-tools-extra, compiler-rt
 build_llvm() {
 build_step "Configure LLVM Build"
+
+# Nuke the build dir to start from a cleaner state and rely on ccache for build time
+if [ -d "${LLVM_BUILD_DIR}" ]; then
+  rm -rf "${LLVM_BUILD_DIR}"
+fi
+
 mkdir -p "${LLVM_BUILD_DIR}"
 cd "${LLVM_BUILD_DIR}"
 cmake -G Ninja \
@@ -136,4 +142,3 @@ update_test_suite
 build_test_suite
 
 exit 0
-


### PR DESCRIPTION
Now that we have buckets available and plumbed through terraform, setup
dispatch_job.py to actually setup sccache so the build scripts will use
the remote cache.
