### PR TITLE
Remove Key Instruction builder and add a new Debugify builder

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1039,25 +1039,6 @@ all = [
                         "-DLLVM_USE_LINKER=gold",
                         "-DLLVM_ENABLE_WERROR=OFF"])},
 
-    {'name': "llvm-clang-key-instructions",
-    'tags'  : ["llvm", "clang", "compiler-rt", "lld", "cross-project-tests"],
-    'workernames': ["sie-linux-worker5"],
-    'builddir': "llvm-ki",
-    'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
-                    depends_on_projects=['llvm','clang','compiler-rt','lld','cross-project-tests'],
-                    extra_configure_args=[
-                        "-DCMAKE_C_COMPILER=gcc",
-                        "-DCMAKE_CXX_COMPILER=g++",
-                        "-DCMAKE_BUILD_TYPE=Release",
-                        "-DCLANG_ENABLE_CLANGD=OFF",
-                        "-DLLVM_BUILD_RUNTIME=ON",
-                        "-DLLVM_BUILD_TESTS=ON",
-                        "-DLLVM_ENABLE_ASSERTIONS=ON",
-                        "-DLLVM_EXPERIMENTAL_KEY_INSTRUCTIONS=ON",
-                        "-DLLVM_INCLUDE_EXAMPLES=OFF",
-                        "-DLLVM_LIT_ARGS=--verbose --timeout=900",
-                        "-DLLVM_USE_LINKER=gold"])},
-
     {'name': "llvm-clang-x86_64-darwin",
     'tags'  : ["llvm", "clang", "clang-tools-extra", "lld", "cross-project-tests"],
     'workernames': ["doug-worker-3"],

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1039,6 +1039,28 @@ all = [
                         "-DLLVM_USE_LINKER=gold",
                         "-DLLVM_ENABLE_WERROR=OFF"])},
 
+    {'name': "llvm-x86_64-debugify-coverage",
+     'tags': ["llvm", "clang", "lld"],
+     'workernames': ["sie-linux-worker5"],
+     'builddir': "llvm-dbg",
+     'factory': DebugifyBuilder.getDebugifyBuildFactory(
+                    clean=True,
+                    depends_on_projects=['llvm','clang','lld'],
+                    extra_configure_args=[
+                        "-DCMAKE_C_COMPILER=clang",
+                        "-DCMAKE_CXX_COMPILER=clang++",
+                        "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                        "-DCMAKE_C_FLAGS_RELWITHDEBINFO=-O2 -gmlt -DNDEBUG",
+                        "-DCMAKE_CXX_FLAGS_RELWITHDEBINFO=-O2 -gmlt -DNDEBUG",
+                        "-DLLVM_CCACHE_BUILD=ON",
+                        "-DLLVM_BUILD_TESTS=ON",
+                        "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_INCLUDE_EXAMPLES=OFF",
+                        "-DLLVM_TARGETS_TO_BUILD=X86",
+                        "-DLLVM_LIT_ARGS=-v",
+                        "-DLLVM_USE_LINKER=lld",
+                        "-DLLVM_ENABLE_WERROR=OFF"])},
+
     {'name': "llvm-clang-x86_64-darwin",
     'tags'  : ["llvm", "clang", "clang-tools-extra", "lld", "cross-project-tests"],
     'workernames': ["doug-worker-3"],

--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -359,7 +359,8 @@ def getReporters():
                         "clang-x86_64-linux-abi-test",
                         "llvm-clang-x86_64-darwin",
                         "llvm-clang-aarch64-darwin",
-                        "llvm-clang-aarch64-darwin-release"])
+                        "llvm-clang-aarch64-darwin-release",
+                        "llvm-x86_64-debugify-coverage"])
             ]),
         reporters.MailNotifier(
             fromaddr = status_email_fromaddr,
@@ -558,6 +559,16 @@ def getReporters():
                         "flang-runtime-cuda-gcc",
                         "flang-runtime-cuda-clang"])
             ]),
+        reporters.MailNotifier(
+            fromaddr = status_email_fromaddr,
+            sendToInterestedUsers = False,
+            extraRecipients = ["stephen.tozer@sony.com"],
+            generators = [
+                utils.LLVMDefaultBuildStatusGenerator(
+                    builders = [
+                        "llvm-x86_64-debugify-coverage"])
+            ]),
+
     ])
 
     return r

--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -359,8 +359,7 @@ def getReporters():
                         "clang-x86_64-linux-abi-test",
                         "llvm-clang-x86_64-darwin",
                         "llvm-clang-aarch64-darwin",
-                        "llvm-clang-aarch64-darwin-release",
-                        "llvm-clang-key-instructions"])
+                        "llvm-clang-aarch64-darwin-release"])
             ]),
         reporters.MailNotifier(
             fromaddr = status_email_fromaddr,
@@ -485,8 +484,7 @@ def getReporters():
                 utils.LLVMDefaultBuildStatusGenerator(
                     builders = [
                         "cross-project-tests-sie-ubuntu",
-                        "llvm-clang-x86_64-sie-win",
-                        "llvm-clang-key-instructions"])
+                        "llvm-clang-x86_64-sie-win"])
             ]),
         reporters.MailNotifier(
             fromaddr = status_email_fromaddr,


### PR DESCRIPTION
We no longer need the Key Instructions builder, so this change removes it, and reassigns the worker to a new Debugify builder that is being added. Additionally this removes the notifications for the old builder and adds new ones for the new builder.

This change depends on #493. 