### PR TITLE
[CI] Add more premerge buildbot workers

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3545,24 +3545,64 @@ all += [
     # postcommit (after changes have landed in main). The configuration for
     # running these checks premerge exists in the monorepo inside the
     # .github/workflows/premerge.yaml file.
-    {'name': "premerge-monolithic-linux",
-     'workernames': ["premerge-us-central-linux", "premerge-us-west-linux"],
-     'builddir': "premerge-monolithic-linux",
-     'factory': AnnotatedBuilder.getAnnotatedBuildFactory(
-                    script="premerge/dispatch_job.py",
-                    checkout_llvm_sources=False,
-                    extra_args=["Linux"],
-                    depends_on_projects=["bolt", "clang", "clang-tools-extra", "compiler-rt", "flang", "flang-rt", "libc", "libclc", "lld", "lldb", "llvm", "mlir", "polly"])},
-    
-    {'name': "premerge-monolithic-windows",
-     'workernames': ["premerge-us-central-windows", "premerge-us-west-windows"],
-     'builddir': "premerge-monolithic-windows",
-     'factory': AnnotatedBuilder.getAnnotatedBuildFactory(
-                    script="premerge/dispatch_job.py",
-                    checkout_llvm_sources=False,
-                    extra_args=["Windows"],
-                    depends_on_projects=["clang-tools-extra", "clang", "libclc", "lld", "llvm", "mlir", "polly"])},
-    
+    {
+        "name": "premerge-monolithic-linux",
+        "workernames": [
+            "premerge-us-central-linux-b1",
+            "premerge-us-central-linux-b2",
+            "premerge-us-central-linux-b3",
+            "premerge-us-west-linux-b1",
+            "premerge-us-west-linux-b2",
+            "premerge-us-west-linux-b3",
+        ],
+        "builddir": "premerge-monolithic-linux",
+        "factory": AnnotatedBuilder.getAnnotatedBuildFactory(
+            script="premerge/dispatch_job.py",
+            checkout_llvm_sources=False,
+            extra_args=["Linux"],
+            depends_on_projects=[
+                "bolt",
+                "clang",
+                "clang-tools-extra",
+                "compiler-rt",
+                "flang",
+                "flang-rt",
+                "libc",
+                "libclc",
+                "lld",
+                "lldb",
+                "llvm",
+                "mlir",
+                "polly",
+            ],
+        ),
+    },
+    {
+        "name": "premerge-monolithic-windows",
+        "workernames": [
+            "premerge-us-central-windows-b1",
+            "premerge-us-central-windows-b2",
+            "premerge-us-central-windows-b3",
+            "premerge-us-west-windows-b1",
+            "premerge-us-west-windows-b2",
+            "premerge-us-west-windows-b3",
+        ],
+        "builddir": "premerge-monolithic-windows",
+        "factory": AnnotatedBuilder.getAnnotatedBuildFactory(
+            script="premerge/dispatch_job.py",
+            checkout_llvm_sources=False,
+            extra_args=["Windows"],
+            depends_on_projects=[
+                "clang-tools-extra",
+                "clang",
+                "libclc",
+                "lld",
+                "llvm",
+                "mlir",
+                "polly",
+            ],
+        ),
+    },
     # Builders for the profcheck configuration
     # These workers run builds with LLVM_ENABLE_PROFCHECK=ON to ensure
     # that profile information is propagated correctly.

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -419,7 +419,7 @@ def get_all():
         create_worker("premerge-us-west-linux-b3", properties={'jobs': 64}, max_builds=1),
         create_worker("premerge-us-west-windows-b1", properties={'jobs': 64}, max_builds=1),
         create_worker("premerge-us-west-windows-b2", properties={'jobs': 64}, max_builds=1),
-        create_worker("premerge-us-west-windows-b2", properties={'jobs': 64}, max_builds=1),
+        create_worker("premerge-us-west-windows-b3", properties={'jobs': 64}, max_builds=1),
 
         # Workers for the profcheck configuration
         # These workers run builds with LLVM_ENABLE_PROFCHECK=ON to ensure

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -408,10 +408,18 @@ def get_all():
         # postcommit (after changes have landed in main). The workers for the
         # infrastructure that runs the checks premerge are setup through Github
         # Actions under the premerge/ folder in llvm-zorg.
-        create_worker("premerge-us-central-linux", properties={'jobs': 64}, max_builds=3),
-        create_worker("premerge-us-central-windows", properties={'jobs': 64}, max_builds=3),
-        create_worker("premerge-us-west-linux", properties={'jobs': 64}, max_builds=3),
-        create_worker("premerge-us-west-windows", properties={'jobs': 64}, max_builds=3),
+        create_worker("premerge-us-central-linux-b1", properties={'jobs': 64}, max_builds=1),
+        create_worker("premerge-us-central-linux-b2", properties={'jobs': 64}, max_builds=1),
+        create_worker("premerge-us-central-linux-b3", properties={'jobs': 64}, max_builds=1),
+        create_worker("premerge-us-central-windows-b1", properties={'jobs': 64}, max_builds=1),
+        create_worker("premerge-us-central-windows-b2", properties={'jobs': 64}, max_builds=1),
+        create_worker("premerge-us-central-windows-b3", properties={'jobs': 64}, max_builds=1),
+        create_worker("premerge-us-west-linux-b1", properties={'jobs': 64}, max_builds=1),
+        create_worker("premerge-us-west-linux-b2", properties={'jobs': 64}, max_builds=1),
+        create_worker("premerge-us-west-linux-b3", properties={'jobs': 64}, max_builds=1),
+        create_worker("premerge-us-west-windows-b1", properties={'jobs': 64}, max_builds=1),
+        create_worker("premerge-us-west-windows-b2", properties={'jobs': 64}, max_builds=1),
+        create_worker("premerge-us-west-windows-b2", properties={'jobs': 64}, max_builds=1),
 
         # Workers for the profcheck configuration
         # These workers run builds with LLVM_ENABLE_PROFCHECK=ON to ensure


### PR DESCRIPTION
The original intention for the premerge workers was that they could handle multiple builds at the same time. However, buildbot does not support a worker running more than one job at a time for a single builder, which is how we have things setup. Switch to having three builders per platform per cluster rather than one builder with max_builders set to 3.