### PR TITLE
[CI] Use iam_member instead of iam_binding for BQ JobUser role

### DIFF
--- a/premerge/main.tf
+++ b/premerge/main.tf
@@ -262,15 +262,10 @@ resource "google_service_account" "operational_metrics_gsa" {
   display_name = "Operational Metrics GSA"
 }
 
-resource "google_project_iam_binding" "bigquery_jobuser_binding" {
+resource "google_project_iam_member" "operational_metrics_gsa_bq_jobuser_member" {
   project = google_service_account.operational_metrics_gsa.project
   role    = "roles/bigquery.jobUser"
-
-  members = [
-    "serviceAccount:${google_service_account.operational_metrics_gsa.email}",
-  ]
-
-  depends_on = [google_service_account.operational_metrics_gsa]
+  member  = "serviceAccount:${google_service_account.operational_metrics_gsa.email}"
 }
 
 resource "kubernetes_namespace" "operational_metrics" {

--- a/premerge/main.tf
+++ b/premerge/main.tf
@@ -266,6 +266,8 @@ resource "google_project_iam_member" "operational_metrics_gsa_bq_jobuser_member"
   project = google_service_account.operational_metrics_gsa.project
   role    = "roles/bigquery.jobUser"
   member  = "serviceAccount:${google_service_account.operational_metrics_gsa.email}"
+
+  depends_on = [google_service_account.operational_metrics_gsa]
 }
 
 resource "kubernetes_namespace" "operational_metrics" {


### PR DESCRIPTION
This change makes it so the `bigquery.jobUser` role can be granted to new members while preserving grants for past members. `google_project_iam_binding` is authoritative, and revokes role access for all other members who are not listed in the resource definition when running `terraform apply`. This is problematic as we now have another internal service account that needs access to `role/bigquery.jobUser`, and it's membership will continue to be revoked as long as we define a binding here.