### PR TITLE
[ProfCheck] Switch to annotated builder

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3606,20 +3606,14 @@ all += [
     # Builders for the profcheck configuration
     # These workers run builds with LLVM_ENABLE_PROFCHECK=ON to ensure
     # that profile information is propagated correctly.
-    {'name' : "profcheck",
-     'workernames' : ["profcheck-b1", "profcheck-b2"],
-     'builddir': "profcheck-build",
-     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
-                     clean=True,
-                     depends_on_projects=['llvm'],
-                     extra_configure_args=[
-                         "-DCMAKE_BUILD_TYPE=Release",
-                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
-                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
-                         "-DLLVM_ENABLE_ASSERTIONS=ON",
-                         "-DLLVM_LIT_ARGS='--exclude-xfail'",
-                         "-DLLVM_ENABLE_PROFCHECK=ON",
-                     ])},
+    {
+        "name": "profcheck",
+        "workernames": ["profcheck-b1", "profcheck-b2"],
+        "builddir": "profcheck-build",
+        "factory": AnnotatedBuilder.getAnnotatedBuildFactory(
+            script="profcheck.sh", clean=True, depends_on_projects=["llvm"]
+        ),
+    },
 ]
 
 # LLDB remote-linux builder env variables.

--- a/zorg/buildbot/builders/annotated/profcheck.sh
+++ b/zorg/buildbot/builders/annotated/profcheck.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -ex
+
+rm -rf build
+mkdir build
+cd build
+
+echo @@@CMake@@@
+
+cmake -GNinja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
+  -DLLVM_LIT_ARGS='--exclude-xfail' \
+  -DLLVM_ENABLE_PROFCHECK=ON \
+  ../llvm
+
+echo @@@Ninja@@@
+
+export LIT_XFAIL="$(cat ../llvm/utils/profcheck-xfail.txt | tr '\n' ';')"
+ninja check-llvm


### PR DESCRIPTION
This allows setting the LIT_XFAIL environment variable before running ninja which enables excluding tests from a file in the LLVM tree. I do not believe this is possible outside of an annotated builder.