### PR TITLE
[ProfCheck] Disable collapsing requests

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3609,6 +3609,7 @@ all += [
     {
         "name": "profcheck",
         "workernames": ["profcheck-b1", "profcheck-b2"],
+        "collapseRequests": False,
         "builddir": "profcheck-build",
         "factory": AnnotatedBuilder.getAnnotatedBuildFactory(
             script="profcheck.sh",


### PR DESCRIPTION
The build is fast enough that we have enough capacity for this. Disabling request collapsing ensures that the blame list is limited to a single commit.