### PR TITLE
[CI] Add notifications for premerge buildbots

### DIFF
--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -577,6 +577,23 @@ def getReporters():
                     builders = [
                         "profcheck"])
             ]),
+        reporters.MailNotifier(
+            fromaddr=status_email_fromaddr,
+            sendToInterestedUsers=False,
+            extraRecipients=[
+                "llvm-presubmit-infra@google.com",
+                "aidengrossman@google.com",
+                "cmtice@google.com",
+            ],
+            generators=[
+                utils.LLVMDefaultBuildStatusGenerator(
+                    subject="Premerge Buildbot Failure: {{ buildername }}",
+                    builders=[
+                        "premerge-monolithic-linux",
+                        "premerge-monolithic-windows",
+                    ],
+                )
+            ]),
     ])
 
     return r

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -408,19 +408,126 @@ def get_all():
         # postcommit (after changes have landed in main). The workers for the
         # infrastructure that runs the checks premerge are setup through Github
         # Actions under the premerge/ folder in llvm-zorg.
-        create_worker("premerge-us-central-linux-b1", properties={'jobs': 64}, max_builds=1),
-        create_worker("premerge-us-central-linux-b2", properties={'jobs': 64}, max_builds=1),
-        create_worker("premerge-us-central-linux-b3", properties={'jobs': 64}, max_builds=1),
-        create_worker("premerge-us-central-windows-b1", properties={'jobs': 64}, max_builds=1),
-        create_worker("premerge-us-central-windows-b2", properties={'jobs': 64}, max_builds=1),
-        create_worker("premerge-us-central-windows-b3", properties={'jobs': 64}, max_builds=1),
-        create_worker("premerge-us-west-linux-b1", properties={'jobs': 64}, max_builds=1),
-        create_worker("premerge-us-west-linux-b2", properties={'jobs': 64}, max_builds=1),
-        create_worker("premerge-us-west-linux-b3", properties={'jobs': 64}, max_builds=1),
-        create_worker("premerge-us-west-windows-b1", properties={'jobs': 64}, max_builds=1),
-        create_worker("premerge-us-west-windows-b2", properties={'jobs': 64}, max_builds=1),
-        create_worker("premerge-us-west-windows-b3", properties={'jobs': 64}, max_builds=1),
-
+        create_worker(
+            "premerge-us-central-linux-b1",
+            properties={"jobs": 64},
+            max_builds=1,
+            notify_on_missing=[
+                "llvm-presubmit-infra@google.com",
+                "aidengrossman@google.com",
+                "cmtice@google.com",
+            ],
+        ),
+        create_worker(
+            "premerge-us-central-linux-b2",
+            properties={"jobs": 64},
+            max_builds=1,
+            notify_on_missing=[
+                "llvm-presubmit-infra@google.com",
+                "aidengrossman@google.com",
+                "cmtice@google.com",
+            ],
+        ),
+        create_worker(
+            "premerge-us-central-linux-b3",
+            properties={"jobs": 64},
+            max_builds=1,
+            notify_on_missing=[
+                "llvm-presubmit-infra@google.com",
+                "aidengrossman@google.com",
+                "cmtice@google.com",
+            ],
+        ),
+        create_worker(
+            "premerge-us-central-windows-b1",
+            properties={"jobs": 64},
+            max_builds=1,
+            notify_on_missing=[
+                "llvm-presubmit-infra@google.com",
+                "aidengrossman@google.com",
+                "cmtice@google.com",
+            ],
+        ),
+        create_worker(
+            "premerge-us-central-windows-b2",
+            properties={"jobs": 64},
+            max_builds=1,
+            notify_on_missing=[
+                "llvm-presubmit-infra@google.com",
+                "aidengrossman@google.com",
+                "cmtice@google.com",
+            ],
+        ),
+        create_worker(
+            "premerge-us-central-windows-b3",
+            properties={"jobs": 64},
+            max_builds=1,
+            notify_on_missing=[
+                "llvm-presubmit-infra@google.com",
+                "aidengrossman@google.com",
+                "cmtice@google.com",
+            ],
+        ),
+        create_worker(
+            "premerge-us-west-linux-b1",
+            properties={"jobs": 64},
+            max_builds=1,
+            notify_on_missing=[
+                "llvm-presubmit-infra@google.com",
+                "aidengrossman@google.com",
+                "cmtice@google.com",
+            ],
+        ),
+        create_worker(
+            "premerge-us-west-linux-b2",
+            properties={"jobs": 64},
+            max_builds=1,
+            notify_on_missing=[
+                "llvm-presubmit-infra@google.com",
+                "aidengrossman@google.com",
+                "cmtice@google.com",
+            ],
+        ),
+        create_worker(
+            "premerge-us-west-linux-b3",
+            properties={"jobs": 64},
+            max_builds=1,
+            notify_on_missing=[
+                "llvm-presubmit-infra@google.com",
+                "aidengrossman@google.com",
+                "cmtice@google.com",
+            ],
+        ),
+        create_worker(
+            "premerge-us-west-windows-b1",
+            properties={"jobs": 64},
+            max_builds=1,
+            notify_on_missing=[
+                "llvm-presubmit-infra@google.com",
+                "aidengrossman@google.com",
+                "cmtice@google.com",
+            ],
+        ),
+        create_worker(
+            "premerge-us-west-windows-b2",
+            properties={"jobs": 64},
+            max_builds=1,
+            notify_on_missing=[
+                "llvm-presubmit-infra@google.com",
+                "aidengrossman@google.com",
+                "cmtice@google.com",
+            ],
+        ),
+        create_worker(
+            "premerge-us-west-windows-b3",
+            properties={"jobs": 64},
+            max_builds=1,
+            notify_on_missing=[
+                "llvm-presubmit-infra@google.com",
+                "aidengrossman@google.com",
+                "cmtice@google.com",
+            ],
+        ),
         # Workers for the profcheck configuration
         # These workers run builds with LLVM_ENABLE_PROFCHECK=ON to ensure
         # that profile information is propagated correctly.


### PR DESCRIPTION
This is so that the appropriate people are getting notifications when there are failures related to the premerge buildbots. Most of the time no action is needed as build failures happen reasonably often and are usually fixed quickly. Having the notifications (especially for missing workers) helps ensure that the infra is not down/broken for a while.

Currently adding the premerge rotation, myself and Caroline. We might eventually want to only have the premerge rotation on this, but as we stabilize the infrastructure, having more people get notifications should be helpful.