### PR TITLE
Add flang-arm64-windows-msvc-testsuite builder

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2631,6 +2631,29 @@ all += [
                         "-DCOMPILER_RT_BUILD_SANITIZERS=OFF",
                         "-DLLVM_CCACHE_BUILD=ON"])},
 
+    {'name' : "flang-arm64-windows-msvc-testsuite",
+    'tags'  : ["flang"],
+    'workernames' : ["linaro-armv8-windows-msvc-06"],
+    'builddir': "flang-arm64-win-msvc-ts",
+    'factory' : ClangBuilder.getClangCMakeBuildFactory(
+                    vs="manual",
+                    clean=False,
+                    checkout_flang=True,
+                    checkout_lld=True,
+                    runTestSuite=True,
+                    testStage1=False,
+                    testsuite_flags=[
+                        '--cmake-define', "TEST_SUITE_SUBDIRS='Fortran'",
+                        '--use-make=ninja',
+                        '--threads=8',
+                        '--build-threads=8'],
+                    extra_cmake_args=[
+                        "-DLLVM_TARGETS_TO_BUILD=AArch64",
+                        "-DCLANG_DEFAULT_LINKER=lld",
+                        "-DCMAKE_TRY_COMPILE_CONFIGURATION=Release",
+                        "-DCOMPILER_RT_BUILD_SANITIZERS=OFF",
+                        "-DLLVM_CCACHE_BUILD=ON"])},
+
     {'name' : 'ppc64-flang-aix',
     'tags'  : ["flang", "ppc", "ppc64", "aix"],
     'workernames' : ['ppc64-flang-aix-test'],

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -51,6 +51,7 @@ def get_all():
         create_worker("linaro-armv8-windows-msvc-03", max_builds=1),
         create_worker("linaro-armv8-windows-msvc-04", max_builds=1),
         create_worker("linaro-armv8-windows-msvc-05", max_builds=1),
+        create_worker("linaro-armv8-windows-msvc-06", max_builds=1),
 
         # Linux s390x Ubuntu Focal, IBM z13 (5GHz), 64GB of RAM
         create_worker("onnx-mlir-nowarn-linux-s390x", properties={'jobs' : 4}, max_builds=1),


### PR DESCRIPTION
This PR adds a new buildbot to run LLVM testsuite on windows. It adds a new builder and worker pair. The testsuite will run after the first stage build skipping the ninja check step as we cover that on other buildbots. This will primarily be the builder to test that ensures LNT and LLVM testsuite are running without regressions on windows. We will later build on it to add support for test more as our Windows hardware availability improves.

This depends on #575 and llvm/llvm-project#155226. 