### PR TITLE
Insert debugify-report into the test suite build directory

### DIFF
--- a/zorg/buildbot/builders/DebugifyBuilder.py
+++ b/zorg/buildbot/builders/DebugifyBuilder.py
@@ -1,6 +1,7 @@
 from buildbot.plugins import util
 from buildbot.steps.shell import ShellCommand
 from zorg.buildbot.builders import TestSuiteBuilder
+from zorg.buildbot.builders.TestSuiteBuilder import test_suite_build_path
 from zorg.buildbot.commands.CmakeCommand import CmakeCommand
 
 
@@ -53,7 +54,9 @@ def getDebugifyBuildFactory(
     ])
 
     # This path will be passed through to util.Interpolate, so we leave it in this format.
-    debugify_output_path = f"%(prop:builddir)s/debugify-report.json"
+    # NB: This must be stored in the test suite build directory, as that is the only way to ensure that it is
+    # unconditionally up before (and not after) each run.
+    debugify_output_path = f"%(prop:builddir)s/{test_suite_build_path}/debugify-report.json"
 
     # Make a local copy of the test suite configure args, as we are going to modify that.
     if extra_test_suite_configure_args is not None:

--- a/zorg/buildbot/builders/TestSuiteBuilder.py
+++ b/zorg/buildbot/builders/TestSuiteBuilder.py
@@ -8,6 +8,9 @@ from zorg.buildbot.commands.CmakeCommand import CmakeCommand
 from zorg.buildbot.commands.NinjaCommand import NinjaCommand
 from zorg.buildbot.commands.LitTestCommand import LitTestCommand
 
+# The DebugifyBuilder needs to know the test-suite build directory, so we share the build directory via this variable.
+test_suite_build_path = 'test/build-test-suite'
+
 # This builder is uses UnifiedTreeBuilders and adds running
 # llvm-test-suite with cmake and ninja step.
 
@@ -30,7 +33,7 @@ def addTestSuiteStep(
     lit = util.Interpolate('%(prop:builddir)s/' + compiler_dir + '/bin/llvm-lit')
     test_suite_base_dir = util.Interpolate('%(prop:builddir)s/' + 'test')
     test_suite_src_dir = util.Interpolate('%(prop:builddir)s/' + 'test/test-suite')
-    test_suite_workdir = util.Interpolate('%(prop:builddir)s/' + 'test/build-test-suite')
+    test_suite_workdir = util.Interpolate('%(prop:builddir)s/' + test_suite_build_path)
     cmake_lit_arg = util.Interpolate('-DTEST_SUITE_LIT:FILEPATH=%(prop:builddir)s/' + compiler_dir + '/bin/llvm-lit')
     # used for cmake building test-suite step
     if extra_configure_args is not None:


### PR DESCRIPTION
As part of the DebugifyBuilder, we add cflag arguments to the test suite build step containing the path of a report file, where any bugs detected by debugify will be written. Debugify appends to the file rather than replacing it, as we wish to accumulate the bugs found in all invocations of Clang during the test suite build step to a single file. Currently however, this file is not cleaned up after builds, meaning that we are constantly appending bugs to the same file after each test run, rather than creating a fresh file - this contaminates the results for future builds, as bugs will never disappear from the list even if they no longer exist in LLVM. This patch moves the report file into the test suite build directory, which will always be cleaned before each test run, preventing the results of one run from seeping into subsequent runs.