### PR TITLE
[CI] Add flang-rt to postcommit testing

### DIFF
--- a/zorg/buildbot/builders/annotated/premerge/dispatch_job.py
+++ b/zorg/buildbot/builders/annotated/premerge/dispatch_job.py
@@ -110,7 +110,7 @@ def start_build_linux(commit_sha: str, bucket_name: str, k8s_client) -> str:
         "export SCCACHE_GCS_RW_MODE=READ_WRITE",
         "export SCCACHE_IDLE_TIMEOUT=0",
         "sccache --start-server",
-        './.ci/monolithic-linux.sh "bolt;clang;clang-tools-extra;flang;libclc;lld;lldb;llvm;mlir;polly" "check-bolt check-clang check-clang-tools check-flang check-lld check-lldb check-llvm check-mlir check-polly" "compiler-rt;libc;libcxx;libcxxabi;libunwind" "check-compiler-rt check-libc" "check-cxx check-cxxabi check-unwind" "OFF"',
+        './.ci/monolithic-linux.sh "bolt;clang;clang-tools-extra;flang;libclc;lld;lldb;llvm;mlir;polly" "check-bolt check-clang check-clang-tools check-flang check-lld check-lldb check-llvm check-mlir check-polly" "compiler-rt;flang-rt;libc;libcxx;libcxxabi;libunwind" "check-compiler-rt check-flang-rt check-libc" "check-cxx check-cxxabi check-unwind" "OFF"',
         "python .ci/cache_lit_timing_files.py upload",
         "echo BUILD FINISHED",
     ]


### PR DESCRIPTION
This patch ensures we test flang-rt postcommit so we are actually testing the configuration introduced by #156039.