### PR TITLE
[ClangBuilder] Correct path of testsuite virtualenv's Python

### DIFF
--- a/zorg/buildbot/builders/ClangBuilder.py
+++ b/zorg/buildbot/builders/ClangBuilder.py
@@ -533,7 +533,8 @@ def _getClangCMakeBuildFactory(
                                    env=env))
 
         # Get generated python, lnt
-        python = InterpolateToPosixPath('%(prop:builddir)s/test/sandbox/Scripts/python')
+        virtualenv_dir = 'Scripts' if vs else 'bin'
+        python = InterpolateToPosixPath(f'%(prop:builddir)s/test/sandbox/{virtualenv_dir}/python')
         lnt_ext = '.exe' if vs else ''
         lnt = InterpolateToPosixPath(f'%(prop:builddir)s/test/sandbox/Scripts/lnt{lnt_ext}')
         lnt_setup = InterpolateToPosixPath('%(prop:builddir)s/test/lnt/setup.py')


### PR DESCRIPTION
Fixes 60d2141a5073ce1330bc45e4cc827344af67894b.

On Windows, it's Scripts/python, on Linux it's bin/python.

Unfortunately there is no third common path to use. Even the virtualenv docs have different paths for Windows and everything else: https://virtualenv.pypa.io/en/latest/user_guide.html#quick-start