### PR TITLE
Revert "Enable BOLT project on Aarch64/Linux Windows host cross builder."

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -269,7 +269,7 @@ all = [
         },
 
     {'name' : "llvm-clang-win-x-aarch64",
-    'tags'  : ["clang", "llvm", "lld", "clang-tools-extra", "compiler-rt", "libc++", "libc++abi", "libunwind", "bolt", "cross", "aarch64"],
+    'tags'  : ["clang", "llvm", "lld", "clang-tools-extra", "compiler-rt", "libc++", "libc++abi", "libunwind", "cross", "aarch64"],
     'workernames' : ["as-builder-2"],
     'builddir': "x-aarch64",
     'factory' : UnifiedTreeBuilder.getCmakeExBuildFactory(
@@ -282,7 +282,6 @@ all = [
                         'libcxx',
                         'libcxxabi',
                         'lld',
-                        'bolt',
                     ],
                     vs = "autodetect",
                     clean = True,
@@ -290,7 +289,6 @@ all = [
                         "check-llvm",
                         "check-clang",
                         "check-lld",
-                        "check-bolt",
                         "check-compiler-rt-aarch64-unknown-linux-gnu",
                         "check-unwind-aarch64-unknown-linux-gnu",
                         "check-cxxabi-aarch64-unknown-linux-gnu",
@@ -299,8 +297,7 @@ all = [
                     cmake_definitions = {
                         "LLVM_TARGETS_TO_BUILD"         : "AArch64",
                         "LLVM_INCLUDE_BENCHMARKS"       : "OFF",
-                        # Allow long timeout for BOLT's dump-dot-func.test test.
-                        "LLVM_LIT_ARGS"                 : "-v -vv --threads=32 --time-tests --timeout=300",
+                        "LLVM_LIT_ARGS"                 : "-v -vv --threads=32 --time-tests",
                         "TOOLCHAIN_TARGET_TRIPLE"       : "aarch64-unknown-linux-gnu",
                         "TOOLCHAIN_TARGET_SYSROOTFS"    : util.Interpolate("%(prop:sysroot_path_agx)s"),
                         "REMOTE_TEST_HOST"              : util.Interpolate("%(prop:remote_host_agx)s"),
@@ -309,7 +306,6 @@ all = [
                         "CMAKE_CXX_FLAGS"               : "-D__OPTIMIZE__",
                         "CMAKE_C_COMPILER_LAUNCHER"     : "ccache",
                         "CMAKE_CXX_COMPILER_LAUNCHER"   : "ccache",
-                        "BOLT_TARGETS_TO_BUILD"         : "AArch64",
                     },
                     cmake_options = [
                         "-C", util.Interpolate("%(prop:srcdir_relative)s/clang/cmake/caches/CrossWinToARMLinux.cmake"),


### PR DESCRIPTION
Reverts llvm/llvm-zorg#577

Noticed unstable builder behavior during the BOLT tests. Requires investigation and update
https://lab.llvm.org/buildbot/#/builders/193/builds/10263
