### PR TITLE
[AMDGPU][Libc] Fix argument passing to script

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2081,7 +2081,8 @@ all += [
     'builddir': "openmp-offload-libc-amdgpu-runtime",
     'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
                     depends_on_projects=['llvm', 'clang', 'compiler-rt', 'lld', 'libc', 'offload', 'openmp', 'libunwind'],
-                    script='amdgpu-offload-cmake.py --cmake-file=AMDGPULibcBot.cmake',
+                    script='amdgpu-offload-cmake.py',
+                    extra_args=['--cmake-file=AMDGPULibcBot.cmake'],
                     checkout_llvm_sources=True,
                     script_interpreter=None
                 )},


### PR DESCRIPTION
Having the argument as part of the script name is an error as it tries to find / exec that exact string.
Pass theargument as extra_args instead. Not sure if we need to split argument name and value in separate array entries.