### PR TITLE
[ClangBuilder] Correct path of testsuite virtualenv's lnt

### DIFF
--- a/zorg/buildbot/builders/ClangBuilder.py
+++ b/zorg/buildbot/builders/ClangBuilder.py
@@ -536,7 +536,7 @@ def _getClangCMakeBuildFactory(
         virtualenv_dir = 'Scripts' if vs else 'bin'
         python = InterpolateToPosixPath(f'%(prop:builddir)s/test/sandbox/{virtualenv_dir}/python')
         lnt_ext = '.exe' if vs else ''
-        lnt = InterpolateToPosixPath(f'%(prop:builddir)s/test/sandbox/Scripts/lnt{lnt_ext}')
+        lnt = InterpolateToPosixPath(f'%(prop:builddir)s/test/sandbox/{virtualenv_dir}/lnt{lnt_ext}')
         lnt_setup = InterpolateToPosixPath('%(prop:builddir)s/test/lnt/setup.py')
 
         # Paths


### PR DESCRIPTION
This is a follow up to #586.

Fixes 60d2141a5073ce1330bc45e4cc827344af67894b.

We forgot to fix the lnt path to work on both windows and linux.

On Windows, it's Scripts/lnt, on Linux it's bin/lnt.