### PR TITLE
[AMDGPU] Add libcxx as listened-to project

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2082,7 +2082,7 @@ all += [
      # We would like to never collapse, but it seems the load is too high on that system to keep up.
     'builddir': "openmp-offload-libc-amdgpu-runtime",
     'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
-                    depends_on_projects=['llvm', 'clang', 'compiler-rt', 'lld', 'libc', 'offload', 'openmp', 'libunwind'],
+                    depends_on_projects=['llvm', 'clang', 'compiler-rt', 'lld', 'libc', 'libcxx', 'libcxxabi', 'offload', 'openmp', 'libunwind'],
                     script='amdgpu-offload-cmake.py',
                     extra_args=['--cmake-file=AMDGPULibcBot.cmake'],
                     checkout_llvm_sources=True,


### PR DESCRIPTION
we are going to enable building libcxx for the device on that builder and hence need to listen to changes in that project.