### PR TITLE
[ProfCheck] Disable Lit Internal Shell

### DIFF
--- a/zorg/buildbot/builders/annotated/profcheck.sh
+++ b/zorg/buildbot/builders/annotated/profcheck.sh
@@ -16,4 +16,5 @@ cmake -GNinja \
 echo @@@BUILD_STEP Ninja@@@
 
 export LIT_XFAIL="$(cat ../llvm-project/llvm/utils/profcheck-xfail.txt | tr '\n' ';')"
+export LIT_USE_INTERNAL_SHELL=0
 ninja check-llvm


### PR DESCRIPTION
This patch disables the use of lit's internal shell for the profcheck builder. This was enabled recently in the monorepo but is causing some test failures on the profcheck buildbot that needs more investigation. Turning off the internal shell for now to give me time to investigate things.