### PR TITLE
[CI] Track whether a commit is a revert

### DIFF
--- a/premerge/bigquery_schema/llvm_commits_table_schema.json
+++ b/premerge/bigquery_schema/llvm_commits_table_schema.json
@@ -57,13 +57,13 @@
     "name": "pull_request_reverted",
     "type": "INTEGER",
     "mode": "NULLABLE",
-    "description": "Pull request reverted by this commit"
+    "description": "Pull request matched in revert message. Not reliable for determining if a PR was reverted, `commit_reverted` may contain a commit belonging to a PR"
   },
   {
     "name": "commit_reverted",
     "type": "STRING",
     "mode": "NULLABLE",
-    "description": "Commit reverted by this commit"
+    "description": "Commit sha matched in revert message. Not reliable for determining if a commit was reverted, `pull_request_reverted` may contain a PR contributing a commit"
   },
   {
     "name": "diff",

--- a/premerge/bigquery_schema/llvm_commits_table_schema.json
+++ b/premerge/bigquery_schema/llvm_commits_table_schema.json
@@ -48,6 +48,24 @@
     "description": "List of GitHub users who reviewed the pull request for this commit"
   },
   {
+    "name": "is_revert",
+    "type": "BOOLEAN",
+    "mode": "NULLABLE",
+    "description": "Whether or not this commit is a revert"
+  },
+  {
+    "name": "pull_request_reverted",
+    "type": "INTEGER",
+    "mode": "NULLABLE",
+    "description": "Pull request reverted by this commit"
+  },
+  {
+    "name": "commit_reverted",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "Commit reverted by this commit"
+  },
+  {
     "name": "diff",
     "type": "RECORD",
     "mode": "REPEATED",

--- a/premerge/ops-container/process_llvm_commits.py
+++ b/premerge/ops-container/process_llvm_commits.py
@@ -121,14 +121,19 @@ def query_for_reviews(
   for commit in new_commits:
     # Check if this commit is a revert
     is_revert = (
-        re.match(r"^Revert \".*\"( \(#\d+\))?", commit.message) is not None
+        re.match(
+            r"^Revert \".*\"( \(#\d+\))?", commit.message, flags=re.IGNORECASE
+        )
+        is not None
     )
 
     # Check which pull request or commit is being reverted (if any)
     pull_request_match = re.search(
-        r"Reverts? (?:llvm\/llvm-project)?#(\d+)", commit.message
+        r"Reverts? (?:llvm\/llvm-project)?#(\d+)", commit.message, flags=re.IGNORECASE
     )
-    commit_match = re.search(r"This reverts commit (\w+)", commit.message)
+    commit_match = re.search(
+        r"This reverts commit (\w+)", commit.message, flags=re.IGNORECASE
+    )
     pull_request_reverted = (
         int(pull_request_match.group(1)) if pull_request_match else None
     )

--- a/premerge/ops-container/process_llvm_commits.py
+++ b/premerge/ops-container/process_llvm_commits.py
@@ -130,7 +130,7 @@ def query_for_reviews(
     )
     commit_match = re.search(r"This reverts commit (\w+)", commit.message)
     pull_request_reverted = (
-        pull_request_match.group(1) if pull_request_match else None
+        int(pull_request_match.group(1)) if pull_request_match else None
     )
     commit_reverted = commit_match.group(1) if commit_match else None
 


### PR DESCRIPTION
This changes adds additional fields for tracking whether a commit to llvm-project is a revert and what commit/pull request it is reverting.

Such commits are detecting by pattern matching against the commit message.