### PR TITLE
Reland Update the project dependencies for the lldb-remote-linux builders.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3664,7 +3664,20 @@ all += [
     'workernames': ["as-builder-9"],
     'builddir': "lldb-remote-linux-ubuntu",
     'factory': UnifiedTreeBuilder.getCmakeExBuildFactory(
-                    depends_on_projects = ["llvm", "clang", "lld", "lldb"],
+                    depends_on_projects = [
+                        'llvm',
+                        'compiler-rt',
+                        'clang',
+                        'libunwind',
+                        'libcxx',
+                        'libcxxabi',
+                        'lld',
+                        'lldb',
+                    ],
+                    # Allow only these projects with LLVM_ENABLE_PROJECTS.
+                    enable_projects = ["llvm", "clang", "lld", "lldb"],
+                    # Use a proper list of runtimes (LLVM_ENABLE_RUNTIMES) from CrossWinToARMLinux.cmake.
+                    # Avoid making it from a list of the depended projects.
                     enable_runtimes = None,
                     checks = [
                         "check-lldb-unit",
@@ -3702,9 +3715,6 @@ all += [
                         "LLDB_ENABLE_CURSES"            : "OFF",
                         "LLDB_ENABLE_LZMA"              : "OFF",
                         "LLDB_ENABLE_LIBXML2"           : "OFF",
-                        # No need to build lldb-server during the first stage.
-                        # We are going to build it for the target platform later.
-                        "LLDB_CAN_USE_LLDB_SERVER"      : "OFF",
                         "LLDB_TEST_USER_ARGS"           : util.Interpolate(
                                                             "--env;ARCH_CFLAGS=-mcpu=cortex-a78;" \
                                                             "--platform-name;remote-linux;" \
@@ -3793,7 +3803,20 @@ all += [
     'workernames': ["as-builder-10"],
     'builddir': "lldb-x-aarch64",
     'factory': UnifiedTreeBuilder.getCmakeExBuildFactory(
-                    depends_on_projects = ["llvm", "clang", "lld", "lldb"],
+                    depends_on_projects = [
+                        'llvm',
+                        'compiler-rt',
+                        'clang',
+                        'libunwind',
+                        'libcxx',
+                        'libcxxabi',
+                        'lld',
+                        'lldb',
+                    ],
+                    # Allow only these projects with LLVM_ENABLE_PROJECTS.
+                    enable_projects = ["llvm", "clang", "lld", "lldb"],
+                    # Use a proper list of runtimes (LLVM_ENABLE_RUNTIMES) from CrossWinToARMLinux.cmake.
+                    # Avoid making it from a list of the depended projects.
                     enable_runtimes = None,
                     checks = [
                         "check-lldb-unit",
@@ -3830,9 +3853,6 @@ all += [
                         "LLDB_ENABLE_CURSES"            : "OFF",
                         "LLDB_ENABLE_LZMA"              : "OFF",
                         "LLDB_ENABLE_LIBXML2"           : "OFF",
-                        # No need to build lldb-server during the first stage.
-                        # We are going to build it for the target platform later.
-                        "LLDB_CAN_USE_LLDB_SERVER"      : "OFF",
                         "LLDB_TEST_USER_ARGS"           : util.Interpolate(
                                                             "--env;ARCH_CFLAGS=-mcpu=cortex-a78;" \
                                                             "--platform-name;remote-linux;" \


### PR DESCRIPTION
Add additional dependencies with the libc++/libc++abi/libunwind and compiler-rt libraries.

Also removed unaffected LLDB_CAN_USE_LLDB_SERVER options.