### PR TITLE
[test-suite] Install LNT using requirements file

### DIFF
--- a/zorg/buildbot/builders/ClangBuilder.py
+++ b/zorg/buildbot/builders/ClangBuilder.py
@@ -622,7 +622,7 @@ def _getClangCMakeBuildFactory(
                                description='install lnt dependencies',
                                workdir='test/sandbox',
                                env=env))
-        f.addStep(ShellCommand(name='install lit in sandbox',
+        f.addStep(ShellCommand(name='install LNT in sandbox',
                                command=[python, '-m', 'pip', 'install', '-r',
                                         'requirements.client.txt'],
                                haltOnFailure=True,


### PR DESCRIPTION
Instead of "setup.py develop". Fixes https://github.com/llvm/llvm-lnt/issues/76.

The new process is tested in CI so we can catch problems before they get to the buildbots.

https://llvm.org/docs/lnt/quickstart.html#installation

The bots only use the client so I've used that specific requirement file as suggested.

The requirement file has an entry ".". This means "install the package defined in the current directory". "current" means the current working directory, not the directory the requirement file is in.

This is handled by running the install command from within the LNT checkout. LNT will still be installed in the sandbox as expected.