### PR TITLE
[CI] Make Advisor Autoupdate Schema

### DIFF
--- a/premerge/advisor/advisor_lib_test.py
+++ b/premerge/advisor/advisor_lib_test.py
@@ -1,7 +1,55 @@
 import unittest
 import tempfile
+import sqlite3
 
 import advisor_lib
+
+
+class AdvisorLibDbSetupTest(unittest.TestCase):
+    def setUp(self):
+        self.db_file = tempfile.NamedTemporaryFile()
+
+    def tearDown(self):
+        self.db_file.close()
+
+    def test_create_table(self):
+        db_connection = advisor_lib.setup_db(self.db_file.name)
+        db_connection.close()
+        connection = sqlite3.connect(self.db_file.name)
+        tables = connection.execute("SELECT name from sqlite_master").fetchall()
+        self.assertListEqual(tables, [("failures",)])
+        table_schema = connection.execute(
+            "SELECT sql FROM sqlite_master WHERE name=?", ("failures",)
+        ).fetchone()
+        self.assertEqual(table_schema, (advisor_lib._CREATE_TABLE_CMD,))
+        connection.close()
+
+    def test_update_schema(self):
+        connection_setup = sqlite3.connect(self.db_file.name)
+        connection_setup.execute("CREATE TABLE failures(dummy_field)")
+        connection_setup.close()
+
+        db_connection = advisor_lib.setup_db(self.db_file.name)
+        db_connection.close()
+
+        connection = sqlite3.connect(self.db_file.name)
+        tables = connection.execute("SELECT name from sqlite_master").fetchall()
+        found_failures_table = False
+        found_old_failures_table = False
+        for table_name in [table_tuple[0] for table_tuple in tables]:
+            if table_name == "failures":
+                found_failures_table = True
+                continue
+            elif table_name.startswith("failures_old_"):
+                found_old_failures_table = True
+                continue
+        self.assertTrue(found_failures_table)
+        self.assertTrue(found_old_failures_table)
+        table_schema = connection.execute(
+            "SELECT sql FROM sqlite_master WHERE name=?", ("failures",)
+        ).fetchone()
+        self.assertEqual(table_schema, (advisor_lib._CREATE_TABLE_CMD,))
+        connection.close()
 
 
 class AdvisorLibTest(unittest.TestCase):


### PR DESCRIPTION
This patch makes the premerge advisor server autoupdate the DB schema if we
ever end up changing it. We handle this by just dropping the existing table
as preserving all data for all time is completely unnecessary in our case.
Unittests have also been added to ensure that the setup_db function works as
it is supposed to.
