### PR TITLE
[CI] Make Premerge Advisor Explain Failures at Head

### DIFF
--- a/premerge/advisor/advisor.py
+++ b/premerge/advisor/advisor.py
@@ -28,7 +28,7 @@ def upload():
 
 @advisor_blueprint.route("/explain")
 def explain():
-    return advisor_lib.explain_failures(flask.request.json)
+    return advisor_lib.explain_failures(flask.request.json, _get_db())
 
 
 def create_app(db_path: str):

--- a/premerge/advisor/integration_test.py
+++ b/premerge/advisor/integration_test.py
@@ -27,8 +27,12 @@ class AdvisorIntegrationTest(unittest.TestCase):
         self.assertEqual(result.status_code, 204)
 
     def test_explain_failures(self):
-        failures = [{"name": "a.ll", "message": "failed"}]
-        result = self.client.get("/explain", json=failures)
+        explanation_request = {
+            "failures": [{"name": "a.ll", "message": "failed"}],
+            "base_commit_sha": "8d29a3bb6f3d92d65bf5811b53bf42bf63685359",
+            "platform": "x86_64-linux",
+        }
+        result = self.client.get("/explain", json=explanation_request)
         self.assertEqual(result.status_code, 200)
         self.assertListEqual(
             result.json, [{"name": "a.ll", "explained": False, "reason": None}]


### PR DESCRIPTION
This patch makes the premerge advisor explain away failures already occurring at
head that it is aware of. This currently has the gap that each premerge advisor
instance only knows the status of about half the commits due to job distribution
across the clusters. Exchanging data between the clusters will happen in a future
patch.
