### PR TITLE
[AMDGPU][OpenMP] Remove xfail for bare metal runner

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1981,7 +1981,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                         ],
                         add_lit_checks=['check-offload'],
-                        add_openmp_lit_args=["--time-tests", "--timeout 100",
+                        add_openmp_lit_args=["--time-tests", "--timeout 100"],
                     )},
 
     {'name' : "openmp-offload-amdgpu-runtime-2",


### PR DESCRIPTION
The test that was xfailed was failing only when run in a containerized
environment with the CPU set that the container executes on does not
match the physical CPU identification.
The buildbot is now back on a physical machine, so this works again.