### PR TITLE
collapse requests for ppc64le-flang bot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2576,7 +2576,6 @@ all += [
 
     {'name' : 'ppc64le-flang-rhel-clang',
     'tags'  : ["flang", "ppc", "ppc64le"],
-    'collapseRequests' : False,
     'workernames' : ['ppc64le-flang-rhel-test'],
     'builddir': 'ppc64le-flang-rhel-clang-build',
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(


### PR DESCRIPTION
The [ppc64le-flang-rhel-clang](https://lab.llvm.org/buildbot/#/builders/157) bot has trouble keeping up with builds, queue was up to 13 days before clearing. Collapsing requests will help manage queue length.