### PR TITLE
[CI] Add Library for Mapping Commit SHAs to Indexes

### DIFF
--- a/premerge/advisor/git_utils.py
+++ b/premerge/advisor/git_utils.py
@@ -46,9 +46,14 @@ def _get_and_add_commit_index(
         check=True,
     )
     log_lines = log_output.stdout.decode("utf-8").split("\n")[:-1]
-    for line_index, log_line in enumerate(log_lines):
+    if len(log_lines) == 0:
+        raise ValueError(
+            "Did not find any commits. The commit likely happened before the commit with index 1."
+        )
+    commit_index = latest_index + len(log_lines) + 1
+    for log_line in log_lines:
         line_commit_sha = log_line.split(" ")[0]
-        commit_index = latest_index + len(log_lines) - line_index
+        commit_index -= 1
         commits_to_add.append((line_commit_sha, commit_index))
     db_connection.executemany("INSERT INTO commits VALUES(?, ?)", commits_to_add)
     if not latest_commit_info:

--- a/premerge/advisor/git_utils_test.py
+++ b/premerge/advisor/git_utils_test.py
@@ -125,3 +125,20 @@ class GitUtilsTest(unittest.TestCase):
             ),
             4,
         )
+
+    def test_get_index_error_invalid_sha(self):
+        commit_shas = self.setup_repository(3)
+        with self.assertRaises(ValueError):
+            git_utils.get_commit_index(
+                commit_shas[0],
+                self.repository_path.name,
+                self.db_connection,
+                commit_shas[1],
+            )
+
+    def test_get_index_error_before_first_commit(self):
+        commit_shas = self.setup_repository(3)
+        with self.assertRaises(subprocess.CalledProcessError):
+            git_utils.get_commit_index(
+                "bad_sha", self.repository_path.name, self.db_connection, commit_shas[0]
+            )


### PR DESCRIPTION
We need to know the index of commits to make some heuristics easier to
write, for example, are there any reported failures in the last five
commits. This patch adds a library that allows getting the index of a
commit assuming linear history. The plan is to use this to ensure the
failures database has commit indices rather than commit SHAs.
