### PR TITLE
Update configuration for llvm-clang-ubuntu-x-aarch64-pauth builder.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3977,8 +3977,17 @@ all += [
                     post_build_steps =
                         TestSuiteBuilder.getLlvmTestSuiteSteps(
                             cmake_definitions = {
+                                "CMAKE_BUILD_TYPE"          : "Release",
+                                "CMAKE_C_FLAGS"             : "-march=armv8.3-a+pauth -mbranch-protection=pac-ret -faarch64-jump-table-hardening -O2",
+                                "CMAKE_CXX_FLAGS"           : "-march=armv8.3-a+pauth -mbranch-protection=pac-ret -faarch64-jump-table-hardening -O2",
+                                "CMAKE_EXE_LINKER_FLAGS"    : "-O2 -Wl,--emit-relocs",
+                                "CMAKE_MODULE_LINKER_FLAGS" : "-O2 -Wl,--emit-relocs",
+                                "CMAKE_SHARED_LINKER_FLAGS" : "-O2 -Wl,--emit-relocs",
+                                # Run on the devkit, limited set of tests.
                                 "TEST_SUITE_REMOTE_HOST"    : "buildbot@arm64-linux-02.lab.llvm.org",
-                                "TEST_SUITE_LIT_FLAGS"      : "-v --threads=32 --time-tests",
+                                "TEST_SUITE_LIT_FLAGS"      : "-v --threads=16 --time-tests",
+                                "TEST_SUITE_RUN_BENCHMARKS" : "ON",
+                                "TEST_SUITE_SUBDIRS"        : "SingleSource;MultiSource;MicroBenchmarks",
                             },
                             compiler_dir = util.Interpolate("%(prop:builddir)s/build"),
                         )


### PR DESCRIPTION
Added steps to build and run the LLVM TestSuite on the target board.

Also removed unneded toolchain library tests.