### PR TITLE
[clang-sparc64-linux] Use system clang and link against the shared lib

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -827,7 +827,10 @@ all = [
                     checkout_lld=False,
                     testsuite_flags=['--threads=32', '--build-threads=32'],
                     extra_cmake_args=['-DLLVM_ENABLE_PROJECTS=clang',
+                                      '-DCMAKE_C_COMPILER=clang',
+                                      '-DCMAKE_CXX_COMPILER=clang++',
                                       '-DLLVM_USE_LINKER=mold',
+                                      '-DLLVM_LINK_LLVM_DYLIB=ON',
                                       '-DLLVM_TARGETS_TO_BUILD=Sparc'])},
 
     ## LoongArch64 Clang+LLVM build check-all + test-suite


### PR DESCRIPTION
When doing manual builds on a local machine this configuration takes about 11% less time to finish a full build compared to the current one.
Hopefully this will fix the linking timeout issue in the buildbot.