### PR TITLE
[CI] Wire Up Premerge Advisor Hosts

### DIFF
--- a/premerge/advisor_deployment.yaml
+++ b/premerge/advisor_deployment.yaml
@@ -38,5 +38,7 @@ spec:
           env:
             - name: ADVISOR_DB_PATH
               value: "/db/advisor_db.sqlite"
+            - name: OTHER_ADVISOR_HOST
+              value: ${ other_advisor_host }
           ports:
           -  containerPort: 5000

--- a/premerge/main.tf
+++ b/premerge/main.tf
@@ -182,6 +182,7 @@ module "premerge_cluster_us_central_resources" {
   windows_buildbot_password                                = data.google_secret_manager_secret_version.us_central_windows_buildbot_password.secret_data
   linux_object_cache_buildbot_service_account_email        = module.premerge_cluster_us_central.linux_object_cache_buildbot_service_account_email
   windows_2022_object_cache_buildbot_service_account_email = module.premerge_cluster_us_central.windows_2022_object_cache_buildbot_service_account_email
+  other_premerge_advisor_host                              = "34.82.126.63"
   providers = {
     kubernetes = kubernetes.llvm-premerge-us-central
     helm       = helm.llvm-premerge-us-central
@@ -209,6 +210,7 @@ module "premerge_cluster_us_west_resources" {
   windows_buildbot_password                                = data.google_secret_manager_secret_version.us_west_windows_buildbot_password.secret_data
   linux_object_cache_buildbot_service_account_email        = module.premerge_cluster_us_west.linux_object_cache_buildbot_service_account_email
   windows_2022_object_cache_buildbot_service_account_email = module.premerge_cluster_us_west.windows_2022_object_cache_buildbot_service_account_email
+  other_premerge_advisor_host                              = "136.114.125.23"
   providers = {
     kubernetes = kubernetes.llvm-premerge-us-west
     helm       = helm.llvm-premerge-us-west

--- a/premerge/premerge_resources/main.tf
+++ b/premerge/premerge_resources/main.tf
@@ -500,7 +500,7 @@ resource "kubernetes_manifest" "premerge_advisor_pvc" {
 }
 
 resource "kubernetes_manifest" "premerge_advisor_deployment" {
-  manifest   = yamldecode(file("advisor_deployment.yaml"))
+  manifest   = yamldecode(templatefile("advisor_deployment.yaml", { other_advisor_host : var.other_premerge_advisor_host }))
   depends_on = [kubernetes_namespace.premerge_advisor, kubernetes_manifest.premerge_advisor_pvc]
 }
 

--- a/premerge/premerge_resources/variables.tf
+++ b/premerge/premerge_resources/variables.tf
@@ -133,3 +133,8 @@ variable "windows_2022_object_cache_buildbot_service_account_email" {
   description = "The email associated with the service account for the buildbot worker accessing the object cache on Windows."
   type        = string
 }
+
+variable "other_premerge_advisor_host" {
+  description = "The hostname of the premerge advisor in the other cluster."
+  type        = string
+}


### PR DESCRIPTION
This patch passes the hostname of the other premerge advisor into the container
so that we know where to request information that might exist on the other cluster.
The IP addresses are stable with how GKE allocates them for external load
balancers. Eventually we probably want to switch over to domains, but that's not
necessary for now.
