### PR TITLE
[CI] Calculate Commit Index When Uploading Failures

### DIFF
--- a/premerge/advisor/advisor.py
+++ b/premerge/advisor/advisor.py
@@ -22,7 +22,9 @@ def _close_db(exception):
 
 @advisor_blueprint.route("/upload", methods=["POST"])
 def upload():
-    advisor_lib.upload_failures(flask.request.json, _get_db())
+    advisor_lib.upload_failures(
+        flask.request.json, _get_db(), flask.current_app.config["REPO_PATH"]
+    )
     return flask.Response(status=204)
 
 
@@ -31,10 +33,11 @@ def explain():
     return advisor_lib.explain_failures(flask.request.json, _get_db())
 
 
-def create_app(db_path: str):
+def create_app(db_path: str, repository_path: str):
     app = Flask(__name__)
     app.register_blueprint(advisor_blueprint)
     app.teardown_appcontext(_close_db)
     with app.app_context():
         app.config["DB_PATH"] = db_path
+        app.config["REPO_PATH"] = repository_path
     return app

--- a/premerge/advisor/integration_test.py
+++ b/premerge/advisor/integration_test.py
@@ -1,22 +1,30 @@
 import unittest
 import tempfile
+import os
 
+import git_utils
 import advisor
 
 
 class AdvisorIntegrationTest(unittest.TestCase):
     def setUp(self):
         self.db_file = tempfile.NamedTemporaryFile()
-        self.app = advisor.create_app(self.db_file.name)
+        self.repository_path_dir = tempfile.TemporaryDirectory()
+        self.repository_path = os.path.join(self.repository_path_dir.name, "actions")
+        git_utils._clone_repository_if_not_present(
+            self.repository_path, "https://github.com/llvm/actions"
+        )
+        self.app = advisor.create_app(self.db_file.name, self.repository_path)
         self.client = self.app.test_client()
 
     def tearDown(self):
         self.db_file.close()
+        self.repository_path_dir.cleanup()
 
     def test_upload_failures(self):
         failure_info = {
             "source_type": "buildbot",
-            "base_commit_sha": "8d29a3bb6f3d92d65bf5811b53bf42bf63685359",
+            "base_commit_sha": "e375fbb0917869e940c189ee0c178155b104b28a",
             "source_id": "10000",
             "failures": [
                 {"name": "a.ll", "message": "failed in way 1"},
@@ -29,7 +37,7 @@ class AdvisorIntegrationTest(unittest.TestCase):
     def test_explain_failures(self):
         explanation_request = {
             "failures": [{"name": "a.ll", "message": "failed"}],
-            "base_commit_sha": "8d29a3bb6f3d92d65bf5811b53bf42bf63685359",
+            "base_commit_sha": "e375fbb0917869e940c189ee0c178155b104b28a",
             "platform": "x86_64-linux",
         }
         result = self.client.get("/explain", json=explanation_request)

--- a/premerge/advisor/server.py
+++ b/premerge/advisor/server.py
@@ -4,5 +4,7 @@ import advisor
 
 
 if __name__ == "__main__":
-    app = advisor.create_app(os.environ["ADVISOR_DB_PATH"])
+    app = advisor.create_app(
+        os.environ["ADVISOR_DB_PATH"], os.environ["ADVISOR_REPO_PATH"]
+    )
     app.run(host="0.0.0.0", port=5000)

--- a/premerge/advisor_deployment.yaml
+++ b/premerge/advisor_deployment.yaml
@@ -38,5 +38,7 @@ spec:
           env:
             - name: ADVISOR_DB_PATH
               value: "/db/advisor_db.sqlite"
+            - name: ADVISOR_REPO_PATH
+              value: "/db/llvm-project"
           ports:
           -  containerPort: 5000


### PR DESCRIPTION
This patch makes it so the /upload endpoint will calculate the commit
index and store in in the DB. This allows for using the commit index
when finding explanations which allows for easily writing some
heuristics.
