### PR TITLE
Disable clangd testing on Linaro quick bots

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -350,6 +350,7 @@ all = [
                     clean=False,
                     checkout_compiler_rt=False,
                     checkout_lld=False,
+                    checkout_clang_tools_extra=False,
                     extra_cmake_args=["-DLLVM_TARGETS_TO_BUILD='ARM'"])},
 
     ## ARMv7 check-all 2-stage
@@ -409,6 +410,7 @@ all = [
                     clean=False,
                     checkout_compiler_rt=False,
                     checkout_lld=False,
+                    checkout_clang_tools_extra=False,
                     extra_cmake_args=["-DLLVM_TARGETS_TO_BUILD='AArch64'"])},
 
     # AArch64 2 stage build with lld, flang, compiler-rt, test-suite and SVE/SME


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/165336.

Our quick bots run on a shared server with many other bots. Some are assigned cores, others are not. It's a bit chaotic but generally it works out. In this case, lately it has not for clangd tests.

We could change the timeouts in clangd testing, but in theory the OS could stall a process for minutes. I don't want to make everyone else deal with that timeout just for our server.

Instead, disable clangd tests on these bots and rely on the other bots who also run the tests but do not have this flakiness.

For instance our single stage SVE bots and 2 stage Armv8 32-bit bot.

This increases the response time for a clangd failure to around 30 minutes for AArch64 and 3 hours for Arm 32-bit. The latter is not great but I've not so far seen a clangd failure that was 32-bit specific, so I'm ok with the risk.