### PR TITLE
Skip scheduling sensitive lit tests on Linaro quick bots

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -351,7 +351,10 @@ all = [
                     checkout_compiler_rt=False,
                     checkout_lld=False,
                     checkout_clang_tools_extra=False,
-                    extra_cmake_args=["-DLLVM_TARGETS_TO_BUILD='ARM'"])},
+                    extra_cmake_args=[
+                        "-DLLVM_TARGETS_TO_BUILD='ARM'",
+                        # Skip scheduling sensitive tests.
+                        "-DLLVM_LIT_ARGS=-v --filter-out '(googletest-timeout|timeout-hang|max-time)\.py'"])},
 
     ## ARMv7 check-all 2-stage
     {'name' : "clang-armv7-2stage",
@@ -411,7 +414,10 @@ all = [
                     checkout_compiler_rt=False,
                     checkout_lld=False,
                     checkout_clang_tools_extra=False,
-                    extra_cmake_args=["-DLLVM_TARGETS_TO_BUILD='AArch64'"])},
+                    extra_cmake_args=[
+                        "-DLLVM_TARGETS_TO_BUILD='AArch64'",
+                        # Skip scheduling sensitive tests.
+                        "-DLLVM_LIT_ARGS=-v --filter-out '(googletest-timeout|timeout-hang|max-time)\.py'"])},
 
     # AArch64 2 stage build with lld, flang, compiler-rt, test-suite and SVE/SME
     # mlir integration tests.


### PR DESCRIPTION
Our quick bots run on a shared machine and use whatever CPU they can get their hands on. This works well to keep utilisation high but causes flaky failures in tests that assume set timeouts.

Such as the 3 lit tests I'm skipping here. These tests are run on all platforms and have not had real failures in a very long time, so 2 fewer bots running them isn't a problem.

The option used is:
https://llvm.org/docs/CommandGuide/lit.html#cmdoption-lit-filter-out

Note that it filters based on name, which does not include the path. Otherwise I would have included "lnt/test/" in the pattern.

The alternative is assigning cores to our quick bots, which is difficult with the resources we have access to. Or we could keep chasing the "perfect" timeout value in the tests. Which is an endless quest because the system can choose to stall a process almost forever if it likes.