### PR TITLE
[CI] Explain More Failures at HEAD

### DIFF
--- a/premerge/advisor/advisor.py
+++ b/premerge/advisor/advisor.py
@@ -30,7 +30,9 @@ def upload():
 
 @advisor_blueprint.route("/explain")
 def explain():
-    return advisor_lib.explain_failures(flask.request.json, _get_db())
+    return advisor_lib.explain_failures(
+        flask.request.json, flask.current_app.config["REPO_PATH"], _get_db()
+    )
 
 
 def create_app(db_path: str, repository_path: str):

--- a/premerge/advisor/advisor_lib.py
+++ b/premerge/advisor/advisor_lib.py
@@ -115,7 +115,7 @@ def _try_explain_failing_at_head(
         )
     else:
         query += "AND base_commit_sha=?"
-        query_params += base_commit_sha
+        query_params += (base_commit_sha,)
     test_name_matches = db_connection.execute(
         query,
         query_params,

--- a/premerge/advisor/advisor_lib_test.py
+++ b/premerge/advisor/advisor_lib_test.py
@@ -206,9 +206,9 @@ class AdvisorLibTest(unittest.TestCase):
             ],
         )
 
-    # Test that we do not explain away a failure at head if the base commit
-    # SHA is different.
-    def test_no_explain_different_base_commit(self):
+    # Test that we do not explain away a failure at head if the only matching
+    # test failures come from commits after the base commit.
+    def test_no_explain_future_commit(self):
         self.assertListEqual(
             self._get_explained_failures(
                 prev_failure_base_commit_sha="6b7064686b706f7064656d6f6e68756e74657273"
@@ -218,6 +218,23 @@ class AdvisorLibTest(unittest.TestCase):
                     "name": "a.ll",
                     "explained": False,
                     "reason": None,
+                }
+            ],
+        )
+
+    # Test that we explain away failures at head that have happened in the
+    # previous couple of commits.
+    def test_explain_head_within_range(self):
+        self.assertListEqual(
+            self._get_explained_failures(
+                base_commit_sha="6b7064686b706f7064656d6f6e68756e74657273",
+                prev_failure_base_commit_sha="8d29a3bb6f3d92d65bf5811b53bf42bf63685359",
+            ),
+            [
+                {
+                    "name": "a.ll",
+                    "explained": True,
+                    "reason": "This test is already failing at the base commit.",
                 }
             ],
         )


### PR DESCRIPTION
This patch updates _try_explain_failing_at_head to also look at the
couple commits behind the base SHA as well. This accounts for the case
where we do not yet have postcommit results yet for the exact base
commit. This should not reduce accuracy given we're matching the failure
message exactly.
