### PR TITLE
Revert "Build the lldb asan tests with the system compiler"

### DIFF
--- a/zorg/jenkins/jobs/jobs/lldb-cmake-sanitized
+++ b/zorg/jenkins/jobs/jobs/lldb-cmake-sanitized
@@ -105,14 +105,11 @@ pipeline {
                     # Running too many asanified threads is too stressful for the kernel and we get >90% system time.
                     export MAX_PARALLEL_TESTS=$(sysctl hw.physicalcpu |awk '{print int(($2+1)/2)}')
 
-                    # Using the system compiler to compile the LLDB tests. By default macOS does
-                    # not allow loading the ASAN runtime into system binaries.
                     python3 llvm-zorg/zorg/jenkins/monorepo_build.py lldb-cmake-sanitized build \
                       --assertions \
                       --projects="clang;lld;lldb"  \
                       --runtimes="" \
                       --cmake-type=Release \
-                      --lldb-test-compiler=$(xcrun -find clang) \
                       --cmake-flag="-DPython3_EXECUTABLE=$(which python)"
                     '''
                     script {


### PR DESCRIPTION
This reverts commit c05cd2aebb71471f53fdfa4238aa3c5c0da28acf.

This was a speculative change and we really do want to test using the just-built compiler.