### PR TITLE
[libc++] Bump next runner image

### DIFF
--- a/premerge/premerge_resources/variables.tf
+++ b/premerge/premerge_resources/variables.tf
@@ -71,7 +71,7 @@ variable "libcxx_release_runner_image" {
 
 variable "libcxx_next_runner_image" {
   type    = string
-  default = "ghcr.io/llvm/libcxx-linux-builder:d6b22a347f813cf4a9832627323a43074f57bbcf"
+  default = "ghcr.io/llvm/libcxx-linux-builder:bf07226c6d6aaf3b8f230e4e36e8aac8e40d8c4d"
 }
 
 variable "linux_runners_namespace_name" {


### PR DESCRIPTION
Bump the libc++ next runner image after llvm/llvm-project#167530.