### PR TITLE
[CI] Add liveness probe to buildbot container

### DIFF
--- a/premerge/buildbot/Dockerfile
+++ b/premerge/buildbot/Dockerfile
@@ -9,5 +9,6 @@ RUN pip3 install --break-system-packages -r /requirements.lock.txt && rm /requir
 RUN mkdir /app
 WORKDIR /app
 COPY startup.sh .
-RUN chmod +x startup.sh
+COPY liveness.sh .
+RUN chmod +x startup.sh && chmod +x liveness.sh
 ENTRYPOINT /app/startup.sh

--- a/premerge/buildbot/liveness.sh
+++ b/premerge/buildbot/liveness.sh
@@ -1,0 +1,1 @@
+ps aux | grep "[b]uildbot-worker start"


### PR DESCRIPTION
This will enable us to add some k8s liveness probes which will automatically restart the container when the buildbot worker fails to connect to the master.

Towards #571.