### PR TITLE
[AIX] limit lit tests on clang builder to avoid limiting other builders

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -766,6 +766,7 @@ all = [
                     clean=False,
                     extra_configure_args=[
                         "-DLLVM_ENABLE_ASSERTIONS=On",
+                        "-DLLVM_LIT_ARGS=--threads=20 -v --time-tests",
                         "-DCMAKE_C_COMPILER=clang",
                         "-DCMAKE_CXX_COMPILER=clang++",
                         "-DPython3_EXECUTABLE:FILEPATH=python3",


### PR DESCRIPTION
The machine that hosts clang aix builder also hosts the flang aix builder. Limit the number of threads the clang build uses in order not to drought the flang build as both run at the same time.