### PR TITLE
[CI] Specify CPU Microarchitectue for Premerge Worker Nodes

### DIFF
--- a/premerge/gke_cluster/main.tf
+++ b/premerge/gke_cluster/main.tf
@@ -35,8 +35,8 @@ resource "google_container_cluster" "llvm_premerge" {
 variable "microarchitecture_map" {
   type = map(string)
   default = {
-    "n2d": "AMD Milan"
-    "n2-": "Intel Ice Lake"
+    "n2d" : "AMD Milan"
+    "n2-" : "Intel Ice Lake"
   }
 }
 
@@ -70,7 +70,7 @@ resource "google_container_node_pool" "llvm_premerge_linux" {
   }
 
   node_config {
-    machine_type = var.linux_machine_type
+    machine_type     = var.linux_machine_type
     min_cpu_platform = var.microarchitecture_map[substr(var.linux_machine_type, 0, 3)]
     taint {
       key    = "premerge-platform"
@@ -105,7 +105,7 @@ resource "google_container_node_pool" "llvm_buildbot_linux" {
   }
 
   node_config {
-    machine_type = var.linux_machine_type
+    machine_type     = var.linux_machine_type
     min_cpu_platform = var.microarchitecture_map[substr(var.linux_machine_type, 0, 3)]
     taint {
       key    = "buildbot-platform"
@@ -137,7 +137,7 @@ resource "google_container_node_pool" "llvm_premerge_libcxx" {
   }
 
   node_config {
-    machine_type = var.libcxx_machine_type
+    machine_type     = var.libcxx_machine_type
     min_cpu_platform = var.microarchitecture_map[substr(var.libcxx_machine_type, 0, 3)]
     taint {
       key    = "premerge-platform-libcxx"
@@ -165,7 +165,7 @@ resource "google_container_node_pool" "llvm_premerge_windows_2022" {
   # We do not set a taint for the windows nodes as kubernetes by default sets
   # a node.kubernetes.io/os taint for windows nodes.
   node_config {
-    machine_type = var.windows_machine_type
+    machine_type     = var.windows_machine_type
     min_cpu_platform = var.microarchitecture_map[substr(var.windows_machine_type, 0, 3)]
     labels = {
       "premerge-platform" : "windows-2022"
@@ -216,7 +216,7 @@ resource "google_container_node_pool" "llvm_buildbot_window_2022" {
     # Use the Linux machine type here as we want to keep the windows machines
     # symmetric with the Linux machines for faster builds. Throughput is not
     # as much of a concern postcommit.
-    machine_type = var.linux_machine_type
+    machine_type     = var.linux_machine_type
     min_cpu_platform = var.microarchitecture_map[substr(var.linux_machine_type, 0, 3)]
     labels = {
       "buildbot-platform" : "windows-2022"


### PR DESCRIPTION
This ensures more consistent performance as the n2/n2d machine types can vary microarchitecturally in ways that significantly impact performance (xx%).