### PR TITLE
Add a new SYCL GPU builder

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2242,6 +2242,24 @@ all += [
                         add_lit_checks=["check-clang", "check-flang", "check-flang-rt", "check-llvm", "check-lld", "check-mlir", "check-offload"],
                         add_openmp_lit_args=["--time-tests", "--timeout 100", "--xfail=affinity/format/proc_bind.c"],
                     )},
+# SYCL GPU builders.
+
+    {'name' : "intel-sycl-gpu",
+    'tags'  : ["sycl"],
+    'collapseRequests': False,     
+    'workernames' : ["intel-sycl-gpu-01"],
+    'builddir': "intel-sycl-gpu",
+    'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                    clean=True,
+                    enable_runtimes=['openmp', 'offload', 'libsycl'],
+                    depends_on_projects=['llvm', 'clang', 'libsycl', 'offload', 'openmp', 'lld'],
+                    extra_configure_args=[
+                        "-DLLVM_CCACHE_BUILD=ON",                        
+                        "-DLLVM_TARGETS_TO_BUILD=host;SPIRV",
+                        "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_INSTALL_UTILS=ON",
+                        "-DCLANG_DEFAULT_LINKER=lld",
+                    ])},
 
 
 # Whole-toolchain builders.

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -386,6 +386,9 @@ def get_all():
         create_worker("rocm-docker-rhel-9", properties={'jobs': 32}, max_builds=1),
         create_worker("rocm-docker-rhel-8", properties={'jobs': 32}, max_builds=1),
 
+        # SYCL GPU
+        create_worker("intel-sycl-gpu-01", properties={'jobs': 192}, max_builds=1),
+
         # Containerized builder for third party libraries using HIP
         create_worker("ext_buildbot_hw_05-hip-docker", properties={'jobs': 32}, max_builds=1),
 


### PR DESCRIPTION
Add a new Intel-hosted machine with a GPU that builds the `libsycl` project.

Once we have tests, we will run the `check` target for `libsycl` as well which will include tests that use the GPU.