### PR TITLE
[HIP] Enable SPIRV backend when testing HIP

### DIFF
--- a/zorg/buildbot/builders/annotated/hip-build.sh
+++ b/zorg/buildbot/builders/annotated/hip-build.sh
@@ -84,7 +84,7 @@ cmake -G Ninja \
   -DCMAKE_C_COMPILER_LAUNCHER=ccache \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
   -DCMAKE_VERBOSE_MAKEFILE=1 \
-  -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" \
+  -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86;SPIRV" \
   -DLLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra" \
   -DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxx;libcxxabi;libunwind" \
   -DCLANG_DEFAULT_LINKER=lld \


### PR DESCRIPTION
This change should not change any tests since the SPIRV tests are currently not used.