### PR TITLE
 Fix : Add timeout parameters to all HTTP requests

### DIFF
--- a/llvmbisect/llvmlab/gcs.py
+++ b/llvmbisect/llvmlab/gcs.py
@@ -73,7 +73,7 @@ CHUNK_SIZE = 5124288
 
 def get_compiler(url, filename):
     """Get the compiler at the url, and save to filename."""
-    r = HTTP_CLIENT.get(url)
+    r = HTTP_CLIENT.get(url, timeout=300)  # 5 minutes for large downloads
     r.raise_for_status()
     with open(filename, 'wb') as fd:
         for chunk in r.iter_content(CHUNK_SIZE):

--- a/premerge/ops-container/process_llvm_commits.py
+++ b/premerge/ops-container/process_llvm_commits.py
@@ -135,6 +135,7 @@ def query_github_graphql_api(
           "Authorization": f"bearer {github_token}",
       },
       json={"query": query},
+      timeout=30,
   )
 
   # Exit if API call fails

--- a/zorg/jenkins/build.py
+++ b/zorg/jenkins/build.py
@@ -784,7 +784,7 @@ def http_download(url, dest):
     try:
         print("GETting", url, "to", dest, "...")
         session = requests.Session()
-        r = session.get(url)
+        r = session.get(url, timeout=60)
         r.raise_for_status()
         # Open our local file for writing
         with open(dest, "wb") as local_file:

--- a/zorg/jenkins/jobs/util/submit-debuginfo-statistics-to-lnt.py
+++ b/zorg/jenkins/jobs/util/submit-debuginfo-statistics-to-lnt.py
@@ -46,8 +46,8 @@ to_send = {
 
 pprint.pprint(to_send)
 try:
-    requests.post("http://104.154.54.203/db_default/v4/nts/submitRun", data=to_send).raise_for_status()
+    requests.post("http://104.154.54.203/db_default/v4/nts/submitRun", data=to_send, timeout=30).raise_for_status()
 except:
     time.sleep(10)
     print("Sleeping because of error.")
-    requests.post("http://104.154.54.203/db_default/v4/nts/submitRun", data=to_send).raise_for_status()
+    requests.post("http://104.154.54.203/db_default/v4/nts/submitRun", data=to_send, timeout=30).raise_for_status()

--- a/zorg/jenkins/jobs/util/submit-lldb-statistics-to-lnt.py
+++ b/zorg/jenkins/jobs/util/submit-lldb-statistics-to-lnt.py
@@ -59,8 +59,8 @@ for testcase_name, stats in _data.items():
 
     pprint.pprint(to_send)
     try:
-        requests.post("http://104.154.54.203/db_default/v4/nts/submitRun", data=to_send).raise_for_status()
+        requests.post("http://104.154.54.203/db_default/v4/nts/submitRun", data=to_send, timeout=30).raise_for_status()
     except:
         time.sleep(10)
         print("Sleeping because of error.")
-        requests.post("http://104.154.54.203/db_default/v4/nts/submitRun", data=to_send).raise_for_status()
+        requests.post("http://104.154.54.203/db_default/v4/nts/submitRun", data=to_send, timeout=30).raise_for_status()


### PR DESCRIPTION
## Summary
Added timeout parameters to all HTTP requests to prevent indefinite hangs.

## Changes
- 5 files modified
- Added timeouts: 30s-300s depending on use case
- All tests passed

## Files
- submit-debuginfo-statistics-to-lnt.py (30s)
- submit-lldb-statistics-to-lnt.py (30s)
- process_llvm_commits.py (30s)
- build.py (60s)
- gcs.py (300s)

## Testing
✅ Syntax validation passed
✅ Timeout parameters verified
✅ Behavior testing passed