### PR TITLE
Build Level Zero offload plugin on Intel GPU builder

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2242,6 +2242,7 @@ all += [
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
                         "-DLLVM_INSTALL_UTILS=ON",
                         "-DCLANG_DEFAULT_LINKER=lld",
+                        "-DLIBOMPTARGET_PLUGINS_TO_BUILD=level_zero",
                     ])},
 
 


### PR DESCRIPTION
This is what we are going to use the GPU for. It's not built by default so we need to set this flag.

Manually tested this.