### PR TITLE
Enable debug output for level_zero plugin on Intel builder

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2243,6 +2243,7 @@ all += [
                         "-DLLVM_INSTALL_UTILS=ON",
                         "-DCLANG_DEFAULT_LINKER=lld",
                         "-DLIBOMPTARGET_PLUGINS_TO_BUILD=level_zero",
+                        "-DLIBOMPTARGET_ENABLE_DEBUG=ON",
                     ])},
 
 


### PR DESCRIPTION
This will be useful for debugging failures.

Manually tested this.