### PR TITLE
Update lldb-cmake-sanitized to use just-built runtimes and build libcxx

### DIFF
--- a/zorg/jenkins/jobs/jobs/lldb-cmake-sanitized
+++ b/zorg/jenkins/jobs/jobs/lldb-cmake-sanitized
@@ -108,7 +108,7 @@ pipeline {
                     python3 llvm-zorg/zorg/jenkins/monorepo_build.py lldb-cmake-sanitized build \
                       --assertions \
                       --projects="clang;lld;lldb"  \
-                      --runtimes="" \
+                      --runtimes="compiler-rt;libcxx;libcxxabi" \
                       --cmake-type=Release \
                       --cmake-flag="-DPython3_EXECUTABLE=$(which python)"
                     '''


### PR DESCRIPTION
Since we use the just-built compiler for tests, we must also use just-built runtimes on macOS.

This also reverts e78725d since we should be able to start building libcxx again after this change.

rdar://164487647