### PR TITLE
Convert lldb-cmake-sanitized to use bootstrapping build

### DIFF
--- a/zorg/jenkins/jobs/jobs/lldb-cmake-sanitized
+++ b/zorg/jenkins/jobs/jobs/lldb-cmake-sanitized
@@ -108,7 +108,7 @@ pipeline {
                     python3 llvm-zorg/zorg/jenkins/monorepo_build.py lldb-cmake-sanitized build \
                       --assertions \
                       --projects="clang;lld;lldb"  \
-                      --runtimes="compiler-rt;libcxx;libcxxabi;libunwind" \
+                      --runtimes="libcxx;libcxxabi;libunwind" \
                       --cmake-type=Release \
                       --cmake-flag="-DPython3_EXECUTABLE=$(which python)"
                     '''


### PR DESCRIPTION
On macOS, we need to use bootstrapped sanitizer runtimes for sanitized libLTO to be loadable in ld

rdar://164487647