### PR TITLE
Revert "[AIX] limit lit tests on clang builder to avoid limiting othe…

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -767,6 +767,7 @@ all = [
                     clean=False,
                     extra_configure_args=[
                         "-DLLVM_ENABLE_ASSERTIONS=On",
+                        "-DLLVM_LIT_ARGS=-v --time-tests",
                         "-DCMAKE_C_COMPILER=clang",
                         "-DCMAKE_CXX_COMPILER=clang++",
                         "-DPython3_EXECUTABLE:FILEPATH=python3",


### PR DESCRIPTION
…r builders (#662)"

This reverts commit 7a8305e89dbfa304ebcc0159ad9b5c265df02863. As limiting the lit tests slowed the bot even more.