### PR TITLE
lldb-cmake-sanitized: Try to fix bootstrapping runtimes build flags

### DIFF
--- a/zorg/jenkins/build.py
+++ b/zorg/jenkins/build.py
@@ -604,7 +604,9 @@ def lldb_cmake_builder(target, variant=None):
                 "-DCLANG_ENABLE_BOOTSTRAP=ON",
                 "-DLLVM_ENABLE_PROJECTS=clang",
                 "-DLLVM_ENABLE_RUNTIMES=compiler-rt",
-                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_BUILD_TYPE={}".format(cmake_build_type),
+                "-DLLVM_BUILD_EXTERNAL_COMPILER_RT=On",
+                "-DCMAKE_MACOSX_RPATH=On"
             ]
         )
 


### PR DESCRIPTION
To fix https://green.lab.llvm.org/job/llvm.org/view/LLDB/job/lldb-cmake-sanitized/3582/

Match CMake flags to the existing clang jobs that bootstrap compiler-rt successfully with LLVM_ENABLE_RUNTIMES

Follow-up to #707