### PR TITLE
Revert "lldb-cmake-sanitized: Try to fix bootstrapping runtimes build flags"

### DIFF
--- a/zorg/jenkins/build.py
+++ b/zorg/jenkins/build.py
@@ -604,9 +604,7 @@ def lldb_cmake_builder(target, variant=None):
                 "-DCLANG_ENABLE_BOOTSTRAP=ON",
                 "-DLLVM_ENABLE_PROJECTS=clang",
                 "-DLLVM_ENABLE_RUNTIMES=compiler-rt",
-                "-DCMAKE_BUILD_TYPE={}".format(cmake_build_type),
-                "-DLLVM_BUILD_EXTERNAL_COMPILER_RT=On",
-                "-DCMAKE_MACOSX_RPATH=On"
+                "-DCMAKE_BUILD_TYPE=Release",
             ]
         )
 


### PR DESCRIPTION
Reverts llvm/llvm-zorg#708

The following build didn't actually run into the issue, so the changes are probably unnecessary.