### PR TITLE
llvm-cmake-sanitized: Add check-lldb to CLANG_BOOTSTRAP_TARGETS

### DIFF
--- a/zorg/jenkins/build.py
+++ b/zorg/jenkins/build.py
@@ -602,6 +602,7 @@ def lldb_cmake_builder(target, variant=None):
             [
                 "-DCMAKE_MAKE_PROGRAM={}".format(NINJA),
                 "-DCLANG_ENABLE_BOOTSTRAP=ON",
+                "-DCLANG_BOOTSTRAP_TARGETS=check-lldb",
                 "-DLLVM_ENABLE_PROJECTS=clang",
                 "-DLLVM_ENABLE_RUNTIMES=compiler-rt",
                 "-DCMAKE_BUILD_TYPE=Release",


### PR DESCRIPTION
To fix https://green.lab.llvm.org/job/llvm.org/view/LLDB/job/lldb-cmake-sanitized/3586/

... getting closer

rdar://164487647