### PR TITLE
lldb-cmake-sanitized should not be incremental

### DIFF
--- a/zorg/jenkins/jobs/jobs/lldb-cmake-sanitized
+++ b/zorg/jenkins/jobs/jobs/lldb-cmake-sanitized
@@ -66,7 +66,7 @@ pipeline {
             steps {
                 sh '''
                    # Non-incremental, so always delete just in case.
-                   rm -rf clang-build clang-install host-compiler *.tar.gz
+                   rm -rf lldb-build clang-install host-compiler *.tar.gz
                    rm -rf venv
                    python3 -m venv venv
                    set +u


### PR DESCRIPTION
The existing script says:

```
# Non-incremental, so always delete just in case.
rm -rf clang-build clang-install host-compiler *.tar.gz
```

But clang-build is not the build directory, `lldb-build` is. I noticed some strange behavior where the stage2 build wasn't being re-configured, and I think it's because of the incremental build.

https://green.lab.llvm.org/job/llvm.org/view/LLDB/job/lldb-cmake-sanitized/3587

Since this is now a bootstrapping build, we should not try to do an incremental build.