### PR TITLE
[AMDGPU][HIP] Listen to more schedulers

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2066,7 +2066,7 @@ all += [
     'workernames' : ["ext_buildbot_hw_05-hip-docker"],
     'builddir': "hip-third-party-libs-test",
     'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
-                    depends_on_projects=['llvm', 'clang', 'compiler-rt', 'lld'],
+                    depends_on_projects=['llvm', 'clang', 'compiler-rt', 'lld', 'mlir', 'flang', 'openmp', 'offload', 'flang-rt'],
                     script="hip-tpl.py",
                     checkout_llvm_sources=True,
                     script_interpreter=None


### PR DESCRIPTION
The CMake cache file that this bot uses enables a few more projects. Since the bot does collapse requests anyway, it won't add a lot to the turnaround time to add these schedulers.