### PR TITLE
Revert part of "[AIX] limit lit tests on clang builder to avoid limiting other builders (#662)"

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -768,7 +768,7 @@ all = [
                     extra_configure_args=[
                         "-DLLVM_ENABLE_ASSERTIONS=On",
                         "-DLLVM_LIT_ARGS=-v --time-tests",
-	`		"-DCMAKE_C_COMPILER=clang",
+                        "-DCMAKE_C_COMPILER=clang",
                         "-DCMAKE_CXX_COMPILER=clang++",
                         "-DPython3_EXECUTABLE:FILEPATH=python3",
                         "-DLLVM_ENABLE_ZLIB=OFF", "-DLLVM_APPEND_VC_REV=OFF",


### PR DESCRIPTION
This reverts the thread limit part of the previous change to the AIX bots, as this limit was causing problems and lengthy runs. We'll work around the original problem some other way.