### PR TITLE
[CI] Create separate tables for storing PR and review data

### DIFF
--- a/premerge/bigquery_schema/llvm_pull_requests_table_schema.json
+++ b/premerge/bigquery_schema/llvm_pull_requests_table_schema.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "pull_request_author",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "GitHub username of the pull request author."
+  },
+  {
+    "name": "pull_request_timestamp_seconds",
+    "type": "INTEGER",
+    "mode": "NULLABLE",
+    "description": "Time the pull request was created at, as a Unix timestamp."
+  },
+  {
+    "name": "pull_request_number",
+    "type": "INTEGER",
+    "mode": "NULLABLE",
+    "description": "Number of the pull request."
+  },
+  {
+    "name": "associated_commit",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "SHA of the commit associated with the pull request."
+  }
+]

--- a/premerge/bigquery_schema/llvm_reviews_table_schema.json
+++ b/premerge/bigquery_schema/llvm_reviews_table_schema.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "review_author",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "GitHub username of the review author."
+  },
+  {
+    "name": "review_timestamp_seconds",
+    "type": "INTEGER",
+    "mode": "NULLABLE",
+    "description": "Time the review was created at, as a Unix timestamp."
+  },
+  {
+    "name": "review_state",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "State of the review, i.e APPROVED, CHANGES_REQUESTED, etc."
+  },
+  {
+    "name": "associated_pull_request",
+    "type": "INTEGER",
+    "mode": "NULLABLE",
+    "description": "Number of the pull request associated with the review."
+  }
+]

--- a/premerge/main.tf
+++ b/premerge/main.tf
@@ -352,6 +352,26 @@ resource "google_bigquery_table" "llvm_commits_table" {
   depends_on = [google_bigquery_dataset.operational_metrics_dataset]
 }
 
+resource "google_bigquery_table" "llvm_pull_requests_table" {
+  dataset_id  = google_bigquery_dataset.operational_metrics_dataset.dataset_id
+  table_id    = "llvm_pull_requests"
+  description = "LLVM pull request data"
+
+  schema = file("./bigquery_schema/llvm_pull_requests_table_schema.json")
+
+  depends_on = [google_bigquery_dataset.operational_metrics_dataset]
+}
+
+resource "google_bigquery_table" "llvm_reviews_table" {
+  dataset_id  = google_bigquery_dataset.operational_metrics_dataset.dataset_id
+  table_id    = "llvm_reviews"
+  description = "LLVM review data"
+
+  schema = file("./bigquery_schema/llvm_reviews_table_schema.json")
+
+  depends_on = [google_bigquery_dataset.operational_metrics_dataset]
+}
+
 resource "google_bigquery_dataset_iam_binding" "operational_metrics_dataset_editor_binding" {
   dataset_id = google_bigquery_dataset.operational_metrics_dataset.dataset_id
   role       = "roles/bigquery.dataEditor"


### PR DESCRIPTION
Adds two new tables for maintaining data regarding LLVM review and pull request data. As we collect and analyze more data, it's not sustainable to have all of our data stored in a single table with many fields. For some metrics we wish to analyze, we'd require some complicated queries that would otherwise be trivial with separate tables.

These tables may be modified & additional fields may be added as needed. Right now they're just set up so that we can substitute them into existing queries. The existing llvm commits table will be modified in a follow-up PR to avoid breakages for the time being.