### PR TITLE
Allow mixed step and factory objects inside of pre/post_*_steps arguments of UnifiedTreeBuilder.getCmakeExBuildFactory.

### DIFF
--- a/test/buildbot/builders/unified_cmakeex.py
+++ b/test/buildbot/builders/unified_cmakeex.py
@@ -246,8 +246,8 @@ assert factory_has_step(f, "cmake-configure", hasarg = "definitions", contains =
 
 # Check the step extensions.
 
-cbf = LLVMBuildFactory()
-cbf.addStep(
+cbf1 = LLVMBuildFactory()
+cbf1.addStep(
     steps.SetProperty(
         name = "pre_configure_step",
         property = "SomeProperty",
@@ -255,10 +255,19 @@ cbf.addStep(
     )
 )
 
+cbf2 = LLVMBuildFactory()
+cbf2.addStep(
+    steps.SetProperty(
+        name = "pre_install_step2",
+        property = "SomeProperty2",
+        value = "SomeValue2"
+    )
+)
+
 f = UnifiedTreeBuilder.getCmakeExBuildFactory(
         # Force adding a default installation target step.
         install_dir = "install-staged",
-        pre_configure_steps = cbf,    # Single step within the build factory
+        pre_configure_steps = cbf1,    # Single step within the build factory
         post_build_steps = [
             steps.SetProperty(
                 name = "post_build_step1",
@@ -276,6 +285,7 @@ f = UnifiedTreeBuilder.getCmakeExBuildFactory(
                 property = "SomeProperty",
                 value = "SomeValue"
             ),
+            cbf2,   # Single step within the build factory
         ],
         post_finalize_steps =[
             steps.SetProperty(
@@ -287,12 +297,13 @@ f = UnifiedTreeBuilder.getCmakeExBuildFactory(
     )
 print(f"Step Extendions: {f}")
 
-assert factory_has_num_steps(f, 9 + 5)
+assert factory_has_num_steps(f, 9 + 6)
 
 assert factory_has_step(f, "pre_configure_step", hasarg = "property", contains = "SomeProperty")
 assert factory_has_step(f, "post_build_step1", hasarg = "property", contains = "SomeProperty")
 assert factory_has_step(f, "post_build_step2", hasarg = "command", contains = ["ls"])
 assert factory_has_step(f, "pre_install_step", hasarg = "property", contains = "SomeProperty")
+assert factory_has_step(f, "pre_install_step2", hasarg = "property", contains = "SomeProperty2")
 assert factory_has_step(f, "post_finalize_step", hasarg = "property", contains = "SomeProperty")
 
 

--- a/zorg/buildbot/builders/UnifiedTreeBuilder.py
+++ b/zorg/buildbot/builders/UnifiedTreeBuilder.py
@@ -796,22 +796,22 @@ def getCmakeExBuildFactory(
         pre_configure_steps : list or LLVMFactory, optional
             The buildflow customization steps to execute before the CMake configuration step.
 
-            Provide a list of build step objects or LLVMFactory object.
+            Provide a list of build step/LLVMFactory objects or a single LLVMFactory object.
 
         post_build_steps : list or LLVMFactory, optional
             The buildflow customization steps to execute after the build step, but before the check steps.
 
-            Provide a list of build step objects or LLVMFactory object.
+            Provide a list of build step/LLVMFactory objects or a single LLVMFactory object.
 
         pre_install_steps : list or LLVMFactory, optional
             The buildflow customization steps to execute after the check steps, but before the installation steps (if requested).
 
-            Provide a list of build step objects or LLVMFactory object.
+            Provide a list of build step/LLVMFactory objects or a single LLVMFactory object.
 
         post_finalize_steps : list or LLVMFactory, optional
             The buildflow customization steps to execute at the end of the build workflow.
 
-            Provide a list of build step objects or LLVMFactory object.
+            Provide a list of build step/LLVMFactory objects or a single LLVMFactory object.
 
         jobs : int, optional
             Restrict a degree of parallelism (default is None).
@@ -884,7 +884,15 @@ def getCmakeExBuildFactory(
     # This function extends the current workflow with provided custom steps.
     def extend_with_custom_steps(fc, s):
         # We already got either list() or LLVMBuildFactory() object here.
-        fc.addSteps(s.steps if isinstance(s, BuildFactory) else s)
+        if isinstance(s, BuildFactory):
+            fc.addSteps(s.steps)
+        else:
+            # The list can be mixed with the step and factory objects.
+            for o in s:
+                if isinstance(o, BuildFactory):
+                    fc.addSteps(o.steps)
+                else:
+                    fc.addStep(o)
 
     def norm_target_list_arg(lst):
         if type(lst) == str:


### PR DESCRIPTION
Applied to the following parameters:
 * pre_configure_steps
 * post_build_steps
 * pre_install_steps
 * post_finalize_steps