### PR TITLE
Migrate common code to shared library directory

### DIFF
--- a/resources/job_description.template
+++ b/resources/job_description.template
@@ -1,0 +1,7 @@
+<h2>Issues</h2>
+<% if (log_summary == "") { %>
+    <p>No known issues detected</p>
+<% } else { %>
+${log_summary}
+<% } %>
+<p><a href="${env.BUILD_URL}consoleFull">Build Log</a></p>

--- a/vars/common.groovy
+++ b/vars/common.groovy
@@ -1,0 +1,123 @@
+@NonCPS
+private def basename(path) {
+    return path.drop(path.lastIndexOf('/') + 1)
+}
+
+@NonCPS
+private def render_template(template_text, log_summary) {
+    def binding = [
+        'currentBuild': currentBuild,
+        'env': env,
+        'log_summary': log_summary,
+    ]
+    def engine = new groovy.text.SimpleTemplateEngine()
+    def template_eng = engine.createTemplate(template_text).make(binding)
+    return template_eng.toString()
+}
+
+// Clone llvm-project.git get the blamelist filled. This is necessary for relay
+// jobs as with current jenkins we do not want to trigger the relay job with any
+// parameters or blamelists. (If we would do that then jenkins won't merge
+// requests anymore and we would be forced to test every single revision for
+// which we don't have the hardware right now).
+//
+// FIXME: Make this do a --bare or --mirror clone instead of a full clone. This
+// is very space-intensive.
+private def clone_llvm_project(name, sha) {
+        dir("pseudo-checkout-${name}") {
+        retry(3) {
+            checkout poll: false, changelog: true, scm: [
+                $class: 'GitSCM',
+                branches: [[name: sha ]],
+                extensions: [
+                    [
+                        $class: 'CloneOption',
+                        timeout: 30
+                    ]
+                ],
+                userRemoteConfigs: [[url: 'https://github.com/llvm/llvm-project.git']]
+            ]
+        }
+    }
+}
+
+private def post_build() {
+    // Analyze build log.
+    def log_url = "${env.BUILD_URL}/consoleText"
+    def ret = sh \
+        script: "curl '${log_url}' -s | config/zorg/jenkins/inspect_log.py > log_summary.html",
+        returnStatus: true
+    if (ret != 0 && currentBuild.currentResult == 'SUCCESS')
+        currentBuild.result = 'UNSTABLE'
+    def log_summary = readFile 'log_summary.html'
+
+    // Update job description.
+    def description_template = libraryResource('job_description.template')
+    def descr_body = render_template(description_template, log_summary)
+    if (currentBuild.description == null)
+        currentBuild.description = ""
+    currentBuild.description += descr_body
+}
+
+def task_pipeline(label, body) {
+    node(label) {
+        skipDefaultCheckout()
+
+        try {
+            stage('main') {
+                dir('config') {
+                    git url: 'https://github.com/llvm/llvm-zorg.git', branch: 'main', poll: false
+                }
+                withEnv([
+                    "PATH=$PATH:$WORKSPACE/venv/bin:/usr/bin:/usr/local/bin"
+                ]) {
+                    withCredentials([string(credentialsId: 's3_resource_bucket', variable: 'S3_BUCKET')]) {
+                        body()
+                    }
+                }
+            }
+        } catch(hudson.AbortException e) {
+            // No need to print the exception if something fails inside a 'sh'
+            // step.
+            currentBuild.result = 'FAILURE'
+        } catch (Exception e) {
+            currentBuild.result = 'FAILURE'
+            throw e
+        } finally {
+            stage('post') {
+                post_build()
+            }
+        }
+    }
+}
+
+def benchmark_pipeline(label, body) {
+    properties([
+        disableResume(),
+        parameters([
+            string(name: 'ARTIFACT'),
+            string(name: 'GIT_DISTANCE'),
+            string(name: 'GIT_SHA')
+        ])
+    ])
+
+    currentBuild.displayName = basename(params.ARTIFACT)
+    task_pipeline(label) {
+        clone_llvm_project('llvm-project', params.GIT_SHA)
+        body()
+    }
+}
+
+def testsuite_pipeline(label, body) {
+    benchmark_pipeline(label) {
+        dir('lnt') {
+            git url: 'https://github.com/llvm/llvm-lnt.git', branch: 'python3.8-stable', poll: false
+        }
+        dir('test-suite') {
+            git url: 'https://github.com/llvm/llvm-test-suite.git', branch: 'main', poll: false
+        }
+        body()
+    }
+}
+
+return this

--- a/vars/relay.groovy
+++ b/vars/relay.groovy
@@ -1,0 +1,86 @@
+private def basename(path) {
+    return path.drop(path.lastIndexOf('/') + 1)
+}
+
+private def relay_steps(joblist, artifact_url, last_good_properties_url) {
+    // The upstream jobs triggering the relay produce a
+    // "last_good_build.properties" file that contains a reference to the
+    // compiler artifact that should be used for this run and which llvm
+    // revision it is based on.
+    // Ensure you have the AWS CLI on path before triggering the relay
+    withCredentials([string(credentialsId: 's3_resource_bucket', variable: 'S3_BUCKET')]) {
+        propfile = basename(last_good_properties_url)
+        sh """
+          rm -f ${propfile}
+          aws s3 cp $S3_BUCKET/clangci/${last_good_properties_url} ${propfile}
+        """
+    }
+
+    def props = readProperties file: propfile
+    def artifact = props.ARTIFACT
+    currentBuild.setDisplayName("${props.GIT_DISTANCE}-${props.GIT_SHA}")
+
+    // Trigger all jobs within the provided list
+    def parallel_builds = [:]
+    for (j in joblist) {
+        def jobname = env.BRANCH_NAME ? "${j}/${env.BRANCH_NAME.replace('/', '%2F')}" : j
+        parallel_builds[jobname] = {
+            def job_params = [
+                [$class: 'StringParameterValue',
+                 name: 'ARTIFACT',
+                 value: artifact],
+                [$class: 'StringParameterValue',
+                 name: 'GIT_SHA',
+                 value: props.GIT_SHA],
+                [$class: 'StringParameterValue',
+                 name: 'GIT_DISTANCE',
+                 value: props.GIT_DISTANCE],
+            ]
+            build job: jobname, parameters: job_params, propagate: false
+        }
+    }
+
+    // Workaround to prevent LNT jobs from running in parallel and overloading the LNT server with submissions
+    if(joblist.any { it.contains("lnt-ctmark") }) {
+         for (j in joblist) {
+            def jobname = env.BRANCH_NAME ? "${j}/${env.BRANCH_NAME.replace('/', '%2F')}" : j
+            parallel_builds[jobname].call()
+         }
+    } else {
+        parallel parallel_builds
+    }
+}
+
+def pipeline(joblist,
+        artifact_url='',
+        last_good_properties_url='') {
+    node(label: 'macos-x86_64') {
+        stage('main') {
+            // Download aws CLI used to gather artifacts
+            sh """
+              rm -rf venv
+              python3 -m venv venv
+              set +u
+              source ./venv/bin/activate
+              pip install awscli
+              set -u
+            """
+            withEnv([
+                "PATH=$PATH:$WORKSPACE/venv/bin:/usr/bin:/usr/local/bin"
+            ]) {
+                def branch = env.BRANCH_NAME ?: 'main'
+
+                if (!artifact_url) {
+                    artifact_url = "llvm.org/clang-stage1-RA/${branch}/latest"
+                }
+
+                if (!last_good_properties_url) {
+                    last_good_properties_url = "llvm.org/clang-stage1-RA/${branch}/last_good_build.properties"
+                }
+                relay_steps joblist, artifact_url, last_good_properties_url
+            }
+        }
+    }
+}
+
+return this


### PR DESCRIPTION
Moves the following code to the vars/ folder to be used properly as a jenkins shared library:
* common.groovy
* relay.groovy

Also updated the calling functions to account for multi branch pipelines in preparation. Shown to work here:
https://ci.swift.org/job/Green-Dragon-Testing/view/main/

Note that I left the old code as is in the zorg folder, so this PR is for now a NFC. I will circle back and delete that code after the migration and testing.

Because of this change, we are able to setup multi branch pipelines in llvm which act as our relay/benchmark jobs