### PR TITLE
[BazelBot] Add initial skeleton

### DIFF
--- a/google-bazel-bot/README.md
+++ b/google-bazel-bot/README.md
@@ -1,0 +1,14 @@
+# Google Bazel Bot
+
+This folder contains all of the source code for the AI bazel build fixer bot.
+The bot uses a combination of deterministic tooling and LLMs to automatically
+generate PRs that fix the bazel build.
+
+## Components
+
+1. Terraform - The GCP resources that are needed to run the bot. This includes
+   a GKE cluster and Kubernetes resources.
+2. Dockerfile - The container definition used for running both the postcommit
+   bazel CI and the fixer bot.
+3. Fixer bot source code - The actual source code that drives the fix loop and
+   interactes with Github to post a PR if it has generated a fix successfully.

--- a/google-bazel-bot/main.tf
+++ b/google-bazel-bot/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.43.0"
+    }
+  }
+}
+
+provider "google" {
+  project = "llvm-bazel"
+}
+
+
+resource "random_id" "default" {
+  byte_length = 8
+}
+
+resource "google_storage_bucket" "terraform_state_bucket" {
+  name     = "${random_id.default.hex}-terraform-remote-backend"
+  location = "US"
+
+  force_destroy               = false
+  public_access_prevention    = "enforced"
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "local_file" "terraform_state" {
+  file_permission = "0644"
+  filename        = "${path.module}/backend.tf"
+
+  content = <<-EOT
+  terraform {
+    backend "gcs" {
+      bucket = "${google_storage_bucket.terraform_state_bucket.name}"
+    }
+  }
+  EOT
+}


### PR DESCRIPTION
Per the RFC, start moving the initial implementation into the open so that it
is auditable and inspectable by the community. This patch just adds the
beginnings:
1. A new top-level folder
2. A README.md with a rough overview
3. Terraform skeleton
