### PR TITLE
Fix build artifact names

### DIFF
--- a/zorg/jenkins/build.py
+++ b/zorg/jenkins/build.py
@@ -121,7 +121,7 @@ class Configuration(object):
         self.host_compiler_url = os.environ.get('HOST_URL',
                                                 'http://green-dragon-21.local/artifacts/')
         self.artifact_url = os.environ.get('ARTIFACT', 'NONE')
-        self.job_name = os.environ.get('JOB_NAME', 'NONE')
+        self.job_name = os.environ.get('JOB_NAME', 'NONE').replace("%2F", "/")
         self.build_id = os.environ.get('BUILD_ID', 'NONE')
         self.build_number = os.environ.get('BUILD_NUMBER', 'NONE')
         self.svn_rev = os.environ.get('LLVM_REV', 'NONE')


### PR DESCRIPTION
* Prepare the build.py script for use in multi branch pipelines by formatting JOB_NAMES which include encoded slashes
* Fix toolchain artifact names to remove build specific metadata, this way the artifact manager script can download a specific build of a toolchain based on it's git SHA/distance and does not need to know arbitrary build information. This will allow the script to reuse artifacts from bisection specific jobs