### PR TITLE
[CI] Collect labels and time merged for LLVM pull requests

### DIFF
--- a/premerge/bigquery_schema/llvm_pull_requests_table_schema.json
+++ b/premerge/bigquery_schema/llvm_pull_requests_table_schema.json
@@ -12,6 +12,12 @@
     "description": "Time the pull request was created at, as a Unix timestamp."
   },
   {
+    "name": "merged_at_timestamp_seconds",
+    "type": "INTEGER",
+    "mode": "NULLABLE",
+    "description": "Time the pull request was merged at, as a Unix timestamp."
+  },
+  {
     "name": "pull_request_number",
     "type": "INTEGER",
     "mode": "NULLABLE",
@@ -22,5 +28,11 @@
     "type": "STRING",
     "mode": "NULLABLE",
     "description": "SHA of the commit associated with the pull request."
+  },
+  {
+    "name": "labels",
+    "type": "STRING",
+    "mode": "REPEATED",
+    "description": "Labels associated with the pull request."
   }
 ]


### PR DESCRIPTION
Begin collecting data for when pull requests are merged into main, as well as what labels those pull requests are tagged with.

For the time being, all pull requests we're concerned with should have their `mergedAt` field set. However, it is likely that we will also be interested in pull requests that haven't been merged sometime in the near future.