### PR TITLE
[CI] Change `labels` from REPEATED STRING to REPEATED RECORD

### DIFF
--- a/premerge/bigquery_schema/llvm_pull_requests_table_schema.json
+++ b/premerge/bigquery_schema/llvm_pull_requests_table_schema.json
@@ -31,8 +31,15 @@
   },
   {
     "name": "labels",
-    "type": "STRING",
+    "type": "RECORD",
     "mode": "REPEATED",
-    "description": "Labels associated with the pull request."
+    "description": "Labels associated with the pull request.",
+    "fields": [
+      {
+        "name": "name",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Labels being a STRING[] causes some issues when trying to import this data internally. Changing to RECORD[] seems to resolve this. Regardless, this is a more robust change since there is label metadata besides just `name` that we may be interested in.

This change results in the replacement of the pull requests table, so data must be backed up before applying.