### PR TITLE
[CI] Fix discrepancy between new BQ schema and collection script

### DIFF
--- a/premerge/ops-container/process_llvm_commits.py
+++ b/premerge/ops-container/process_llvm_commits.py
@@ -88,7 +88,7 @@ class LLVMPullRequestData:
   pull_request_timestamp_seconds: int
   merged_at_timestamp_seconds: int
   associated_commit: str
-  labels: list[str]
+  labels: list[dict[str, str]]
 
 
 @dataclasses.dataclass
@@ -275,6 +275,14 @@ def extract_pull_request_data(
     else:
       merge_unix_timestamp = None
 
+    # Extract label names associated with the pull request
+    labels = [
+        {
+            "name": label["name"],
+        }
+        for label in pull_request["labels"]["nodes"]
+    ]
+
     pull_request_data.append(
         LLVMPullRequestData(
             pull_request_number=pull_request["number"],
@@ -282,9 +290,7 @@ def extract_pull_request_data(
             pull_request_timestamp_seconds=create_unix_timestamp,
             merged_at_timestamp_seconds=merge_unix_timestamp,
             associated_commit=commit_sha.removeprefix("commit_"),
-            labels=[
-                label["name"] for label in pull_request["labels"]["nodes"]
-            ],
+            labels=labels,
         )
     )
 

--- a/premerge/ops-container/process_llvm_commits_test.py
+++ b/premerge/ops-container/process_llvm_commits_test.py
@@ -358,7 +358,10 @@ class TestProcessLLVMCommits(unittest.TestCase):
         merged_at.timestamp(),
     )
     self.assertEqual(pull_request_data[0].associated_commit, 'abcdef')
-    self.assertIn('llvm:test-label', pull_request_data[0].labels)
+    self.assertIn(
+        'llvm:test-label',
+        [label['name'] for label in pull_request_data[0].labels],
+    )
 
   def test_extract_pull_request_data_with_missing_author(self):
     """Test extracting pull request data from GitHub API data."""


### PR DESCRIPTION
Following #743, the `labels` field for pull request data became a list of RECORD instead of a list of STRING. However, the data collection script kept collecting data a list of STRING, which led to errors when trying to upload to our BigQuery dataset.

This wasn't caught by any tests since we were just checking for the presence of a test label, and not doing any type checking.
