### PR TITLE
Add a new clang-x64-windows-msvc-forward-slashes builder.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -659,6 +659,17 @@ all = [
                     script="clang-windows.py",
                     depends_on_projects=['llvm', 'clang', 'lld', 'debuginfo-tests'])},
 
+    {'name' : 'clang-x64-windows-msvc-forward-slashes',
+    'tags'  : ["clang"],
+    'workernames' : ['windows-gcebot2'],
+    'builddir': 'clang-x64-windows-msvc-forward-slashes',
+    'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
+                    script="clang-windows.py",
+                    extra_args=[
+                        '--extra_cmake_arg=-DLLVM_WINDOWS_PREFER_FORWARD_SLASH=ON',
+                    ],
+                    depends_on_projects=['llvm', 'clang', 'lld', 'debuginfo-tests'])},
+
     {'name' : "clang-m68k-linux",
     'tags'  : ["clang"],
     'workernames' : ["debian-akiko-m68k"],

--- a/zorg/buildbot/builders/annotated/clang-windows.py
+++ b/zorg/buildbot/builders/annotated/clang-windows.py
@@ -6,6 +6,7 @@ import annotated_builder
 
 def main(argv):
     ap = annotated_builder.get_argument_parser()
+    ap.add_argument('--extra_cmake_arg', nargs='*', default=[])
     args = ap.parse_args(argv[1:])
 
     # TODO: Add back debuginfo-tests once it works.
@@ -19,7 +20,7 @@ def main(argv):
         '-DLLVM_ENABLE_PDB=ON',
         '-DLLVM_ENABLE_ASSERTIONS=ON',
         '-DLLVM_TARGETS_TO_BUILD=all',
-    ]
+    ] + args.extra_cmake_arg
     check_targets = [
         'check-llvm',
         'check-clang',


### PR DESCRIPTION
This builder is designed to be run to ensure that clang passes tests when -DLLVM_WINDOWS_PREFER_FORWARD_SLASH is enabled.