### PR TITLE
[BazelBot] Clean up Dockerfile

### DIFF
--- a/google-bazel-bot/docker/Dockerfile
+++ b/google-bazel-bot/docker/Dockerfile
@@ -57,7 +57,7 @@ RUN wget --no-verbose -O /usr/bin/bazelisk https://github.com/bazelbuild/bazelis
   chmod +x /usr/bin/bazelisk; \
   bazelisk --version
 
-# Build and install buildifier
+# Build and install buildifier and buildozer
 RUN git clone https://github.com/bazelbuild/buildtools.git /tmp/buildtools; \
   cd /tmp/buildtools; \
   bazelisk build --noshow_progress --ui_event_filters=-debug,-info //buildifier //buildozer; \


### PR DESCRIPTION
This patch cleans up the Dockerfile a bit:
1. We can disable a security mitigation now that we drop the package.
2. Install CMake from the repositories now that it is new enough.
3. Drop sccache given we do not need it for the bazel image.
4. Drop bazel bot specific packages from the base Dockerfile (will be added
   in a stage 2 build later).
5. Some other misc cleanup.
