### PR TITLE
[BazelBot] Prepare container build to be multistage

### DIFF
--- a/.github/workflows/build-bazel-bot-container.yml
+++ b/.github/workflows/build-bazel-bot-container.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           container-name: bazel-buildkite
           context: google-bazel-bot/docker
+          target: bazel-buildkite
 
   push-container:
     if: github.event_name == 'push'

--- a/google-bazel-bot/docker/Dockerfile
+++ b/google-bazel-bot/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/ubuntu:24.04
+FROM docker.io/ubuntu:24.04 AS bazel-buildkite
 
 # Make sure apt-get doesn't prompt for stuff like our time zone, etc.
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Add a target that we can use. This allows for adding a multi-stage build more incrementally.