### PR TITLE
Change builders llvm-clang-x86_64-gcc-ubuntu and llvm-clang-x86_64-gcc-ubuntu-release to do clean builds.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1019,6 +1019,7 @@ all = [
     'workernames': ["sie-linux-worker3"],
     'builddir': "llvm-clang-x86_64-gcc-ubuntu",
     'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                    clean=True,
                     depends_on_projects=['llvm','clang','clang-tools-extra','compiler-rt','lld','cross-project-tests'],
                     extra_configure_args=[
                         "-DCMAKE_C_COMPILER=gcc",

--- a/buildbot/osuosl/master/config/release_builders.py
+++ b/buildbot/osuosl/master/config/release_builders.py
@@ -295,6 +295,7 @@ all = [
     'workernames': ["sie-linux-worker3"],
     'builddir': "x86_64-gcc-rel",
     'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                    clean=True,
                     depends_on_projects=['llvm','clang','clang-tools-extra','compiler-rt','lld','cross-project-tests'],
                     extra_configure_args=[
                         "-DCMAKE_C_COMPILER=gcc",


### PR DESCRIPTION
Switch these two builders that share the same worker to do a clean build instead of a dirty build.