### PR TITLE
Remove clang-x64-windows-msvc and make Aiden the PoC for sanitizer-windows

### DIFF
--- a/buildbot/google/docker/buildbot-sanitizer-windows/admin
+++ b/buildbot/google/docker/buildbot-sanitizer-windows/admin
@@ -1,1 +1,1 @@
-Reid Kleckner <rnk@google.com>
+Vitaly Buka <vitalybuka@google.com>

--- a/buildbot/google/docker/buildbot-sanitizer-windows/run.ps1
+++ b/buildbot/google/docker/buildbot-sanitizer-windows/run.ps1
@@ -25,7 +25,7 @@ Write-Output "Windows version: $(cmd /c ver)" > $HOST_FILE
 Write-Output "VCTools version: $(ls C:\BuildTools\VC\Tools\MSVC | Select -ExpandProperty Name)" >> $HOST_FILE
 Write-Output "Cores          : $((Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors)" >> $HOST_FILE
 Write-Output "RAM            : $([int][Math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1073741824)) GB" >> $HOST_FILE
-Write-Output "Reid Kleckner <rnk@google.com>" > "info\admin"
+Write-Output "Aiden Grossman <aidengrossman@google.com>" > "info\admin"
 
 # create the worker
 Write-Output "creating worker..."

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -651,14 +651,6 @@ all = [
                         "-DLLVM_ENABLE_RUNTIMES=openmp",
                         "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"])},
 
-    {'name' : 'clang-x64-windows-msvc',
-    'tags'  : ["clang"],
-    'workernames' : ['windows-gcebot2'],
-    'builddir': 'clang-x64-windows-msvc',
-    'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
-                    script="clang-windows.py",
-                    depends_on_projects=['llvm', 'clang', 'lld', 'debuginfo-tests'])},
-
     {'name' : "clang-m68k-linux",
     'tags'  : ["clang"],
     'workernames' : ["debian-akiko-m68k"],

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -124,8 +124,6 @@ def get_all():
 
         # Windows Server 2012 x86_64 16-core GCE instance
         create_worker("sanitizer-windows", properties={'jobs': 16}, max_builds=1),
-        # Windows Server 2012 x86_64 32-core GCE instance
-        create_worker("windows-gcebot2", properties={'jobs': 32}, max_builds=1),
 
         # Ubuntu 14.04 x86_64-scei-ps4, 2 x Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
         create_worker("as-worker-91", max_builds=1),


### PR DESCRIPTION
The [clang-x64-windows-msvc bot](https://lab.llvm.org/buildbot/#/builders/63) has been offline for three months at this point, and I no longer have access to it, so I cannot revive it. The VM needs to be removed and reprovisioned. The process for setting it up was entirely manual, and while there is a Google Doc outlining the process, it is stale.

Bringing it back essentially means a complete rebuild, so we might as well go ahead and remove this entry in the meantime, since the bot itself is not online at the moment. Perhaps the only residual value this buildbot has is that it may have a secret shared with the build master.

I believe we still have windows premerge coverage and various other arm64 windows builders. The main value this bot provides is that it does a clang-cl bootstrap build, and I can't say for certain that we cover that on the arm bots.

For sanitizer-windows, I changed the admin point-of-contact from me to Aiden. I thought perhaps Vitaly might be a better point-of-contact, but I think Aiden knows more about Windows CI concerns, and I think that's usually the thing this bot runs into, so I went with him.