### PR TITLE
[lldb][matrix] Skip lldb-dap on matrix bot

### DIFF
--- a/zorg/jenkins/jobs/jobs/lldb-cmake-matrix
+++ b/zorg/jenkins/jobs/jobs/lldb-cmake-matrix
@@ -138,6 +138,7 @@ pipeline {
                       --dotest-flag="llgs" \
                       --dotest-flag="--skip-category" \
                       --dotest-flag="debugserver" \
+                      --dotest-flag="--skip-category lldb-dap" \
                       --dotest-flag="--dwarf-version=2"
 
                     # Give the system some time to recover.
@@ -174,6 +175,7 @@ pipeline {
 		      --dotest-flag="llgs" \
 		      --dotest-flag="--skip-category" \
 		      --dotest-flag="debugserver" \
+                      --dotest-flag="--skip-category lldb-dap" \
                       --dotest-flag="--dwarf-version=4"
 
                     # Give the system some time to recover.
@@ -210,6 +212,7 @@ pipeline {
 		      --dotest-flag="llgs" \
 		      --dotest-flag="--skip-category" \
 		      --dotest-flag="debugserver" \
+                      --dotest-flag="--skip-category lldb-dap" \
                       --dotest-flag="--dwarf-version=5"
 
                     # Give the system some time to recover.
@@ -285,6 +288,7 @@ pipeline {
                       --dotest-flag="llgs" \
                       --dotest-flag="--skip-category" \
                       --dotest-flag="debugserver" \
+                      --dotest-flag="--skip-category lldb-dap"
 
                     # Give the system some time to recover.
                     sleep 120
@@ -359,6 +363,7 @@ pipeline {
                       --dotest-flag="llgs" \
                       --dotest-flag="--skip-category" \
                       --dotest-flag="debugserver" \
+                      --dotest-flag="--skip-category lldb-dap"
 
                     # Give the system some time to recover.
                     sleep 120


### PR DESCRIPTION
There's no need to run the tests there anyway because the matrix bot is primarily testing whether LLDB itself can debug binaries produced by older compilers. DAP is just a wrapper around LLDB and so shouldn't need any coverage on this bot.