### PR TITLE
Update LLVM testsuite compiler flags for 'llvm-clang-ubuntu-x-aarch64-pauthtest' builder.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -4046,7 +4046,7 @@ all += [
                             compiler_flags = "--target=aarch64-linux-pauthtest -march=armv8l+pauth -O2",
                             # Common linker flags.
                             linker_flags = util.Interpolate(
-                                "--target=aarch64-linux-pauthtest -march=armv8l+pauth -O2 "
+                                "--target=aarch64-linux-pauthtest -march=armv8l+pauth -O2 -fno-inline "
                                 "-Wl,--emit-relocs "
                                 "-Wl,--dynamic-linker=/home/%(prop:remote_test_user_pauth)s/musl-loader/aarch64-linux-pauthtest/lib/ld-musl-aarch64.so.1 "
                                 "-Wl,-rpath=/home/%(prop:remote_test_user_pauth)s/musl-loader/aarch64-linux-pauthtest/lib"


### PR DESCRIPTION
Added '-fno-inline' compiler flag to avoid clang crash.

See: https://github.com/llvm/llvm-project/pull/179688