### PR TITLE
Reland Update LLVM testsuite compiler flags for 'llvm-clang-ubuntu-x-aarch64-pauthtest' builder.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -4043,10 +4043,10 @@ all += [
                         ),
                         TestSuiteBuilder.getLlvmTestSuiteSteps(
                             # Common C/CXX flags.
-                            compiler_flags = "--target=aarch64-linux-pauthtest -march=armv8l+pauth -O2",
+                            compiler_flags = "--target=aarch64-linux-pauthtest -march=armv8l+pauth -O2 -fno-inline",
                             # Common linker flags.
                             linker_flags = util.Interpolate(
-                                "--target=aarch64-linux-pauthtest -march=armv8l+pauth -O2 -fno-inline "
+                                "--target=aarch64-linux-pauthtest -march=armv8l+pauth -O2 "
                                 "-Wl,--emit-relocs "
                                 "-Wl,--dynamic-linker=/home/%(prop:remote_test_user_pauth)s/musl-loader/aarch64-linux-pauthtest/lib/ld-musl-aarch64.so.1 "
                                 "-Wl,-rpath=/home/%(prop:remote_test_user_pauth)s/musl-loader/aarch64-linux-pauthtest/lib"


### PR DESCRIPTION
Added '-fno-inline' compiler flag to avoid clang crash.

See: https://github.com/llvm/llvm-project/pull/179688

Reland PR #773 with fixed options for the testsuite compiler
(https://github.com/llvm/llvm-zorg/pull/773)