### PR TITLE
[BazelBot] Use a separate app for creating PRs

### DIFF
--- a/google-bazel-bot/bazel-bot/bazelbot_server_test.py
+++ b/google-bazel-bot/bazel-bot/bazelbot_server_test.py
@@ -25,6 +25,8 @@ class TestBazelBotServer(unittest.TestCase):
             "BUILDKITE_API_TOKEN": "bk_token",
             "GITHUB_APP_ID": "app_id",
             "GITHUB_APP_PRIVATE_KEY": "private_key",
+            "GITHUB_PR_APP_ID": "pr_app_id",
+            "GITHUB_PR_APP_PRIVATE_KEY": "pr_private_key",
         },
     )
     def test_credential_manager(self):
@@ -34,6 +36,8 @@ class TestBazelBotServer(unittest.TestCase):
         self.assertEqual(creds.bk_token, "bk_token")
         self.assertEqual(creds.gh_fork_repo_name, "fork_user/llvm-project")
         self.assertEqual(creds.gh_pr_repo_name, "pr_user/llvm-project")
+        self.assertEqual(creds.gh_pr_app_id, "pr_app_id")
+        self.assertEqual(creds.gh_pr_app_private_key, "pr_private_key")
 
     @mock.patch("utils.git.Repo")
     @mock.patch("utils.github.GithubIntegration")

--- a/google-bazel-bot/bazel-bot/utils.py
+++ b/google-bazel-bot/bazel-bot/utils.py
@@ -37,6 +37,8 @@ class CredentialManager:
         self.bk_token = os.getenv("BUILDKITE_API_TOKEN")
         self.gh_app_id = os.getenv("GITHUB_APP_ID")
         self.gh_app_private_key = os.getenv("GITHUB_APP_PRIVATE_KEY")
+        self.gh_pr_app_id = os.getenv("GITHUB_PR_APP_ID")
+        self.gh_pr_app_private_key = os.getenv("GITHUB_PR_APP_PRIVATE_KEY")
 
     @property
     def gh_fork_repo_name(self):
@@ -188,10 +190,10 @@ class LocalGitRepo:
                 self.repo_path,
             )
         self.repo = git.Repo(repo_path)
-        self.github_integration = github.GithubIntegration(
+        self.fork_github_integration = github.GithubIntegration(
             auth=github.Auth.AppAuth(creds.gh_app_id, creds.gh_app_private_key)
         )
-        self.gh_fork_installation = self.github_integration.get_repo_installation(
+        self.gh_fork_installation = self.fork_github_integration.get_repo_installation(
             self.creds.gh_fork_user, "llvm-project"
         )
         self.gh_fork_repo = (
@@ -199,7 +201,10 @@ class LocalGitRepo:
                 self.creds.gh_fork_repo_name
             )
         )
-        self.gh_pr_installation = self.github_integration.get_repo_installation(
+        self.pr_github_integration = github.GithubIntegration(
+            auth=github.Auth.AppAuth(creds.gh_pr_app_id, creds.gh_pr_app_private_key)
+        )
+        self.gh_pr_installation = self.pr_github_integration.get_repo_installation(
             self.creds.gh_pr_user, "llvm-project"
         )
         self.gh_pr_repo = (
@@ -254,7 +259,7 @@ class LocalGitRepo:
         try:
             logger.info(f"Pushing branch {branch_name} to remote...")
             self.repo.delete_remote(self.remote_name)
-            access_token = self.github_integration.get_access_token(
+            access_token = self.fork_github_integration.get_access_token(
                 self.gh_fork_installation.id
             ).token
             self.repo.create_remote(

--- a/google-bazel-bot/bazel-fixer-bot.yaml
+++ b/google-bazel-bot/bazel-fixer-bot.yaml
@@ -51,6 +51,16 @@ spec:
                 secretKeyRef:
                   name: github-app
                   key: private-key
+            - name: GITHUB_PR_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: github-pr-app
+                  key: id
+            - name: GITHUB_PR_APP_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: github-pr-app
+                  key: private-key
             - name: GITHUB_FORK_USER
               value: google-bazel-bot
             - name: GITHUB_PR_USER

--- a/google-bazel-bot/main.tf
+++ b/google-bazel-bot/main.tf
@@ -151,6 +151,14 @@ data "google_secret_manager_secret_version" "github_app_private_key" {
   secret = "github-app-private-key"
 }
 
+data "google_secret_manager_secret_version" "github_pr_app_id" {
+  secret = "github-pr-app-id"
+}
+
+data "google_secret_manager_secret_version" "github_pr_app_private_key" {
+  secret = "github-pr-app-private-key"
+}
+
 resource "kubernetes_namespace" "bazel_ci" {
   metadata {
     name = "bazel-ci"
@@ -200,6 +208,21 @@ resource "kubernetes_secret" "github_app" {
   depends_on = [kubernetes_namespace.bazel_ci]
 }
 
+resource "kubernetes_secret" "github_pr_app" {
+  metadata {
+    name      = "github-pr-app"
+    namespace = kubernetes_namespace.bazel_ci.metadata[0].name
+  }
+
+  data = {
+    "id"          = data.google_secret_manager_secret_version.github_pr_app_id.secret_data
+    "private-key" = data.google_secret_manager_secret_version.github_pr_app_private_key.secret_data
+  }
+
+  type       = "Opaque"
+  depends_on = [kubernetes_namespace.bazel_ci]
+}
+
 resource "kubernetes_service_account" "bazel_cache_ksa" {
   metadata {
     name      = "bazel-cache-ksa"
@@ -240,6 +263,7 @@ resource "kubernetes_manifest" "bazel_fixer_bot" {
     kubernetes_namespace.bazel_ci,
     kubernetes_secret.github_app,
     kubernetes_secret.github_api_token,
+    kubernetes_secret.github_pr_app,
     kubernetes_service_account.bazel_cache_ksa
   ]
 }


### PR DESCRIPTION
This second app has more minimal permissions (can only create PRs) which was one of the requirements in the original bazelbot RFC.