### PR TITLE
[CI] Split common script functionality into a separate library

### DIFF
--- a/premerge/ops-container/Dockerfile
+++ b/premerge/ops-container/Dockerfile
@@ -2,6 +2,6 @@ FROM docker.io/python:3.12
 
 COPY requirements.lock.txt ./
 RUN pip3 install --no-cache-dir -r requirements.lock.txt
-COPY process_llvm_commits.py ./
+COPY process_llvm_commits.py operational_metrics_lib.py ./
 
 CMD ["python3", "process_llvm_commits.py"]

--- a/premerge/ops-container/operational_metrics_lib.py
+++ b/premerge/ops-container/operational_metrics_lib.py
@@ -1,0 +1,342 @@
+import dataclasses
+import datetime
+import logging
+import math
+from typing import Any
+from google.cloud import bigquery
+import requests
+import retry
+
+
+GITHUB_GRAPHQL_API_URL = "https://api.github.com/graphql"
+
+# How many subqueries to query the GitHub GraphQL API for at a time.
+# Querying too many subqueries at once often leads to the call failing.
+DEFAULT_GITHUB_API_BATCH_SIZE = 35
+
+PULL_REQUEST_GRAPHQL_DATA = """
+author {
+  login
+}
+title
+number
+state
+createdAt
+mergedAt
+labels(first: 25) {
+  nodes {
+    name
+  }
+}
+reviewRequests(first: 10) {
+  nodes {
+    requestedReviewer {
+      ... on User {
+        login
+      }
+    }
+  }
+}
+reviews(last: 100) {
+  nodes {
+    state
+    reviewID: id
+    createdAt
+    reviewer: author {
+      login
+    }
+  }
+}
+"""
+
+
+@dataclasses.dataclass
+class LLVMCommitData:
+  commit_sha: str
+  commit_timestamp_seconds: int
+  diff: list[dict[str, int | str]]
+  commit_author: str | None = (
+      None  # Username of author is unknown until API call
+  )
+  associated_pull_request: int | None = None
+  is_revert: bool = False
+  pull_request_reverted: int | None = None
+  commit_reverted: str | None = None
+
+
+@dataclasses.dataclass
+class LLVMPullRequestData:
+  pull_request_number: int
+  pull_request_author: str
+  pull_request_title: str
+  pull_request_state: str
+  pull_request_timestamp_seconds: int
+  merged_at_timestamp_seconds: int | None
+  associated_commit: str | None
+  labels: list[dict[str, str]]
+  requested_reviewers: list[str]
+
+
+@dataclasses.dataclass
+class LLVMReviewData:
+  review_id: str
+  review_author: str
+  review_timestamp_seconds: int
+  review_state: str
+  associated_pull_request: int
+
+
+@retry.retry(
+    exceptions=(
+        requests.exceptions.HTTPError,
+        requests.exceptions.ChunkedEncodingError,
+    ),
+    tries=5,
+    delay=1,
+    backoff=2,
+)
+def query_github_graphql_api(
+    query: str,
+    github_token: str,
+    variables: dict[str, str] | None = None,
+) -> requests.Response:
+  """Query GitHub GraphQL API, retrying on failure.
+
+  Args:
+    query: The GraphQL query to send to the GitHub API.
+    github_token: The access token to use with the GitHub GraphQL API.
+    variables: The variables to use with the GraphQL query.
+
+  Returns:
+    The response from the GitHub GraphQL API.
+  """
+  variables = variables or {}
+  response = requests.post(
+      url=GITHUB_GRAPHQL_API_URL,
+      headers={
+          "Authorization": f"bearer {github_token}",
+      },
+      json={"query": query, "variables": variables},
+  )
+  # Exit if API call fails
+  # A failed API call means a large batch of data is missing and will not be
+  # reflected in the dashboard. The dashboard will silently misrepresent
+  # commit data if we continue execution, so it's better to fail loudly.
+  response.raise_for_status()
+
+  return response
+
+
+def fetch_repository_data_from_github(
+    github_token: str,
+    subqueries: list[str],
+    batch_size: int = DEFAULT_GITHUB_API_BATCH_SIZE,
+) -> dict[str, dict[str, Any]]:
+  """Fetch repository data from the GitHub API using provided subqueries.
+
+  Args:
+    github_token: The access token to use with the GitHub GraphQL API.
+    subqueries: List of GraphQL subqueries to fetch data for.
+    batch_size: The number of commits to query the GitHub GraphQL API for at a
+      time.
+
+  Returns:
+    A dictionary of commit hash to commit data from the GitHub GraphQL API.
+  """
+  api_subquery_results = {}
+  query_template = """
+    query {
+      repository(owner:"llvm", name:"llvm-project"){
+          %s
+      }
+    }
+  """
+  num_batches = math.ceil(len(subqueries) / batch_size)
+  logging.info("Querying GitHub GraphQL API in %d batches", num_batches)
+  for i in range(num_batches):
+    subquery_batch = subqueries[i * batch_size : (i + 1) * batch_size]
+    query = query_template % "".join(subquery_batch)
+
+    logging.info(
+        "Querying batch %d of %d (%d subqueries)",
+        i + 1,
+        num_batches,
+        len(subquery_batch),
+    )
+    response = query_github_graphql_api(query, github_token)
+
+    api_subquery_results.update(response.json()["data"]["repository"])
+
+  return api_subquery_results
+
+
+def parse_pull_request_data(
+    pull_request: dict[str, Any],
+    associated_commit: str | None = None,
+) -> LLVMPullRequestData:
+  """Parse pull requests from the GitHub GraphQL API response.
+
+  Args:
+    pull_request: The JSON response for a single pull request from the GitHub
+      GraphQL API.
+    associated_commit: The commit hash associated with this pull request.
+
+  Returns:
+    An LLVMPullRequestData object containing the parsed data.
+  """
+  # Some pull requests have no author, possible when an account is deleted or
+  # email address is changed.
+  if pull_request["author"] is not None:
+    author_login = pull_request["author"]["login"]
+  else:
+    author_login = None
+    logging.warning(
+        "No author found for pull request %d", pull_request["number"]
+    )
+
+  # Convert ISO timestamp to Unix timestamp, in seconds
+  create_unix_timestamp = int(
+      datetime.datetime.fromisoformat(pull_request["createdAt"]).timestamp()
+  )
+  if pull_request["mergedAt"] is not None:
+    merge_unix_timestamp = int(
+        datetime.datetime.fromisoformat(pull_request["mergedAt"]).timestamp()
+    )
+  else:
+    merge_unix_timestamp = None
+
+  # Extract label names associated with the pull request
+  labels = [
+      {
+          "name": label["name"],
+      }
+      for label in pull_request["labels"]["nodes"]
+  ]
+
+  requested_reviewers = []
+  for request in pull_request["reviewRequests"]["nodes"]:
+    if request["requestedReviewer"] is not None:
+      requested_reviewers.append(request["requestedReviewer"]["login"])
+    else:
+      logging.warning(
+          "No login found for requested reviewer associated with pull"
+          " request %d",
+          pull_request["number"],
+      )
+
+  return LLVMPullRequestData(
+      pull_request_number=pull_request["number"],
+      pull_request_author=author_login,
+      pull_request_title=pull_request["title"],
+      pull_request_state=pull_request["state"],
+      pull_request_timestamp_seconds=create_unix_timestamp,
+      merged_at_timestamp_seconds=merge_unix_timestamp,
+      associated_commit=associated_commit,
+      labels=labels,
+      requested_reviewers=requested_reviewers,
+  )
+
+
+def parse_review_data(
+    pull_request: dict[str, Any],
+) -> list[LLVMReviewData]:
+  """Extract review data from GitHub API data.
+
+  Args:
+    pull_request: JSON response for a single pull request from Github API.
+
+  Returns:
+    List of LLVMReviewData objects for each review found.
+  """
+  associated_pull_request = pull_request["number"]
+  pull_request_author = (
+      pull_request["author"]["login"] if pull_request["author"] else None
+  )
+
+  review_data = []
+  for review in pull_request["reviews"]["nodes"]:
+    # Some reviews have no author, possible when an account is deleted or
+    # email address is changed.
+    if review["reviewer"] is not None:
+      reviewer_login = review["reviewer"]["login"]
+    else:
+      reviewer_login = None
+      logging.warning(
+          "No reviewer found for review associated with pull request %d",
+          associated_pull_request,
+      )
+
+    # Skip 'reviews' that were made by the pull request author.
+    if reviewer_login is not None and reviewer_login == pull_request_author:
+      continue
+
+    # Convert ISO timestamp to Unix timestamp, in seconds
+    unix_timestamp = int(
+        datetime.datetime.fromisoformat(review["createdAt"]).timestamp()
+    )
+
+    review_data.append(
+        LLVMReviewData(
+            review_id=review["reviewID"],
+            review_author=reviewer_login,
+            review_timestamp_seconds=unix_timestamp,
+            review_state=review["state"].upper(),
+            associated_pull_request=associated_pull_request,
+        )
+    )
+
+  return review_data
+
+
+def upload_to_bigquery(
+    bq_client: bigquery.Client,
+    bq_dataset: str,
+    bq_table: str,
+    llvm_data: list[LLVMCommitData | LLVMPullRequestData | LLVMReviewData],
+    primary_key: str,
+) -> None:
+  """Upload processed LLVM metrics to a BigQuery dataset.
+
+  Args:
+    bq_client: The BigQuery client to use.
+    bq_dataset: The name of the BigQuery dataset to upload to.
+    bq_table: The name of the BigQuery table to upload to.
+    llvm_data: List of LLVM data to process & upload to BigQuery.
+    primary_key: The name of the field to use as a primary key when merging
+      pending data with existing records.
+  """
+  target_table_id = f"{bq_dataset}.{bq_table}"
+  staging_table_id = f"{target_table_id}_staging"
+
+  records = [dataclasses.asdict(record) for record in llvm_data]
+  fields = [field for field in records[0].keys()]
+
+  update_values = ", ".join([f"dest.{field} = src.{field}" for field in fields])
+  insert_values = ", ".join([f"src.{field}" for field in fields])
+
+  query = f"""
+  MERGE {target_table_id} AS dest
+  USING {staging_table_id} AS src
+  ON dest.{primary_key} = src.{primary_key}
+  WHEN MATCHED THEN
+    UPDATE SET {update_values}
+  WHEN NOT MATCHED THEN
+    INSERT ({", ".join(fields)}) VALUES ({insert_values})
+  """
+
+  try:
+    bq_client.load_table_from_json(
+        json_rows=records,
+        destination=staging_table_id,
+        job_config=bigquery.LoadJobConfig(
+            schema=bq_client.get_table(target_table_id).schema,
+            write_disposition="WRITE_TRUNCATE",
+        ),
+    ).result()
+
+    bq_client.query(query).result()
+  except Exception as e:
+    logging.error("Failed to upload LLVM data to BigQuery: %s", e)
+    exit(1)
+  finally:
+    bq_client.delete_table(staging_table_id, not_found_ok=True)

--- a/premerge/ops-container/operational_metrics_lib_test.py
+++ b/premerge/ops-container/operational_metrics_lib_test.py
@@ -1,0 +1,166 @@
+import dataclasses
+from typing import Any
+import unittest
+import unittest.mock
+
+import operational_metrics_lib
+import requests
+
+
+class TestOperationalMetricsLib(unittest.TestCase):
+
+  def _create_llvm_commit_data(
+      self, commit_sha: str = 'abcdef'
+  ) -> operational_metrics_lib.LLVMCommitData:
+    """Creates a basic LLVMCommitData object."""
+    return operational_metrics_lib.LLVMCommitData(
+        commit_sha=commit_sha,
+        commit_timestamp_seconds=10000000,
+        diff=[],
+    )
+
+  def _create_mock_api_response(
+      self, status_code: int = 200, payload: dict[str, Any] | None = None
+  ) -> requests.Response:
+    """Creates a mock API response."""
+    response = requests.Response()
+    response.status_code = status_code
+    response.json = unittest.mock.MagicMock(
+        return_value=payload if payload else {}
+    )
+    return response
+
+  @unittest.mock.patch.object(requests, 'post', autospec=True)
+  def test_query_github_graphql_api_success(self, mock_post):
+    """Test querying against the GitHub GraphQL API."""
+    mock_post.return_value = self._create_mock_api_response()
+
+    _ = operational_metrics_lib.query_github_graphql_api(
+        'dummy_query', 'dummy_token', variables={'x': 'y'}
+    )
+
+    _, mock_kwargs = mock_post.call_args
+    mock_post.assert_called_once()
+    self.assertEqual(
+        mock_kwargs['json'], {'query': 'dummy_query', 'variables': {'x': 'y'}}
+    )
+    self.assertEqual(
+        mock_kwargs['headers'], {'Authorization': 'bearer dummy_token'}
+    )
+
+  @unittest.mock.patch.object(requests, 'post', autospec=True)
+  def test_query_github_graphql_api_with_http_error_retries(self, mock_post):
+    """Test querying against the GitHub GraphQL API with in an HTTP error."""
+    mock_post.return_value = self._create_mock_api_response(status_code=404)
+
+    with self.assertLogs(level='WARNING'):
+      with self.assertRaises(requests.exceptions.HTTPError):
+        with unittest.mock.patch('time.sleep'):  # Avoid sleep in unit test
+          _ = operational_metrics_lib.query_github_graphql_api(
+              'dummy_query', 'dummy_token'
+          )
+
+    # Assert that the post was retried at least once
+    self.assertGreater(mock_post.call_count, 1)
+
+  @unittest.mock.patch.object(requests, 'post', autospec=True)
+  def test_fetch_repository_data_from_github(self, mock_post):
+    """Test fetching GitHub API data for a list of commits."""
+    response_payload = {
+        'data': {'repository': {'commit_abcdef': {}, 'commit_ghijkl': {}}}
+    }
+    mock_post.return_value = self._create_mock_api_response(
+        payload=response_payload
+    )
+
+    subqueries = ['commit_abcdef: ...', 'commit_ghijkl: ...']
+
+    api_data = operational_metrics_lib.fetch_repository_data_from_github(
+        github_token='dummy_token',
+        subqueries=subqueries,
+    )
+
+    _, mock_kwargs = mock_post.call_args
+    mock_post.assert_called_once()
+    self.assertEqual(len(api_data), 2)
+    self.assertIn('commit_abcdef', mock_kwargs['json']['query'])
+    self.assertIn('commit_ghijkl', mock_kwargs['json']['query'])
+
+  @unittest.mock.patch.object(requests, 'post', autospec=True)
+  def test_fetch_repository_data_from_github_batching(self, mock_post):
+    """Test fetching GitHub API data in batches at a time."""
+    response_payload = {'data': {'repository': {}}}
+    mock_post.return_value = self._create_mock_api_response(
+        payload=response_payload
+    )
+
+    # Require 3 batches to make 50 subqueries
+    subqueries = [str(i) for i in range(50)]
+    batch_size = 24
+
+    _ = operational_metrics_lib.fetch_repository_data_from_github(
+        github_token='dummy_token',
+        subqueries=subqueries,
+        batch_size=batch_size,
+    )
+
+    self.assertEqual(mock_post.call_count, 3)
+
+  def test_upload_to_bigquery(self):
+    """Test uploading commit data to BigQuery."""
+    mock_bq_client = unittest.mock.MagicMock()
+    mock_bq_table = unittest.mock.MagicMock()
+
+    mock_bq_client.get_table.return_value = mock_bq_table
+    mock_bq_table.schema = []
+
+    commit_data = self._create_llvm_commit_data(commit_sha='abcdef')
+    expected_commit_record = dataclasses.asdict(commit_data)
+
+    operational_metrics_lib.upload_to_bigquery(
+        bq_client=mock_bq_client,
+        bq_dataset='mock_dataset',
+        bq_table='mock_table',
+        llvm_data=[commit_data],
+        primary_key='commit_sha',
+    )
+
+    # Staging table
+    mock_bq_client.load_table_from_json.assert_called_once()
+    mock_bq_client.load_table_from_json.assert_called_once_with(
+        json_rows=[expected_commit_record],
+        destination='mock_dataset.mock_table_staging',
+        job_config=unittest.mock.ANY,
+    )
+
+    # Merging
+    mock_bq_client.query.assert_called_once()
+    executed_query = mock_bq_client.query.call_args.args[0]
+    self.assertIn('MERGE mock_dataset.mock_table', executed_query)
+    self.assertIn('USING mock_dataset.mock_table_staging', executed_query)
+    self.assertIn('ON dest.commit_sha = src.commit_sha', executed_query)
+
+    # Cleanup
+    mock_bq_client.delete_table.assert_called_once_with(
+        'mock_dataset.mock_table_staging',
+        not_found_ok=True,
+    )
+
+  def test_upload_to_bigquery_exits_on_error(self):
+    """Test uploading commit data to BigQuery resulting in errors."""
+    mock_bq_client = unittest.mock.MagicMock()
+    mock_bq_client.load_table_from_json.side_effect = Exception('Mock BQ Error')
+
+    with self.assertLogs(level='ERROR'):
+      with self.assertRaises(SystemExit):
+        operational_metrics_lib.upload_to_bigquery(
+            bq_client=mock_bq_client,
+            bq_dataset='mock_dataset',
+            bq_table='mock_table',
+            llvm_data=[self._create_llvm_commit_data(commit_sha='abcdef')],
+            primary_key='commit_sha',
+        )
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/premerge/ops-container/process_llvm_commits.py
+++ b/premerge/ops-container/process_llvm_commits.py
@@ -1,16 +1,12 @@
-import dataclasses
 import datetime
 import logging
-import math
 import os
 import re
 from typing import Any, Optional
 import git
 from google.cloud import bigquery
-import requests
-import retry
+import operational_metrics_lib
 
-GITHUB_GRAPHQL_API_URL = "https://api.github.com/graphql"
 REPOSITORY_URL = "https://github.com/llvm/llvm-project.git"
 
 # BigQuery dataset and tables to write metrics to.
@@ -42,75 +38,12 @@ commit_{commit_sha}:
       associatedPullRequests(first: 1) {{
         totalCount
         pullRequest: nodes {{
-          author {{ login }}
-          number
-          title
-          createdAt
-          mergedAt
-          labels(first: 25) {{
-            nodes {{
-              name
-            }}
-          }}
-          reviewRequests(first: 10) {{
-            nodes {{
-              requestedReviewer {{
-                ... on User {{
-                  login
-                }}
-              }}
-            }}
-          }}
-          reviews(last: 100) {{
-            nodes {{
-              state
-              reviewID: id
-              createdAt
-              reviewer: author {{
-                login
-              }}
-            }}
-          }}
+          {requested_pull_request_data}
         }}
       }}
     }}
   }}
 """
-
-
-@dataclasses.dataclass
-class LLVMCommitData:
-  commit_sha: str
-  commit_timestamp_seconds: int
-  diff: list[dict[str, int | str]]
-  commit_author: str | None = (
-      None  # Username of author is unknown until API call
-  )
-  associated_pull_request: int | None = None
-  is_revert: bool = False
-  pull_request_reverted: int | None = None
-  commit_reverted: str | None = None
-
-
-@dataclasses.dataclass
-class LLVMPullRequestData:
-  pull_request_number: int
-  pull_request_author: str
-  pull_request_title: str
-  pull_request_timestamp_seconds: int
-  merged_at_timestamp_seconds: int
-  associated_commit: str
-  labels: list[dict[str, str]]
-  requested_reviewers: list[str]
-
-
-@dataclasses.dataclass
-class LLVMReviewData:
-  review_id: str
-  review_author: str
-  review_timestamp_seconds: int
-  review_state: str
-  associated_pull_request: int
 
 
 def scrape_commits_by_date(
@@ -187,14 +120,14 @@ def parse_commit_revert_info(
 
 def extract_initial_commit_data(
     commit: git.Commit,
-) -> LLVMCommitData:
+) -> operational_metrics_lib.LLVMCommitData:
   # Parse commit message for revert information
   is_revert, pull_request_reverted, commit_reverted = parse_commit_revert_info(
       commit.message
   )
 
   # Add entry
-  return LLVMCommitData(
+  return operational_metrics_lib.LLVMCommitData(
       commit_sha=commit.hexsha,
       commit_timestamp_seconds=commit.committed_date,
       diff=[
@@ -215,7 +148,7 @@ def extract_initial_commit_data(
 def extract_commit_data(
     scraped_commits: list[git.Commit],
     api_data: dict[str, Any],
-) -> list[LLVMCommitData]:
+) -> list[operational_metrics_lib.LLVMCommitData]:
   """Extract commit data from scraped Git commits and GitHub API data.
 
   Args:
@@ -253,7 +186,7 @@ def extract_commit_data(
 
 def extract_pull_request_data(
     api_data: dict[str, Any],
-) -> list[LLVMPullRequestData]:
+) -> list[operational_metrics_lib.LLVMPullRequestData]:
   """Extract pull request data from GitHub API data.
 
   Args:
@@ -268,50 +201,10 @@ def extract_pull_request_data(
       continue
     pull_request = commit_data["associatedPullRequests"]["pullRequest"][0]
 
-    # Some pull requests have no author, possible when an account is deleted or
-    # email address is changed.
-    if pull_request["author"] is not None:
-      author_login = pull_request["author"]["login"]
-    else:
-      author_login = None
-      logging.warning(
-          "No author found for pull request %d", pull_request["number"]
-      )
-
-    # Convert ISO timestamp to Unix timestamp, in seconds
-    create_unix_timestamp = int(
-        datetime.datetime.fromisoformat(pull_request["createdAt"]).timestamp()
-    )
-    if pull_request["mergedAt"] is not None:
-      merge_unix_timestamp = int(
-          datetime.datetime.fromisoformat(pull_request["mergedAt"]).timestamp()
-      )
-    else:
-      merge_unix_timestamp = None
-
-    # Extract label names associated with the pull request
-    labels = [
-        {
-            "name": label["name"],
-        }
-        for label in pull_request["labels"]["nodes"]
-    ]
-
-    requested_reviewers = [
-        review_request["requestedReviewer"]["login"]
-        for review_request in pull_request["reviewRequests"]["nodes"]
-    ]
-
     pull_request_data.append(
-        LLVMPullRequestData(
-            pull_request_number=pull_request["number"],
-            pull_request_author=author_login,
-            pull_request_title=pull_request["title"],
-            pull_request_timestamp_seconds=create_unix_timestamp,
-            merged_at_timestamp_seconds=merge_unix_timestamp,
+        operational_metrics_lib.parse_pull_request_data(
+            pull_request=pull_request,
             associated_commit=commit_sha.removeprefix("commit_"),
-            labels=labels,
-            requested_reviewers=requested_reviewers,
         )
     )
 
@@ -320,7 +213,7 @@ def extract_pull_request_data(
 
 def extract_review_data(
     api_data: dict[str, Any],
-) -> list[LLVMReviewData]:
+) -> list[operational_metrics_lib.LLVMReviewData]:
   """Extract review data from GitHub API data.
 
   Args:
@@ -334,152 +227,26 @@ def extract_review_data(
     if commit_data["associatedPullRequests"]["totalCount"] == 0:
       continue
     pull_request = commit_data["associatedPullRequests"]["pullRequest"][0]
-    associated_pull_request = pull_request["number"]
-    pull_request_author = (
-        pull_request["author"]["login"] if pull_request["author"] else None
-    )
-
-    for review in pull_request["reviews"]["nodes"]:
-      # Some reviews have no author, possible when an account is deleted or
-      # email address is changed.
-      if review["reviewer"] is not None:
-        reviewer_login = review["reviewer"]["login"]
-      else:
-        reviewer_login = None
-        logging.warning(
-            "No reviewer found for review associated with pull request %d",
-            associated_pull_request,
-        )
-
-      # Skip 'reviews' that were made by the pull request author.
-      if reviewer_login is not None and reviewer_login == pull_request_author:
-        continue
-
-      # Convert ISO timestamp to Unix timestamp, in seconds
-      unix_timestamp = int(
-          datetime.datetime.fromisoformat(review["createdAt"]).timestamp()
-      )
-
-      review_data.append(
-          LLVMReviewData(
-              review_id=review["reviewID"],
-              review_author=reviewer_login,
-              review_timestamp_seconds=unix_timestamp,
-              review_state=review["state"].upper(),
-              associated_pull_request=associated_pull_request,
-          )
-      )
+    review_data.extend(operational_metrics_lib.parse_review_data(pull_request))
 
   return review_data
 
 
-@retry.retry(
-    exceptions=(
-        requests.exceptions.HTTPError,
-        requests.exceptions.ChunkedEncodingError,
-    ),
-    tries=5,
-    delay=1,
-    backoff=2,
-)
-def query_github_graphql_api(
-    query: str,
-    github_token: str,
-) -> requests.Response:
-  """Query GitHub GraphQL API, retrying on failure.
-
-  Args:
-    query: The GraphQL query to send to the GitHub API.
-    github_token: The access token to use with the GitHub GraphQL API.
-
-  Returns:
-    The response from the GitHub GraphQL API.
-  """
-  response = requests.post(
-      url=GITHUB_GRAPHQL_API_URL,
-      headers={
-          "Authorization": f"bearer {github_token}",
-      },
-      json={"query": query},
-  )
-  # Exit if API call fails
-  # A failed API call means a large batch of data is missing and will not be
-  # reflected in the dashboard. The dashboard will silently misrepresent
-  # commit data if we continue execution, so it's better to fail loudly.
-  response.raise_for_status()
-
-  return response
-
-
-def fetch_github_api_data(
+def fetch_commit_data_from_github(
     github_token: str,
     commit_hashes: list[str],
-    batch_size: int = GITHUB_API_BATCH_SIZE,
-) -> dict[str, dict[str, Any]]:
-  """Fetch commit data from the GitHub GraphQL API.
-
-  Args:
-    github_token: The access token to use with the GitHub GraphQL API.
-    commit_hashes: List of commit hashes to fetch data for.
-    batch_size: The number of commits to query the GitHub GraphQL API for at a
-      time.
-
-  Returns:
-    A dictionary of commit hash to commit data from the GitHub GraphQL API.
-  """
-  # Create GraphQL subqueries for each commit
+):
   commit_subqueries = [
-      COMMIT_GRAPHQL_SUBQUERY_TEMPLATE.format(commit_sha=commit_sha)
+      COMMIT_GRAPHQL_SUBQUERY_TEMPLATE.format(
+          commit_sha=commit_sha,
+          requested_pull_request_data=operational_metrics_lib.PULL_REQUEST_GRAPHQL_DATA,
+      )
       for commit_sha in commit_hashes
   ]
-  api_commit_data = {}
-  query_template = """
-    query {
-      repository(owner:"llvm", name:"llvm-project"){
-          %s
-      }
-    }
-  """
-  num_batches = math.ceil(len(commit_subqueries) / batch_size)
-  logging.info("Querying GitHub GraphQL API in %d batches", num_batches)
-  for i in range(num_batches):
-    subquery_batch = commit_subqueries[i * batch_size : (i + 1) * batch_size]
-    query = query_template % "".join(subquery_batch)
-
-    logging.info(
-        "Querying batch %d of %d (%d commits)",
-        i + 1,
-        num_batches,
-        len(subquery_batch),
-    )
-    response = query_github_graphql_api(query, github_token)
-
-    api_commit_data.update(response.json()["data"]["repository"])
-
-  return api_commit_data
-
-
-def upload_daily_metrics_to_bigquery(
-    bq_client: bigquery.Client,
-    bq_dataset: str,
-    bq_table: str,
-    llvm_data: list[LLVMCommitData | LLVMPullRequestData | LLVMReviewData],
-) -> None:
-  """Upload processed LLVM metrics to a BigQuery dataset.
-
-  Args:
-    bq_client: The BigQuery client to use.
-    bq_dataset: The name of the BigQuery dataset to upload to.
-    bq_table: The name of the BigQuery table to upload to.
-    llvm_data: List of LLVM data to process & upload to BigQuery.
-  """
-  table_ref = bq_client.dataset(bq_dataset).table(bq_table)
-  table = bq_client.get_table(table_ref)
-  llvm_records = [dataclasses.asdict(commit) for commit in llvm_data]
-  errors = bq_client.insert_rows(table=table, rows=llvm_records)
-  if errors:
-    logging.error("Failed to upload LLVM data to BigQuery: %s", errors)
-    exit(1)
+  return operational_metrics_lib.fetch_repository_data_from_github(
+      github_token=github_token,
+      subqueries=commit_subqueries,
+  )
 
 
 def main() -> None:
@@ -506,24 +273,33 @@ def main() -> None:
     return
 
   logging.info("Fetching GitHub API data for discovered commits.")
-  api_data = fetch_github_api_data(github_token, commits)
+  api_data = fetch_commit_data_from_github(github_token, commits)
   commit_data = extract_commit_data(commits, api_data)
   pull_request_data = extract_pull_request_data(api_data)
   review_data = extract_review_data(api_data)
 
   logging.info("Uploading metrics to BigQuery.")
   bq_client = bigquery.Client()
-  upload_daily_metrics_to_bigquery(
-      bq_client, OPERATIONAL_METRICS_DATASET, LLVM_COMMITS_TABLE, commit_data
-  )
-  upload_daily_metrics_to_bigquery(
+  operational_metrics_lib.upload_to_bigquery(
       bq_client,
-      OPERATIONAL_METRICS_DATASET,
-      LLVM_PULL_REQUESTS_TABLE,
-      pull_request_data,
+      bq_dataset=OPERATIONAL_METRICS_DATASET,
+      bq_table=LLVM_COMMITS_TABLE,
+      llvm_data=commit_data,
+      primary_key="commit_sha",
   )
-  upload_daily_metrics_to_bigquery(
-      bq_client, OPERATIONAL_METRICS_DATASET, LLVM_REVIEWS_TABLE, review_data
+  operational_metrics_lib.upload_to_bigquery(
+      bq_client,
+      bq_dataset=OPERATIONAL_METRICS_DATASET,
+      bq_table=LLVM_PULL_REQUESTS_TABLE,
+      llvm_data=pull_request_data,
+      primary_key="pull_request_number",
+  )
+  operational_metrics_lib.upload_to_bigquery(
+      bq_client,
+      bq_dataset=OPERATIONAL_METRICS_DATASET,
+      bq_table=LLVM_REVIEWS_TABLE,
+      llvm_data=review_data,
+      primary_key="review_id",
   )
   bq_client.close()
 

--- a/premerge/ops-container/process_llvm_commits_test.py
+++ b/premerge/ops-container/process_llvm_commits_test.py
@@ -1,4 +1,3 @@
-import dataclasses
 import datetime
 from typing import Any
 import unittest
@@ -27,16 +26,6 @@ class TestProcessLLVMCommits(unittest.TestCase):
     }
     commit.message = message
     return commit
-
-  def _create_llvm_commit_data(
-      self, commit_sha: str = 'abcdef'
-  ) -> process_llvm_commits.LLVMCommitData:
-    """Creates a basic LLVMCommitData object."""
-    return process_llvm_commits.LLVMCommitData(
-        commit_sha=commit_sha,
-        commit_timestamp_seconds=10000000,
-        diff=[],
-    )
 
   def _create_mock_api_response(
       self, status_code: int = 200, payload: dict[str, Any] | None = None
@@ -87,6 +76,7 @@ class TestProcessLLVMCommits(unittest.TestCase):
             {'login': pull_request_author} if pull_request_author else None
         ),
         'title': pull_request_title,
+        'state': 'MERGED',
         'createdAt': created_at,
         'mergedAt': merged_at,
         'reviews': {'nodes': reviews or []},
@@ -224,38 +214,7 @@ class TestProcessLLVMCommits(unittest.TestCase):
     self.assertIsNone(commit_data.commit_reverted)
 
   @unittest.mock.patch.object(requests, 'post', autospec=True)
-  def test_query_github_graphql_api_success(self, mock_post):
-    """Test querying against the GitHub GraphQL API."""
-    mock_post.return_value = self._create_mock_api_response()
-
-    _ = process_llvm_commits.query_github_graphql_api(
-        'dummy_query', 'dummy_token'
-    )
-
-    _, mock_kwargs = mock_post.call_args
-    mock_post.assert_called_once()
-    self.assertEqual(mock_kwargs['json'], {'query': 'dummy_query'})
-    self.assertEqual(
-        mock_kwargs['headers'], {'Authorization': 'bearer dummy_token'}
-    )
-
-  @unittest.mock.patch.object(requests, 'post', autospec=True)
-  def test_query_github_graphql_api_with_http_error_retries(self, mock_post):
-    """Test querying against the GitHub GraphQL API resulting in an HTTP error."""
-    mock_post.return_value = self._create_mock_api_response(status_code=404)
-
-    with self.assertLogs(level='WARNING'):
-      with self.assertRaises(requests.exceptions.HTTPError):
-        with unittest.mock.patch('time.sleep'):  # Avoid sleep in unit test
-          _ = process_llvm_commits.query_github_graphql_api(
-              'dummy_query', 'dummy_token'
-          )
-
-    # Assert that the post was retried at least once
-    self.assertGreater(mock_post.call_count, 1)
-
-  @unittest.mock.patch.object(requests, 'post', autospec=True)
-  def test_fetch_github_api_data(self, mock_post):
+  def test_fetch_commit_data_from_github(self, mock_post):
     """Test fetching GitHub API data for a list of commits."""
     response_payload = {
         'data': {'repository': {'commit_abcdef': {}, 'commit_ghijkl': {}}}
@@ -264,7 +223,7 @@ class TestProcessLLVMCommits(unittest.TestCase):
         payload=response_payload
     )
 
-    api_data = process_llvm_commits.fetch_github_api_data(
+    api_data = process_llvm_commits.fetch_commit_data_from_github(
         github_token='dummy_token',
         commit_hashes=['abcdef', 'ghijkl'],
     )
@@ -274,26 +233,6 @@ class TestProcessLLVMCommits(unittest.TestCase):
     self.assertEqual(len(api_data), 2)
     self.assertIn('commit_abcdef', mock_kwargs['json']['query'])
     self.assertIn('commit_ghijkl', mock_kwargs['json']['query'])
-
-  @unittest.mock.patch.object(requests, 'post', autospec=True)
-  def test_fetch_github_api_data_batching(self, mock_post):
-    """Test fetching GitHub API data in batches at a time."""
-    response_payload = {'data': {'repository': {}}}
-    mock_post.return_value = self._create_mock_api_response(
-        payload=response_payload
-    )
-
-    # Require 3 batches to query 50 commits
-    commit_hashes = [str(i) for i in range(50)]
-    batch_size = 24
-
-    _ = process_llvm_commits.fetch_github_api_data(
-        github_token='dummy_token',
-        commit_hashes=commit_hashes,
-        batch_size=batch_size,
-    )
-
-    self.assertEqual(mock_post.call_count, 3)
 
   def test_extract_commit_data(self):
     """Test extracting commit data from scraped commits and GitHub API data."""
@@ -459,42 +398,6 @@ class TestProcessLLVMCommits(unittest.TestCase):
       review_data = process_llvm_commits.extract_review_data(commit_data)
     self.assertEqual(len(review_data), 1)
     self.assertIsNone(review_data[0].review_author)
-
-  def test_upload_daily_metrics_to_bigquery(self):
-    """Test uploading commit data to BigQuery."""
-    mock_bq_client = unittest.mock.MagicMock()
-    mock_table = unittest.mock.MagicMock()
-
-    mock_bq_client.get_table.return_value = mock_table
-    mock_bq_client.insert_rows.return_value = []  # No errors
-
-    commit_data = self._create_llvm_commit_data(commit_sha='abcdef')
-    expected_commit_record = dataclasses.asdict(commit_data)
-
-    process_llvm_commits.upload_daily_metrics_to_bigquery(
-        mock_bq_client,
-        bq_dataset='mock_dataset',
-        bq_table='mock_table',
-        llvm_data=[commit_data],
-    )
-
-    mock_bq_client.insert_rows.assert_called_once_with(
-        table=mock_table, rows=[expected_commit_record]
-    )
-
-  def test_upload_daily_metrics_to_bigquery_exits_on_error(self):
-    """Test uploading commit data to BigQuery resulting in errors."""
-    mock_bq_client = unittest.mock.MagicMock()
-    mock_bq_client.insert_rows.return_value = ['Error']
-
-    with self.assertLogs(level='ERROR'):
-      with self.assertRaises(SystemExit):
-        process_llvm_commits.upload_daily_metrics_to_bigquery(
-            bq_client=mock_bq_client,
-            bq_dataset='mock_dataset',
-            bq_table='mock_table',
-            llvm_data=[self._create_llvm_commit_data(commit_sha='abcdef')],
-        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In anticipation of another script for amending previously stored commit data, split the existing `process_llvm_commits.py` into a separate `operational_metrics_lib.py`.

In a follow up pull request, another script will be querying both the GitHub GraphQL API and our BigQuery datasets for pull request and review data. Instead of have redundant code blocks, functions should be available for reuse wherever possible.