### PR TITLE
Renamed 'llvm-clang-ubuntu-x-aarch64-pauth' ptrauth builder to 'llvm-clang-ubuntu-x-aarch64-pac-ret'.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3793,10 +3793,10 @@ all += [
         },
         
     # PtrAuth (PAuth) builders.
-    {'name' : "llvm-clang-ubuntu-x-aarch64-pauth",
-    'tags'  : ["clang", "llvm", "lld", "clang-tools-extra", "compiler-rt", "libc++", "libc++abi", "libunwind", "cross", "aarch64", "pauth", "ptrauth"],
+    {'name' : "llvm-clang-ubuntu-x-aarch64-pac-ret",
+    'tags'  : ["clang", "llvm", "lld", "clang-tools-extra", "compiler-rt", "libc++", "libc++abi", "libunwind", "cross", "aarch64", "pauth", "ptrauth", "pac-ret"],
     'workernames' : ["as-builder-11"],
-    'builddir': "x-aarch64-pauth",
+    'builddir': "x-aarch64-pac-ret",
     'factory' : UnifiedTreeBuilder.getCmakeExBuildFactory(
                     depends_on_projects = [
                         'llvm',

--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -326,7 +326,7 @@ def getReporters():
                         "llvm-nvptx-nvidia-win", "llvm-nvptx64-nvidia-win",
                         "lldb-remote-linux-ubuntu", "lldb-remote-linux-win",
                         "lldb-x86_64-win",
-                        "llvm-clang-ubuntu-x-aarch64-pauth"])
+                        "llvm-clang-ubuntu-x-aarch64-pac-ret"])
             ]),
         reporters.MailNotifier(
             fromaddr = status_email_fromaddr,
@@ -345,7 +345,7 @@ def getReporters():
             generators = [
                 utils.LLVMDefaultBuildStatusGenerator(
                     builders = [
-                        "llvm-clang-ubuntu-x-aarch64-pauth"])
+                        "llvm-clang-ubuntu-x-aarch64-pac-ret"])
             ]),
         reporters.MailNotifier(
             fromaddr = status_email_fromaddr,


### PR DESCRIPTION
Assign more reliable name for the pac-ret ptrauth builder.