### PR TITLE
Update compiler options for 'llvm-clang-ubuntu-x-aarch64-pauthtest' builder.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3920,7 +3920,7 @@ all += [
                         ),
                         TestSuiteBuilder.getLlvmTestSuiteSteps(
                             # Common C/CXX flags.
-                            compiler_flags = "--target=aarch64-linux-pauthtest -march=armv8l+pauth -O2 -fno-inline",
+                            compiler_flags = "--target=aarch64-linux-pauthtest -march=armv8l+pauth -O2",
                             # Common linker flags.
                             linker_flags = util.Interpolate(
                                 "--target=aarch64-linux-pauthtest -march=armv8l+pauth -O2 "


### PR DESCRIPTION
Finally removed '-fno-inline' option when compiling the LLVM TestSuite tests.