### PR TITLE
Update configuration for the remote Aarch64 LLDB builders.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3561,7 +3561,7 @@ all += [
 
                         "TOOLCHAIN_TARGET_TRIPLE"       : "aarch64-unknown-linux-gnu",
                         "TOOLCHAIN_TARGET_COMPILER_FLAGS"   :  "-mcpu=cortex-a78",
-                        "TOOLCHAIN_TARGET_SYSROOTFS"    : util.Interpolate("%(prop:sysroot_path_aarch64)s"),
+                        "TOOLCHAIN_TARGET_SYSROOTFS"    : util.Interpolate("%(prop:sysroots)s/aarch64-linux-gnu"),
                         "LIBCXX_ABI_VERSION"            : "1",
                         "LLVM_INSTALL_TOOLCHAIN_ONLY"   : "OFF",
 
@@ -3569,7 +3569,7 @@ all += [
                         "LLDB_TEST_COMPILER"            : util.Interpolate("%(prop:builddir)s/build/bin/clang"),
                         "LLDB_TEST_PLATFORM_URL"        : util.Interpolate("connect://%(prop:remote_test_host)s:1234"),
                         "LLDB_TEST_PLATFORM_WORKING_DIR": "/home/ubuntu/lldb-tests",
-                        "LLDB_TEST_SYSROOT"             : util.Interpolate("%(prop:sysroot_path_aarch64)s"),
+                        "LLDB_TEST_SYSROOT"             : util.Interpolate("%(prop:sysroots)s/aarch64-linux-gnu"),
                         "LLDB_ENABLE_PYTHON"            : "ON",
                         "LLDB_ENABLE_SWIG"              : "ON",
                         "LLDB_ENABLE_LIBEDIT"           : "OFF",
@@ -3582,7 +3582,7 @@ all += [
                                                             "--skip-category=lldb-server"),
                     },
                     cmake_options = [
-                        "-C", util.Interpolate("%(prop:srcdir_relative)s/clang/cmake/caches/CrossWinToARMLinux.cmake"),
+                        "-C", util.Interpolate("%(prop:srcdir_relative)s/clang/cmake/caches/cross-linux-toolchain.cmake"),
                     ],
                     install_dir = "native",
                     post_build_steps =
@@ -3700,14 +3700,14 @@ all += [
 
                         "TOOLCHAIN_TARGET_TRIPLE"       : "aarch64-unknown-linux-gnu",
                         "TOOLCHAIN_TARGET_COMPILER_FLAGS"   :  "-mcpu=cortex-a78",
-                        "TOOLCHAIN_TARGET_SYSROOTFS:PATH"   : util.Interpolate("%(prop:sysroot_path_aarch64)s"),
+                        "TOOLCHAIN_TARGET_SYSROOTFS:PATH"   : util.Interpolate("%(prop:sysroots)s/aarch64-linux-gnu"),
                         "LIBCXX_ABI_VERSION"            : "1",
                         "LLVM_INSTALL_TOOLCHAIN_ONLY"   : "OFF",
 
                         "LLDB_TEST_ARCH"                : "aarch64",
                         "LLDB_TEST_PLATFORM_URL"        : util.Interpolate("connect://%(prop:remote_test_host)s:1234"),
                         "LLDB_TEST_PLATFORM_WORKING_DIR": "/home/ubuntu/lldb-tests",
-                        "LLDB_TEST_SYSROOT:PATH"        : util.Interpolate("%(prop:sysroot_path_aarch64)s"),
+                        "LLDB_TEST_SYSROOT:PATH"        : util.Interpolate("%(prop:sysroots)s/aarch64-linux-gnu"),
                         "LLDB_ENABLE_PYTHON"            : "ON",
                         "LLDB_ENABLE_SWIG"              : "ON",
                         "LLDB_ENABLE_LIBEDIT"           : "OFF",
@@ -3720,7 +3720,7 @@ all += [
                                                             "--skip-category=lldb-server"),
                     },
                     cmake_options = [
-                        "-C", util.Interpolate("%(prop:srcdir_relative)s/clang/cmake/caches/CrossWinToARMLinux.cmake"),
+                        "-C", util.Interpolate("%(prop:srcdir_relative)s/clang/cmake/caches/cross-linux-toolchain.cmake"),
                     ],
                     install_dir = "native",
                     post_build_steps =

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -248,19 +248,17 @@ def get_all():
         # Ubuntu 24.04
         create_worker("as-builder-9", properties={
                         'jobs'                  : 128, 
-                        'remote_test_host'      : 'jetson-agx-2198.lab.llvm.org',
+                        'remote_test_host'      : 'arm64-linux-04.lab.llvm.org',
                         'remote_test_user'      : 'ubuntu',
-                        'sysroot_path_aarch64'  : '/mnt/fs/jetson-agx-ubuntu',
-                        'tools_root_path'       : '/home/buildbot/worker/as-builder-9/tools', 
+                        'sysroots'              : '/mnt/fs/sysroots',
                     },
                     max_builds=1),
         # Windows Server 2022
         create_worker("as-builder-10", properties={
                         'jobs'                  : 128, 
-                        'remote_test_host'      : 'jetson-agx-0086.lab.llvm.org',
+                        'remote_test_host'      : 'arm64-linux-03.lab.llvm.org',
                         'remote_test_user'      : 'ubuntu',
-                        'sysroot_path_aarch64'  : 'c:/buildbot/fs/jetson-agx-ubuntu',
-                        'zlib_root_path'        : 'c:/buildbot/fs/zlib-win32',
+                        'sysroots'              : 'c:/buildbot/fs',
                     },
                     max_builds=1),
         # Ubuntu Server on x86_64


### PR DESCRIPTION
* use 'cross-linux-toolchain.cmake' cache file instead of 'CrossWinToARMLinux.cmake'.
* assigned the generic armv7l/aarch64 devkits to the builders.
* assigned the generic target sysroots to the builders.

Affected builders:

* lldb-remote-linux-ubuntu
* lldb-remote-linux-win

Affected workers:

* as-builder-9
* as-builder-10