### PR TITLE
[BazelBot] Move bazel-fixer-bot entrypoint to Dockerfile

### DIFF
--- a/google-bazel-bot/docker/Dockerfile
+++ b/google-bazel-bot/docker/Dockerfile
@@ -95,3 +95,6 @@ RUN python3 -m venv .venv
 COPY bazel-bot/requirements.lock.txt .
 RUN .venv/bin/python3 -m pip install --require-hashes -r ./requirements.lock.txt
 COPY bazel-bot/* .
+
+ENTRYPOINT [".venv/bin/python3"]
+CMD ["./bazelbot_server.py", "--llvm_git_repo=/var/lib/buildkite-agent/llvm-project-bazelbot/", "--create_prs"]


### PR DESCRIPTION
This will enable us to remove it from the k8s YAML. This makes it easier
to switch things up in the code as now we can version them together
rather than needing to make k8s changes when the container gets
deployed.
