### PR TITLE
[BazelBot] Remove execution logs from bazel builds

### DIFF
--- a/google-bazel-bot/bazel-bot/bazel-build
+++ b/google-bazel-bot/bazel-bot/bazel-build
@@ -4,18 +4,15 @@
 set -ueo pipefail
 
 # Assumes one is cd-ed into utils/bazel directory already.
-mkdir -p $HOME/bazel_execution_log
 if [ $# -eq 0 ]; then
   # Quiet mode is important so it doesn't populate LLM logs with unnecessary info 
   bazelisk query //... + @llvm-project//... --lockfile_mode=off | \
   xargs --max-args 1000000 --max-chars 1000000 --exit \
   bazelisk --quiet build --lockfile_mode=off --config=generic_clang --jobs=128 \
   --build_tag_filters=-nobuildkite  \
-  --test_tag_filters=-nobuildkite  \
-  --execution_log_binary_file="$HOME/bazel_execution_log/$(git rev-parse HEAD).log"
+  --test_tag_filters=-nobuildkite
 else
   bazelisk --quiet build $@ --lockfile_mode=off --config=generic_clang --jobs=128 \
   --build_tag_filters=-nobuildkite  \
-  --test_tag_filters=-nobuildkite  \
-  --execution_log_binary_file="$HOME/bazel_execution_log/$(git rev-parse HEAD).log"
+  --test_tag_filters=-nobuildkite
 fi

--- a/google-bazel-bot/bazel-bot/bazel-build-ci
+++ b/google-bazel-bot/bazel-bot/bazel-build-ci
@@ -6,7 +6,6 @@ set -ueo pipefail
 # remote cache.
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/bin
 export BAZELISK_HOME=/var/lib/buildkite-agent/.cache/bazelisk
-mkdir -p "$HOME/bazel_execution_log"
 if [ $# -eq 0 ]; then
   # Differences from build script running on buildkite:
   # 1. Quiet mode is important so it doesn't populate LLM logs with unnecessary info 
@@ -16,11 +15,9 @@ if [ $# -eq 0 ]; then
   xargs --max-args 1000000 --max-chars 1000000 --exit \
   bazelisk --quiet build --lockfile_mode=off --config=ci --jobs=128 --nokeep_going \
   --remote_cache=https://storage.googleapis.com/llvm-bazel-cache \
-  --google_default_credentials \
-  --execution_log_binary_file="$HOME/bazel_execution_log/$(git rev-parse HEAD).log"
+  --google_default_credentials
 else
   bazelisk --quiet build --lockfile_mode=off $@ --config=ci --jobs=128 --nokeep_going \
   --remote_cache=https://storage.googleapis.com/llvm-bazel-cache \
-  --google_default_credentials \
-  --execution_log_binary_file="$HOME/bazel_execution_log/$(git rev-parse HEAD).log"
+  --google_default_credentials
 fi  

--- a/google-bazel-bot/bazel-bot/bazel-test
+++ b/google-bazel-bot/bazel-bot/bazel-test
@@ -11,12 +11,10 @@ if [ $# -eq 0 ]; then
   xargs --max-args 1000000 --max-chars 1000000 --exit \
   bazelisk --quiet test --lockfile_mode=off --config=generic_clang --jobs=128 \
   --build_tag_filters=-nobuildkite  \
-  --test_tag_filters=-nobuildkite  \
-  --execution_log_binary_file="$HOME/bazel_execution_log/$(git rev-parse HEAD).log"
+  --test_tag_filters=-nobuildkite
 else
   # Quiet mode is important so it doesn't populate LLM logs with unnecessary info
   bazelisk --quiet test $@ --lockfile_mode=off --config=generic_clang --jobs=128 \
   --build_tag_filters=-nobuildkite  \
-  --test_tag_filters=-nobuildkite  \
-  --execution_log_binary_file="$HOME/bazel_execution_log/$(git rev-parse HEAD).log"
+  --test_tag_filters=-nobuildkite
 fi

--- a/google-bazel-bot/bazel-bot/bazel-test-ci
+++ b/google-bazel-bot/bazel-bot/bazel-test-ci
@@ -13,11 +13,9 @@ if [ $# -eq 0 ]; then
   xargs --max-args 1000000 --max-chars 1000000 --exit \
   bazelisk --quiet test --lockfile_mode=off --config=ci --jobs=128 --nokeep_going \
   --remote_cache=https://storage.googleapis.com/llvm-bazel-cache \
-  --google_default_credentials \
-  --execution_log_binary_file="$HOME/bazel_execution_log/$(git rev-parse HEAD).log"
+  --google_default_credentials
 else
   bazelisk --quiet test $@ --lockfile_mode=off --config=ci --jobs=128 --nokeep_going \
   --remote_cache=https://storage.googleapis.com/llvm-bazel-cache \
-  --google_default_credentials \
-  --execution_log_binary_file="$HOME/bazel_execution_log/$(git rev-parse HEAD).log"
+  --google_default_credentials
 fi


### PR DESCRIPTION
These would accumulate and then cause the worker container to run out of storage, especially because here we had no eviction strategy. These are also not used anywhere as far as I can tell, so were just wasting space.