### PR TITLE
[CI] Group commits per pull request record

### DIFF
--- a/premerge/bigquery_schema/llvm_pull_requests_table_schema.json
+++ b/premerge/bigquery_schema/llvm_pull_requests_table_schema.json
@@ -42,10 +42,10 @@
     "description": "The state of this pull request (OPEN, MERGED, etc)."
   },
   {
-    "name": "associated_commit",
+    "name": "associated_commits",
     "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "SHA of the commit associated with the pull request."
+    "mode": "REPEATED",
+    "description": "List of SHAs for the commits associated with the pull request."
   },
   {
     "name": "labels",

--- a/premerge/ops-container/amend_pull_request_data.py
+++ b/premerge/ops-container/amend_pull_request_data.py
@@ -419,6 +419,7 @@ def main():
   logging.info("Updating post-commit reviews in BigQuery.")
   update_post_commit_reviews_in_bigquery(bq_client, github_token)
 
+  logging.info("Recording repository snapshot in BigQuery.")
   record_repository_snapshot_in_bigquery(bq_client)
 
   bq_client.close()

--- a/premerge/ops-container/operational_metrics_lib.py
+++ b/premerge/ops-container/operational_metrics_lib.py
@@ -79,7 +79,7 @@ class LLVMPullRequestData:
   pull_request_timestamp_seconds: int
   last_updated_at_timestamp_seconds: int
   merged_at_timestamp_seconds: int | None
-  associated_commit: str | None
+  associated_commits: list[str]
   labels: list[dict[str, str]]
   requested_reviewers: list[str]
   is_stale_data: bool = False  # Used to avoid amending outdated data (>14 days)
@@ -196,14 +196,14 @@ def fetch_repository_data_from_github(
 
 def parse_pull_request_data(
     pull_request: dict[str, Any],
-    associated_commit: str | None = None,
+    associated_commits: list[str] | None = None,
 ) -> LLVMPullRequestData:
   """Parse pull requests from the GitHub GraphQL API response.
 
   Args:
     pull_request: The JSON response for a single pull request from the GitHub
       GraphQL API.
-    associated_commit: The commit hash associated with this pull request.
+    associated_commits: The commit hashes associated with this pull request.
 
   Returns:
     An LLVMPullRequestData object containing the parsed data.
@@ -264,7 +264,7 @@ def parse_pull_request_data(
       pull_request_timestamp_seconds=create_unix_timestamp,
       last_updated_at_timestamp_seconds=updated_unix_timestamp,
       merged_at_timestamp_seconds=merge_unix_timestamp,
-      associated_commit=associated_commit,
+      associated_commits=associated_commits or [],  # Avoid None values
       labels=labels,
       requested_reviewers=requested_reviewers,
   )
@@ -338,6 +338,11 @@ def upload_to_bigquery(
     primary_key: The name of the field to use as a primary key when merging
       pending data with existing records.
   """
+
+  if not llvm_data:
+    logging.info("No data to upload to BigQuery.")
+    return
+
   target_table_id = f"{bq_dataset}.{bq_table}"
   staging_table_id = f"{target_table_id}_staging"
 

--- a/premerge/ops-container/process_llvm_commits.py
+++ b/premerge/ops-container/process_llvm_commits.py
@@ -195,20 +195,32 @@ def extract_pull_request_data(
   Returns:
     List of LLVMPullRequestData objects for each pull request found.
   """
-  pull_request_data = []
+  pull_requests_by_number = {}
+  commits_by_pull_request_number = {}
+
   for commit_sha, commit_data in api_data.items():
     if commit_data["associatedPullRequests"]["totalCount"] == 0:
       continue
+
     pull_request = commit_data["associatedPullRequests"]["pullRequest"][0]
+    pull_request_number = pull_request["number"]
+    commit_hash = commit_sha.removeprefix("commit_")
 
-    pull_request_data.append(
-        operational_metrics_lib.parse_pull_request_data(
-            pull_request=pull_request,
-            associated_commit=commit_sha.removeprefix("commit_"),
-        )
-    )
+    if pull_request_number not in pull_requests_by_number:
+      pull_requests_by_number[pull_request_number] = pull_request
+      commits_by_pull_request_number[pull_request_number] = []
 
-  return pull_request_data
+    commits_by_pull_request_number[pull_request_number].append(commit_hash)
+
+  return [
+      operational_metrics_lib.parse_pull_request_data(
+          pull_request=pull_request,
+          associated_commits=commits_by_pull_request_number[
+              pull_request_number
+          ],
+      )
+      for pull_request_number, pull_request in pull_requests_by_number.items()
+  ]
 
 
 def extract_review_data(

--- a/premerge/ops-container/process_llvm_commits_test.py
+++ b/premerge/ops-container/process_llvm_commits_test.py
@@ -83,10 +83,13 @@ class TestProcessLLVMCommits(unittest.TestCase):
         'mergedAt': merged_at,
         'reviews': {'nodes': reviews or []},
         'label_events': {
-            'nodes': [{
-                'createdAt': created_at,
-                'label': {'name': label_name},
-            } for label_name in labels or []]
+            'nodes': [
+                {
+                    'createdAt': created_at,
+                    'label': {'name': label_name},
+                }
+                for label_name in labels or []
+            ]
         },
         'reviewRequests': {
             'nodes': [
@@ -322,12 +325,40 @@ class TestProcessLLVMCommits(unittest.TestCase):
         pull_request_data[0].merged_at_timestamp_seconds,
         merged_at.timestamp(),
     )
-    self.assertEqual(pull_request_data[0].associated_commit, 'abcdef')
+    self.assertEqual(pull_request_data[0].associated_commits, ['abcdef'])
     self.assertIn(
         'llvm:test-label',
         [label['name'] for label in pull_request_data[0].labels],
     )
     self.assertIn('reviewer_1', pull_request_data[0].requested_reviewers)
+
+  def test_extract_pull_request_data_with_multiple_commits(self):
+    """Test extracting pull request data with multiple associated commits."""
+    pull_request_api_data = self._create_pull_request_api_data(
+        pull_request_number=12345,
+        pull_request_title='[TEST] Title',
+        pull_request_author='pull_request_author',
+        created_at='2020-01-01T00:00:00Z',
+        updated_at='2020-01-01T00:00:00Z',
+    )
+    commit_api_data = {
+        'commit_abcdef': self._create_commit_api_data(
+            pull_request_data=pull_request_api_data
+        ),
+        'commit_ghijkl': self._create_commit_api_data(
+            pull_request_data=pull_request_api_data
+        ),
+    }
+
+    pull_request_data = process_llvm_commits.extract_pull_request_data(
+        commit_api_data
+    )
+
+    self.assertEqual(len(pull_request_data), 1)
+    self.assertEqual(pull_request_data[0].pull_request_number, 12345)
+    self.assertEqual(
+        set(pull_request_data[0].associated_commits), {'abcdef', 'ghijkl'}
+    )
 
   def test_extract_pull_request_data_with_missing_author(self):
     """Test extracting pull request data from GitHub API data."""


### PR DESCRIPTION
Instead of having each (pull request number, commit sha) pairing be it's own row in bigquery, store associated commits under a single list.

While rare, it is possible for pull requests to be merged with multiple commits (Example: [#177909](https://github.com/llvm/llvm-project/pull/177909/commits)). Such pull requests cause errors when trying to call `operational_metrics_lib.upload_to_bigquery` due to duplicate primary keys.

This change will _**destroy and replace**_ our existing pull requests tables, so a backup is required prior to submission so that we may restore all data.

Queries powering our dashboards will require some adjustment as well.