### PR TITLE
[sanitizers] Preparation for P3953R3: Rename `std::runtime_format`

### DIFF
--- a/zorg/buildbot/builders/sanitizers/buildbot_functions.sh
+++ b/zorg/buildbot/builders/sanitizers/buildbot_functions.sh
@@ -459,7 +459,9 @@ function check_stage2 {
       LIT_OPTS+=" --timeout=1500"
       build_step "stage2/$sanitizer_name check-cxx"
       # Very slow.
-      export LIT_FILTER_OUT="std/utilities/format/format.functions/format.locale.runtime_format.pass.cpp"
+      export LIT_FILTER_OUT="std/utilities/format/format.functions/format.locale.dynamic_format.pass.cpp"
+      LIT_FILTER_OUT+="|std/utilities/format/format.functions/format.dynamic_format.pass.cpp"
+      LIT_FILTER_OUT+="|std/utilities/format/format.functions/format.locale.runtime_format.pass.cpp"
       LIT_FILTER_OUT+="|std/utilities/format/format.functions/format.runtime_format.pass.cpp"
       LIT_FILTER_OUT+="|std/utilities/format/format.functions/format_to_n.locale.pass.cpp"
       LIT_FILTER_OUT+="|std/utilities/format/format.functions/format_to_n.pass.cpp"


### PR DESCRIPTION
See
- https://wg21.link/p3953r3
- https://llvm.org/PR189657

Revert
- https://llvm.org/PR191912

It would make more sense to rename the test files to mention `dynamic_format`. For compatibility, this patch temporarily use both old and new names.