### PR TITLE
[CI] Track open pull requests targeting main, only

### DIFF
--- a/premerge/ops-container/amend_pull_request_data.py
+++ b/premerge/ops-container/amend_pull_request_data.py
@@ -33,7 +33,7 @@ def fetch_open_pull_requests_from_github(
   search_query = """
   query($cursor: String) {{
     search(
-      query: "repo:llvm/llvm-project is:pr is:open created:>{cutoff_timestamp}",
+      query: "repo:llvm/llvm-project is:pr is:open base:main created:>{cutoff_timestamp}",
       type: ISSUE,
       first: 100,
       after: $cursor


### PR DESCRIPTION
So far, `amend_pull_request_date.py` has been keeping track of __all__ open pull requests in the llvm/llvm-project repository, regardless of whether those pull requests were targeting main or not.

This change should address that, and make it so that we only track pull requests attempting to merge into main.