### PR TITLE
[AIX] adjust thread numbers for aix builder

### DIFF
--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -116,7 +116,7 @@ def get_all():
         create_worker("sanitizer-buildbot12", properties={'jobs': 48}, max_builds=2),
 
         # POWER 8 PowerPC AIX 7.2
-        create_worker("aix-ppc64", properties={'jobs': 80}, max_builds=1),
+        create_worker("aix-ppc64", properties={'jobs': 75}, max_builds=1),
 
         # IBM z13 (s390x), Ubuntu 16.04.2
         create_worker("systemz-1", properties={'jobs': 4, 'vcs_protocol': 'https'}, max_builds=4),


### PR DESCRIPTION
A bunch of builds fails due to current width of 80, reduce it to 75