### PR TITLE
[CI] Group pull request counts by age when snapshotting

### DIFF
--- a/premerge/bigquery_schema/llvm_repository_snapshots_table_schema.json
+++ b/premerge/bigquery_schema/llvm_repository_snapshots_table_schema.json
@@ -6,21 +6,43 @@
     "description": "Time this snapshot was taken at, as a Unix timestamp."
   },
   {
-    "name": "open_pull_request_count",
-    "type": "INTEGER",
-    "mode": "NULLABLE",
-    "description": "The number of non-stale, open pull requests at this snapshot."
+    "name": "open_pull_request_count_by_age",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "Number of non-stale, open pull requests at this snapshot. Grouped by age.",
+    "fields": [
+      {
+        "name": "age_in_days",
+        "type": "INTEGER",
+        "mode": "NULLABLE",
+        "description": "The age of the pull requests."
+      },
+      {
+        "name": "pull_request_count",
+        "type": "INTEGER",
+        "mode": "NULLABLE",
+        "description": "The number of pull requests `age_in_days` old"
+      }
+    ]
   },
   {
-    "name": "recent_unapproved_pull_request_count",
-    "type": "INTEGER",
-    "mode": "NULLABLE",
-    "description": "The number of pull requests requiring post-commit review (merged within the last 14 days)."
-  },
-  {
-    "name": "stale_unapproved_pull_request_count",
-    "type": "INTEGER",
-    "mode": "NULLABLE",
-    "description": "The number of pull requests requiring post-commit review (merged between 14 an 180 days ago)."
+    "name": "unapproved_pull_request_count_by_age",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "Number of unapproved & merged pull requests at this snapshot. Grouped by age.",
+    "fields": [
+      {
+        "name": "age_in_days",
+        "type": "INTEGER",
+        "mode": "NULLABLE",
+        "description": "The age of the pull requests."
+      },
+      {
+        "name": "pull_request_count",
+        "type": "INTEGER",
+        "mode": "NULLABLE",
+        "description": "The number of pull requests `age_in_days` old"
+      }
+    ]
   }
 ]

--- a/premerge/bigquery_schema/llvm_repository_snapshots_table_schema.json
+++ b/premerge/bigquery_schema/llvm_repository_snapshots_table_schema.json
@@ -15,7 +15,7 @@
         "name": "age_in_days",
         "type": "INTEGER",
         "mode": "NULLABLE",
-        "description": "The age of the pull requests."
+        "description": "The age of the pull requests, since time of creation."
       },
       {
         "name": "pull_request_count",
@@ -35,7 +35,7 @@
         "name": "age_in_days",
         "type": "INTEGER",
         "mode": "NULLABLE",
-        "description": "The age of the pull requests."
+        "description": "The age of the pull requests, since time of merge."
       },
       {
         "name": "pull_request_count",

--- a/premerge/ops-container/amend_pull_request_data.py
+++ b/premerge/ops-container/amend_pull_request_data.py
@@ -15,6 +15,22 @@ LLVM_PULL_REQUESTS_TABLE = "llvm_pull_requests"
 LLVM_REVIEWS_TABLE = "llvm_reviews"
 LLVM_REPOSITORY_SNAPSHOT_TABLE = "llvm_repository_snapshots"
 
+OPEN_PULL_REQUEST_PREDICATE = (
+    "LLVMPull.pull_request_state = 'OPEN' AND NOT LLVMPull.is_stale_data"
+)
+
+UNAPPROVED_PULL_REQUEST_PREDICATE = f"""
+LLVMPull.pull_request_state = 'MERGED'
+AND 'reviewed-post-commit' NOT IN UNNEST(LLVMPull.labels.name)
+AND NOT EXISTS(
+  SELECT 1
+  FROM {OPERATIONAL_METRICS_DATASET}.{LLVM_REVIEWS_TABLE} AS LLVMReview
+  WHERE
+    LLVMReview.review_state = 'APPROVED'
+    AND LLVMReview.associated_pull_request = LLVMPull.pull_request_number
+)
+"""
+
 
 def fetch_open_pull_requests_from_github(
     github_token: str,
@@ -76,6 +92,58 @@ def fetch_open_pull_requests_from_github(
   return pull_requests
 
 
+def get_pull_requests_by_age_from_bigquery(
+    bq_client: bigquery.Client,
+    predicate: str,
+    timestamp_column: str,
+    minimum_age_days: int,
+    maximum_age_days: int,
+) -> dict[int, list[int]]:
+  """Get pull requests from BigQuery, filtered by predicate and grouped by age.
+
+  Args:
+    bq_client: The BigQuery client to use for querying.
+    predicate: The predicate to use for filtering pull requests.
+    timestamp_column: The column to use for the timestamp.
+    minimum_age_days: The minimum age in days to filter by.
+    maximum_age_days: The maximum age in days to filter by.
+
+  Returns:
+    A dictionary of pull requests grouped by age in days.
+  """
+
+  query = f"""
+  SELECT
+    ARRAY_AGG(DISTINCT pull_request_number) AS pull_request_numbers,
+    TIMESTAMP_DIFF(
+        CURRENT_TIMESTAMP(),
+        TIMESTAMP_SECONDS(LLVMPull.{timestamp_column}),
+        DAY
+    ) AS age_in_days
+  FROM {OPERATIONAL_METRICS_DATASET}.{LLVM_PULL_REQUESTS_TABLE} AS LLVMPull
+  WHERE
+    {predicate}
+  GROUP BY age_in_days
+  HAVING
+    age_in_days >= @minimum_age_days
+    AND age_in_days < @maximum_age_days
+  """
+  job_config = bigquery.QueryJobConfig(
+      query_parameters=[
+          bigquery.ScalarQueryParameter(
+              "minimum_age_days", "INT64", minimum_age_days
+          ),
+          bigquery.ScalarQueryParameter(
+              "maximum_age_days", "INT64", maximum_age_days
+          ),
+      ],
+  )
+  return {
+      row.age_in_days: row.pull_request_numbers
+      for row in bq_client.query(query, job_config=job_config).result()
+  }
+
+
 def mark_stale_pull_request_data_in_bigquery(
     bq_client: bigquery.Client,
     cutoff_age_days: int,
@@ -105,27 +173,6 @@ def mark_stale_pull_request_data_in_bigquery(
       ],
   )
   bq_client.query(query, job_config=job_config).result()
-
-
-def get_open_pull_requests_from_bigquery(
-    bq_client: bigquery.Client,
-) -> list[int]:
-  """Get a list of open pull requests that have already been recorded.
-
-  Args:
-    bq_client: The BigQuery client to use for querying.
-
-  Returns:
-    A list of open pull request numbers that have already been recorded.
-  """
-  query = f"""
-  SELECT pull_request_number
-  FROM {OPERATIONAL_METRICS_DATASET}.{LLVM_PULL_REQUESTS_TABLE}
-  WHERE
-    pull_request_state = 'OPEN'
-    AND NOT is_stale_data
-  """
-  return [row.pull_request_number for row in bq_client.query(query).result()]
 
 
 def query_pull_request_data_from_github(
@@ -164,62 +211,6 @@ def query_pull_request_data_from_github(
   )
 
   return [pull_request for _, pull_request in pull_request_data.items()]
-
-
-def get_unapproved_pull_requests_from_bigquery(
-    bq_client: bigquery.Client,
-    minimum_age_days: int,
-    maximum_age_days: int,
-) -> list[int]:
-  """Get merged pull requests that have not yet been approved.
-
-  Args:
-    bq_client: The BigQuery client to use for querying.
-    minimum_age_days: The minimum age of pull requests to query, inclusive.
-    maximum_age_days: The maximum age of pull requests to query, exclusive.
-
-  Returns:
-    A list of relevant pull request numbers
-  """
-  query = f"""
-  SELECT
-    LLVMPull.pull_request_number
-  FROM {OPERATIONAL_METRICS_DATASET}.{LLVM_PULL_REQUESTS_TABLE} AS LLVMPull
-  WHERE
-    LLVMPull.pull_request_state = 'MERGED'
-    AND TIMESTAMP_DIFF(
-        CURRENT_TIMESTAMP(),
-        TIMESTAMP_SECONDS(LLVMPull.pull_request_timestamp_seconds),
-        DAY
-    ) >= @minimum_age_days
-    AND TIMESTAMP_DIFF(
-        CURRENT_TIMESTAMP(),
-        TIMESTAMP_SECONDS(LLVMPull.merged_at_timestamp_seconds),
-        DAY
-    ) < @maximum_age_days
-    AND 'reviewed-post-commit' NOT IN UNNEST(LLVMPull.labels.name)
-    AND NOT EXISTS(
-      SELECT 1
-      FROM {OPERATIONAL_METRICS_DATASET}.{LLVM_REVIEWS_TABLE} AS LLVMReview
-      WHERE
-        LLVMReview.review_state = 'APPROVED'
-        AND LLVMReview.associated_pull_request = LLVMPull.pull_request_number
-    )
-  """
-  job_config = bigquery.QueryJobConfig(
-      query_parameters=[
-          bigquery.ScalarQueryParameter(
-              "minimum_age_days", "INT64", minimum_age_days
-          ),
-          bigquery.ScalarQueryParameter(
-              "maximum_age_days", "INT64", maximum_age_days
-          ),
-      ],
-  )
-  return [
-      row.pull_request_number
-      for row in bq_client.query(query, job_config=job_config).result()
-  ]
 
 
 def upload_github_data_to_bigquery(
@@ -308,7 +299,16 @@ def update_open_pull_requests_in_bigquery(
   """
 
   # Fetch potential updates for already recorded pull requests that are open.
-  recorded_open_pull_requests = get_open_pull_requests_from_bigquery(bq_client)
+  open_pull_requests_by_age = get_pull_requests_by_age_from_bigquery(
+      bq_client,
+      predicate=OPEN_PULL_REQUEST_PREDICATE,
+      timestamp_column="pull_request_timestamp_seconds",
+      minimum_age_days=0,
+      maximum_age_days=180,  # Six months
+  )
+  recorded_open_pull_requests = []
+  for _, pull_request_numbers in open_pull_requests_by_age.items():
+    recorded_open_pull_requests.extend(pull_request_numbers)
   pull_request_data = query_pull_request_data_from_github(
       recorded_open_pull_requests, github_token
   )
@@ -336,11 +336,18 @@ def update_post_commit_reviews_in_bigquery(
   """
   # After two weeks, a merged pull request is most likely not going to receive
   # any more reviews.
-  unapproved_merged_pull_requests = get_unapproved_pull_requests_from_bigquery(
-      bq_client,
-      minimum_age_days=0,
-      maximum_age_days=14,
+  unapproved_merged_pull_requests_by_age = (
+      get_pull_requests_by_age_from_bigquery(
+          bq_client,
+          predicate=UNAPPROVED_PULL_REQUEST_PREDICATE,
+          timestamp_column="merged_at_timestamp_seconds",
+          minimum_age_days=0,
+          maximum_age_days=14,
+      )
   )
+  unapproved_merged_pull_requests = []
+  for _, pull_request_numbers in unapproved_merged_pull_requests_by_age.items():
+    unapproved_merged_pull_requests.extend(pull_request_numbers)
   pull_request_data = query_pull_request_data_from_github(
       unapproved_merged_pull_requests, github_token
   )
@@ -366,21 +373,28 @@ def record_repository_snapshot_in_bigquery(
   snapshot_timestamp_seconds = int(
       datetime.datetime.now(datetime.timezone.utc).timestamp()
   )
-  open_pull_request_count = len(get_open_pull_requests_from_bigquery(bq_client))
-  recent_unapproved_pull_request_count = len(
-      get_unapproved_pull_requests_from_bigquery(
-          bq_client,
-          minimum_age_days=0,
-          maximum_age_days=14,
-      )
+  open_pull_requests_by_age = get_pull_requests_by_age_from_bigquery(
+      bq_client,
+      predicate=OPEN_PULL_REQUEST_PREDICATE,
+      timestamp_column="pull_request_timestamp_seconds",
+      minimum_age_days=0,
+      maximum_age_days=180,  # Six months
   )
-  stale_unapproved_pull_request_count = len(
-      get_unapproved_pull_requests_from_bigquery(
-          bq_client,
-          minimum_age_days=14,
-          maximum_age_days=180,  # Six months.
-      )
+  open_pull_request_count_by_age = [
+      {"age_in_days": age, "pull_request_count": len(pull_request_numbers)}
+      for age, pull_request_numbers in open_pull_requests_by_age.items()
+  ]
+  unapproved_pull_requests_by_age = get_pull_requests_by_age_from_bigquery(
+      bq_client,
+      predicate=UNAPPROVED_PULL_REQUEST_PREDICATE,
+      timestamp_column="merged_at_timestamp_seconds",
+      minimum_age_days=0,
+      maximum_age_days=180,  # Six months
   )
+  unapproved_pull_request_count_by_age = [
+      {"age_in_days": age, "pull_request_count": len(pull_request_numbers)}
+      for age, pull_request_numbers in unapproved_pull_requests_by_age.items()
+  ]
 
   operational_metrics_lib.upload_to_bigquery(
       bq_client,
@@ -389,9 +403,8 @@ def record_repository_snapshot_in_bigquery(
       [
           operational_metrics_lib.LLVMRepositorySnapshot(
               snapshot_timestamp_seconds=snapshot_timestamp_seconds,
-              open_pull_request_count=open_pull_request_count,
-              recent_unapproved_pull_request_count=recent_unapproved_pull_request_count,
-              stale_unapproved_pull_request_count=stale_unapproved_pull_request_count,
+              open_pull_request_count_by_age=open_pull_request_count_by_age,
+              unapproved_pull_request_count_by_age=unapproved_pull_request_count_by_age,
           )
       ],
       "snapshot_timestamp_seconds",

--- a/premerge/ops-container/amend_pull_request_data_test.py
+++ b/premerge/ops-container/amend_pull_request_data_test.py
@@ -86,24 +86,54 @@ class TestAmendPullRequestData(unittest.TestCase):
     self.assertEqual(query_parameters.name, "cutoff_age_days")
     self.assertEqual(query_parameters.value, 14)
 
-  def test_get_open_pull_requests_from_bigquery(self):
-    """Test getting open pull requests from BigQuery."""
+  def test_get_pull_requests_by_age_from_bigquery(self):
+    """Test getting pull requests grouped by age from BigQuery."""
     mock_bq_client = unittest.mock.MagicMock()
     mock_bq_query_job = unittest.mock.MagicMock()
-    mock_bq_query_job.result.return_value = [
-        self._create_mock_bq_row(1234),
-        self._create_mock_bq_row(5678),
-    ]
+
+    mock_row_1 = unittest.mock.MagicMock()
+    mock_row_1.age_in_days = 2
+    mock_row_1.pull_request_numbers = [1111, 2222]
+
+    mock_row_2 = unittest.mock.MagicMock()
+    mock_row_2.age_in_days = 5
+    mock_row_2.pull_request_numbers = [3333]
+
+    mock_bq_query_job.result.return_value = [mock_row_1, mock_row_2]
     mock_bq_client.query.return_value = mock_bq_query_job
 
-    result = amend_pull_request_data.get_open_pull_requests_from_bigquery(
-        mock_bq_client
+    result = amend_pull_request_data.get_pull_requests_by_age_from_bigquery(
+        bq_client=mock_bq_client,
+        predicate="mock_column = 'MOCK_VALUE'",
+        timestamp_column="mock_timestamp_seconds",
+        minimum_age_days=0,
+        maximum_age_days=14,
     )
+
     mock_bq_client.query.assert_called_once()
+
+    # Check query string formatting
     executed_query = mock_bq_client.query.call_args.args[0]
-    self.assertIn("SELECT pull_request_number", executed_query)
-    self.assertRegex(executed_query, r"WHERE\s+pull_request_state = 'OPEN'")
-    self.assertEqual(result, [1234, 5678])
+    self.assertIn("mock_column = 'MOCK_VALUE'", executed_query)
+    self.assertIn(
+        "TIMESTAMP_SECONDS(LLVMPull.mock_timestamp_seconds)", executed_query
+    )
+    self.assertIn("ARRAY_AGG(DISTINCT pull_request_number)", executed_query)
+
+    # Check query arguments
+    job_config = mock_bq_client.query.call_args.kwargs["job_config"]
+    query_parameters = {
+        param.name: param.value for param in job_config.query_parameters
+    }
+    self.assertEqual(query_parameters["minimum_age_days"], 0)
+    self.assertEqual(query_parameters["maximum_age_days"], 14)
+
+    # Check results
+    expected_result = {
+        2: [1111, 2222],
+        5: [3333],
+    }
+    self.assertEqual(result, expected_result)
 
   @unittest.mock.patch.object(
       operational_metrics_lib, "fetch_repository_data_from_github"
@@ -126,36 +156,6 @@ class TestAmendPullRequestData(unittest.TestCase):
     self.assertEqual(mock_fetch_repository_data_from_github.call_count, 1)
     self.assertEqual(len(call_kwargs["subqueries"]), 2)
     self.assertEqual(result, [{"number": 1234}, {"number": 5678}])
-
-  def test_get_unapproved_pull_requests_from_bigquery(self):
-    """Test getting unapproved pull requests from BigQuery."""
-    mock_bq_client = unittest.mock.MagicMock()
-    mock_bq_query_job = unittest.mock.MagicMock()
-    mock_bq_query_job.result.return_value = [
-        self._create_mock_bq_row(1234),
-        self._create_mock_bq_row(5678),
-    ]
-    mock_bq_client.query.return_value = mock_bq_query_job
-
-    result = amend_pull_request_data.get_unapproved_pull_requests_from_bigquery(
-        mock_bq_client,
-        minimum_age_days=0,
-        maximum_age_days=14,
-    )
-    job_config = mock_bq_client.query.call_args.kwargs["job_config"]
-    min_parameter, max_parameter = job_config.query_parameters
-
-    mock_bq_client.query.assert_called_once()
-    executed_query = mock_bq_client.query.call_args.args[0]
-    self.assertRegex(executed_query, r"SELECT\s+(.+.)?pull_request_number")
-    self.assertRegex(
-        executed_query, r"WHERE\s+(.+.)?pull_request_state = 'MERGED'"
-    )
-    self.assertEqual(min_parameter.name, "minimum_age_days")
-    self.assertEqual(min_parameter.value, 0)
-    self.assertEqual(max_parameter.name, "maximum_age_days")
-    self.assertEqual(max_parameter.value, 14)
-    self.assertEqual(result, [1234, 5678])
 
   @unittest.mock.patch.object(
       operational_metrics_lib, "parse_pull_request_data"

--- a/premerge/ops-container/operational_metrics_lib.py
+++ b/premerge/ops-container/operational_metrics_lib.py
@@ -7,7 +7,6 @@ from google.cloud import bigquery
 import requests
 import retry
 
-
 GITHUB_GRAPHQL_API_URL = "https://api.github.com/graphql"
 
 # How many subqueries to query the GitHub GraphQL API for at a time.
@@ -97,9 +96,8 @@ class LLVMReviewData:
 @dataclasses.dataclass
 class LLVMRepositorySnapshot:
   snapshot_timestamp_seconds: int
-  open_pull_request_count: int
-  recent_unapproved_pull_request_count: int
-  stale_unapproved_pull_request_count: int
+  open_pull_request_count_by_age: list[dict[str, int]]
+  unapproved_pull_request_count_by_age: list[dict[str, int]]
 
 
 LLVMData: TypeAlias = (


### PR DESCRIPTION
Instead of predefining how to bucket pull request counts, just group all pull requests by their age. This allows us more flexibility when deciding how to display these metrics in our dashboards. Previously, it was impossible to make any adjustments in how & what data was being visualized without updating this script and destroying + recreating the snapshots table.