### PR TITLE
[CI] Filter out None returns from the GraphQL API

### DIFF
--- a/premerge/ops-container/amend_pull_request_data.py
+++ b/premerge/ops-container/amend_pull_request_data.py
@@ -210,7 +210,13 @@ def query_pull_request_data_from_github(
       subqueries=pull_request_subqueries,
   )
 
-  return [pull_request for _, pull_request in pull_request_data.items()]
+  # TODO: Determine why some pull requests are None, and whether such pull
+  # requests should be deleted from our datasets.
+  return [
+      pull_request
+      for _, pull_request in pull_request_data.items()
+      if pull_request is not None
+  ]
 
 
 def upload_github_data_to_bigquery(


### PR DESCRIPTION
There are some cases where a previously existing & recorded pull requests now returns 404 when querying. It's not clear what circumstances would cause this, but this change should keep the workflow from failing.

We'll probably want to follow up after investigating a little more to determine what cases cause such pull requests, and whether or not we want to remove them from our datasets.