### PR TITLE
[buildbot] Enable IR2Vec Python bindings on ml-opt builders

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2693,6 +2693,7 @@ all += [
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_IR2VEC_ENABLE_PYTHON_BINDINGS=ON",
                         "-DTENSORFLOW_C_LIB_PATH=/tmp/tensorflow",
                         "-C", "/tmp/tflitebuild/tflite.cmake",
                         "-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON"
@@ -2712,6 +2713,7 @@ all += [
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_IR2VEC_ENABLE_PYTHON_BINDINGS=ON",
                         "-DTENSORFLOW_C_LIB_PATH=/tmp/tensorflow",
                         "-C", "/tmp/tflitebuild/tflite.cmake",
                         "-DTENSORFLOW_AOT_PATH=/var/lib/buildbot/.local/lib/python3.7/site-packages/tensorflow",
@@ -2735,6 +2737,7 @@ all += [
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_IR2VEC_ENABLE_PYTHON_BINDINGS=ON",
                         "-DTENSORFLOW_AOT_PATH=/var/lib/buildbot/.local/lib/python3.7/site-packages/tensorflow"
                     ])},
 

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1463,7 +1463,7 @@ all += [
                     llvm_srcdir="llvm.src",
                     obj_dir="llvm.obj",
                     clean=True,
-                    pip_requirements='mlir/python/requirements.txt',
+                    install_pip_requirements=True,
                     targets = ['check-mlir-build-only'],
                     checks = ['check-mlir'],
                     depends_on_projects=['llvm','mlir'],
@@ -1489,7 +1489,7 @@ all += [
                     llvm_srcdir="llvm.src",
                     obj_dir="llvm.obj",
                     clean=True,
-                    pip_requirements='mlir/python/requirements.txt',
+                    install_pip_requirements=True,
                     targets = ['check-mlir-build-only'],
                     checks = ['check-mlir'],
                     depends_on_projects=['llvm','mlir'],
@@ -2688,13 +2688,11 @@ all += [
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
                     depends_on_projects=['llvm'],
-                    pip_requirements='llvm/tools/llvm-ir2vec/Bindings/requirements.txt',
                     extra_configure_args=[
                         "-DCMAKE_BUILD_TYPE=Release",
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
-                        "-DLLVM_IR2VEC_ENABLE_PYTHON_BINDINGS=ON",
                         "-DTENSORFLOW_C_LIB_PATH=/tmp/tensorflow",
                         "-C", "/tmp/tflitebuild/tflite.cmake",
                         "-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON"
@@ -2709,13 +2707,11 @@ all += [
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
                     depends_on_projects=['llvm'],
-                    pip_requirements='llvm/tools/llvm-ir2vec/Bindings/requirements.txt',
                     extra_configure_args= [
                         "-DCMAKE_BUILD_TYPE=Release",
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
-                        "-DLLVM_IR2VEC_ENABLE_PYTHON_BINDINGS=ON",
                         "-DTENSORFLOW_C_LIB_PATH=/tmp/tensorflow",
                         "-C", "/tmp/tflitebuild/tflite.cmake",
                         "-DTENSORFLOW_AOT_PATH=/var/lib/buildbot/.local/lib/python3.7/site-packages/tensorflow",
@@ -2734,13 +2730,11 @@ all += [
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
                     depends_on_projects=['llvm'],
-                    pip_requirements='llvm/tools/llvm-ir2vec/Bindings/requirements.txt',
                     extra_configure_args= [
                         "-DCMAKE_BUILD_TYPE=Release",
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
-                        "-DLLVM_IR2VEC_ENABLE_PYTHON_BINDINGS=ON",
                         "-DTENSORFLOW_AOT_PATH=/var/lib/buildbot/.local/lib/python3.7/site-packages/tensorflow"
                     ])},
 
@@ -2997,7 +2991,7 @@ all += [
          depends_on_projects=['llvm', 'mlir'],
          targets = ['check-mlir-build-only'],
          checks = ['check-mlir'],
-         pip_requirements='mlir/python/requirements.txt',
+         install_pip_requirements=True,
          extra_configure_args= mlir_default_cmake_options + [
              '-DLLVM_CCACHE_BUILD=ON',
              '-DLLVM_ENABLE_ASSERTIONS=ON',

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1463,7 +1463,7 @@ all += [
                     llvm_srcdir="llvm.src",
                     obj_dir="llvm.obj",
                     clean=True,
-                    install_pip_requirements=True,
+                    pip_requirements='mlir/python/requirements.txt',
                     targets = ['check-mlir-build-only'],
                     checks = ['check-mlir'],
                     depends_on_projects=['llvm','mlir'],
@@ -1489,7 +1489,7 @@ all += [
                     llvm_srcdir="llvm.src",
                     obj_dir="llvm.obj",
                     clean=True,
-                    install_pip_requirements=True,
+                    pip_requirements='mlir/python/requirements.txt',
                     targets = ['check-mlir-build-only'],
                     checks = ['check-mlir'],
                     depends_on_projects=['llvm','mlir'],
@@ -2688,11 +2688,13 @@ all += [
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
                     depends_on_projects=['llvm'],
+                    pip_requirements='llvm/tools/llvm-ir2vec/Bindings/requirements.txt',
                     extra_configure_args=[
                         "-DCMAKE_BUILD_TYPE=Release",
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_IR2VEC_ENABLE_PYTHON_BINDINGS=ON",
                         "-DTENSORFLOW_C_LIB_PATH=/tmp/tensorflow",
                         "-C", "/tmp/tflitebuild/tflite.cmake",
                         "-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON"
@@ -2707,11 +2709,13 @@ all += [
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
                     depends_on_projects=['llvm'],
+                    pip_requirements='llvm/tools/llvm-ir2vec/Bindings/requirements.txt',
                     extra_configure_args= [
                         "-DCMAKE_BUILD_TYPE=Release",
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_IR2VEC_ENABLE_PYTHON_BINDINGS=ON",
                         "-DTENSORFLOW_C_LIB_PATH=/tmp/tensorflow",
                         "-C", "/tmp/tflitebuild/tflite.cmake",
                         "-DTENSORFLOW_AOT_PATH=/var/lib/buildbot/.local/lib/python3.7/site-packages/tensorflow",
@@ -2730,11 +2734,13 @@ all += [
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
                     depends_on_projects=['llvm'],
+                    pip_requirements='llvm/tools/llvm-ir2vec/Bindings/requirements.txt',
                     extra_configure_args= [
                         "-DCMAKE_BUILD_TYPE=Release",
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",
                         "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_IR2VEC_ENABLE_PYTHON_BINDINGS=ON",
                         "-DTENSORFLOW_AOT_PATH=/var/lib/buildbot/.local/lib/python3.7/site-packages/tensorflow"
                     ])},
 
@@ -2991,7 +2997,7 @@ all += [
          depends_on_projects=['llvm', 'mlir'],
          targets = ['check-mlir-build-only'],
          checks = ['check-mlir'],
-         install_pip_requirements=True,
+         pip_requirements='mlir/python/requirements.txt',
          extra_configure_args= mlir_default_cmake_options + [
              '-DLLVM_CCACHE_BUILD=ON',
              '-DLLVM_ENABLE_ASSERTIONS=ON',

--- a/zorg/buildbot/builders/UnifiedTreeBuilder.py
+++ b/zorg/buildbot/builders/UnifiedTreeBuilder.py
@@ -1,6 +1,8 @@
 # UnifiedTreeBuilder.py
 #
 
+import os
+
 from buildbot.plugins import steps, util
 from buildbot.steps.shell import SetPropertyFromCommand
 from buildbot.process.factory import BuildFactory
@@ -267,9 +269,18 @@ def getCmakeBuildFactory(
            install_dir = None,
            clean = False,
            extra_configure_args = None,
-           install_pip_requirements = False,
+           pip_requirements = None,
+           install_pip_requirements = None, # deprecated, use pip_requirements instead
            env = None,
            **kwargs):
+
+    # Warn the deprecated install_pip_requirements boolean parameter.
+    if install_pip_requirements:
+        raise ValueError(
+            "install_pip_requirements=True is deprecated. "
+            "Pass the requirements file path relative to the repo root instead, e.g.:\n"
+            "    pip_requirements='mlir/python/requirements.txt'"
+        )
 
     f = getLLVMBuildFactoryAndSourcecodeSteps(
             depends_on_projects=depends_on_projects,
@@ -283,13 +294,17 @@ def getCmakeBuildFactory(
 
     cleanBuildRequested = lambda step: step.build.getProperty("clean") or step.build.getProperty("clean_obj") or clean
 
-    if install_pip_requirements:
-        # Install python requirements, right now for MLIR
-        # but can evolve to more projects later.
+    if pip_requirements:
+        if not isinstance(pip_requirements, str):
+            raise ValueError(
+                "pip_requirements must be a string path relative to the repo root, "
+                "e.g. 'mlir/python/requirements.txt'"
+            )
+
         f.addStep(steps.ShellCommand(
-            name='install-mlir-requirements',
-            command=["pip", "install", "-q", "-r", "../mlir/python/requirements.txt"],
-            workdir=f.llvm_srcdir))
+            name='install-pip-requirements',
+            command=["pip", "install", "-q", "-r", pip_requirements],
+            workdir=os.path.join(f.llvm_srcdir, "..")))
 
     addCmakeSteps(
         f,
@@ -315,9 +330,18 @@ def getCmakeWithNinjaBuildFactory(
            install_dir = None,
            clean = False,
            extra_configure_args = None,
-           install_pip_requirements = False,
+           pip_requirements = None,
+           install_pip_requirements = None, # deprecated, use pip_requirements instead
            env = None,
            **kwargs):
+
+    # Warn the deprecated install_pip_requirements boolean parameter.
+    if install_pip_requirements is not None:
+        raise ValueError(
+            "install_pip_requirements=True is deprecated. "
+            "Pass the requirements file path relative to the repo root instead, e.g.:\n"
+            "    pip_requirements='mlir/python/requirements.txt'"
+        )
 
     # Make a local copy of the configure args, as we are going to modify that.
     if extra_configure_args:
@@ -351,7 +375,7 @@ def getCmakeWithNinjaBuildFactory(
             install_dir=install_dir,
             clean=clean,
             extra_configure_args=cmake_args,
-            install_pip_requirements=install_pip_requirements,
+            pip_requirements=pip_requirements,
             env=merged_env,
             **kwargs) # Pass through all the extra arguments.
 
@@ -381,9 +405,17 @@ def getCmakeWithNinjaWithMSVCBuildFactory(
            # %VS140COMNTOOLS% selects the 2015 toolchain.
            vs=None,
            target_arch=None,
-           install_pip_requirements = False,
+           pip_requirements=None,
+           install_pip_requirements = None, # deprecated, use pip_requirements instead
            env = None,
            **kwargs):
+
+    if install_pip_requirements is not None:
+        raise ValueError(
+            "install_pip_requirements=True is deprecated. "
+            "Pass the requirements file path relative to the repo root instead, e.g.:\n"
+            "    pip_requirements='mlir/python/requirements.txt'"
+        )
 
     # Make a local copy of the configure args, as we are going to modify that.
     if extra_configure_args:
@@ -411,13 +443,17 @@ def getCmakeWithNinjaWithMSVCBuildFactory(
 
     cleanBuildRequested = lambda step: step.build.getProperty("clean") or step.build.getProperty("clean_obj") or clean
 
-    if install_pip_requirements:
-        # Install python requirements, right now for MLIR
-        # but can evolve to more projects later.
+    if pip_requirements:
+        if not isinstance(pip_requirements, str):
+            raise ValueError(
+                "pip_requirements must be a string path relative to the repo root, "
+                "e.g. 'mlir/python/requirements.txt'"
+            )
+
         f.addStep(steps.ShellCommand(
-            name='install-mlir-requirements',
-            command=["pip", "install", "-q", "-r", "../mlir/python/requirements.txt"],
-            workdir=f.llvm_srcdir))
+            name='install-pip-requirements',
+            command=["pip", "install", "-q", "-r", pip_requirements],
+            workdir=os.path.join(f.llvm_srcdir, "..")))
 
     addCmakeSteps(
         f,

--- a/zorg/buildbot/builders/UnifiedTreeBuilder.py
+++ b/zorg/buildbot/builders/UnifiedTreeBuilder.py
@@ -1,8 +1,6 @@
 # UnifiedTreeBuilder.py
 #
 
-import os
-
 from buildbot.plugins import steps, util
 from buildbot.steps.shell import SetPropertyFromCommand
 from buildbot.process.factory import BuildFactory
@@ -269,18 +267,9 @@ def getCmakeBuildFactory(
            install_dir = None,
            clean = False,
            extra_configure_args = None,
-           pip_requirements = None,
-           install_pip_requirements = None, # deprecated, use pip_requirements instead
+           install_pip_requirements = False,
            env = None,
            **kwargs):
-
-    # Warn the deprecated install_pip_requirements boolean parameter.
-    if install_pip_requirements:
-        raise ValueError(
-            "install_pip_requirements=True is deprecated. "
-            "Pass the requirements file path relative to the repo root instead, e.g.:\n"
-            "    pip_requirements='mlir/python/requirements.txt'"
-        )
 
     f = getLLVMBuildFactoryAndSourcecodeSteps(
             depends_on_projects=depends_on_projects,
@@ -294,17 +283,13 @@ def getCmakeBuildFactory(
 
     cleanBuildRequested = lambda step: step.build.getProperty("clean") or step.build.getProperty("clean_obj") or clean
 
-    if pip_requirements:
-        if not isinstance(pip_requirements, str):
-            raise ValueError(
-                "pip_requirements must be a string path relative to the repo root, "
-                "e.g. 'mlir/python/requirements.txt'"
-            )
-
+    if install_pip_requirements:
+        # Install python requirements, right now for MLIR
+        # but can evolve to more projects later.
         f.addStep(steps.ShellCommand(
-            name='install-pip-requirements',
-            command=["pip", "install", "-q", "-r", pip_requirements],
-            workdir=os.path.join(f.llvm_srcdir, "..")))
+            name='install-mlir-requirements',
+            command=["pip", "install", "-q", "-r", "../mlir/python/requirements.txt"],
+            workdir=f.llvm_srcdir))
 
     addCmakeSteps(
         f,
@@ -330,18 +315,9 @@ def getCmakeWithNinjaBuildFactory(
            install_dir = None,
            clean = False,
            extra_configure_args = None,
-           pip_requirements = None,
-           install_pip_requirements = None, # deprecated, use pip_requirements instead
+           install_pip_requirements = False,
            env = None,
            **kwargs):
-
-    # Warn the deprecated install_pip_requirements boolean parameter.
-    if install_pip_requirements is not None:
-        raise ValueError(
-            "install_pip_requirements=True is deprecated. "
-            "Pass the requirements file path relative to the repo root instead, e.g.:\n"
-            "    pip_requirements='mlir/python/requirements.txt'"
-        )
 
     # Make a local copy of the configure args, as we are going to modify that.
     if extra_configure_args:
@@ -375,7 +351,7 @@ def getCmakeWithNinjaBuildFactory(
             install_dir=install_dir,
             clean=clean,
             extra_configure_args=cmake_args,
-            pip_requirements=pip_requirements,
+            install_pip_requirements=install_pip_requirements,
             env=merged_env,
             **kwargs) # Pass through all the extra arguments.
 
@@ -405,17 +381,9 @@ def getCmakeWithNinjaWithMSVCBuildFactory(
            # %VS140COMNTOOLS% selects the 2015 toolchain.
            vs=None,
            target_arch=None,
-           pip_requirements=None,
-           install_pip_requirements = None, # deprecated, use pip_requirements instead
+           install_pip_requirements = False,
            env = None,
            **kwargs):
-
-    if install_pip_requirements is not None:
-        raise ValueError(
-            "install_pip_requirements=True is deprecated. "
-            "Pass the requirements file path relative to the repo root instead, e.g.:\n"
-            "    pip_requirements='mlir/python/requirements.txt'"
-        )
 
     # Make a local copy of the configure args, as we are going to modify that.
     if extra_configure_args:
@@ -443,17 +411,13 @@ def getCmakeWithNinjaWithMSVCBuildFactory(
 
     cleanBuildRequested = lambda step: step.build.getProperty("clean") or step.build.getProperty("clean_obj") or clean
 
-    if pip_requirements:
-        if not isinstance(pip_requirements, str):
-            raise ValueError(
-                "pip_requirements must be a string path relative to the repo root, "
-                "e.g. 'mlir/python/requirements.txt'"
-            )
-
+    if install_pip_requirements:
+        # Install python requirements, right now for MLIR
+        # but can evolve to more projects later.
         f.addStep(steps.ShellCommand(
-            name='install-pip-requirements',
-            command=["pip", "install", "-q", "-r", pip_requirements],
-            workdir=os.path.join(f.llvm_srcdir, "..")))
+            name='install-mlir-requirements',
+            command=["pip", "install", "-q", "-r", "../mlir/python/requirements.txt"],
+            workdir=f.llvm_srcdir))
 
     addCmakeSteps(
         f,


### PR DESCRIPTION
This is the follow-up to [THIS](https://github.com/llvm/llvm-project/pull/194593#pullrequestreview-4198371591) requested during review.

- Enables IR2Vec Python binding tests on the three ml-opt buildbots (`ml-opt-dev-x86-64`, `ml-opt-devrel-x86-64`, `ml-opt-rel-x86-64`) by adding `-DLLVM_IR2VEC_ENABLE_PYTHON_BINDINGS=ON` to each builder's CMake args and installing the bindings' pip requirements before the build.

- The binding tests run under `check-llvm` with no separate check target, so they integrate into the existing build and the tests run automatically.

- The existing `install_pip_requirements=True` parameter in `getCmakeBuildFactory` / `getCmakeWithNinjaBuildFactory` / `getCmakeWithNinjaWithMSVCBuildFactory` had a hardcoded path to `mlir/python/requirements.txt`, making it unusable for anything other than MLIR. This PR replaces it with `pip_requirements=<str>`, where the caller passes a repo-root-relative path to the requirements file.

All callers in this repo are updated in the same commit. The old parameter is retained and emits an error to catch any out-of-tree uses. This is necessary because if an downstream caller passes the variable, they're likely to run into errors downstream, because unlike before, no default pip installs will run with this parameter.

**Question**

- The ml-opt workers have Python 3.7 present (attached by the TF AOT path).  Is it possible to confirm a newer Python is available on `ml-opt-dev-x86-64-b1/b2`, `ml-opt-devrel-x86-64-b1/b2`, and `ml-opt-rel-x86-64-b1/b2`, and that it will be used by `pip` and CMake's `find_package(Python3)`?  If not, that needs resolving before this lands.

A test buildbot run would be appreciated.

Tagging @svkeerthy , @boomanaiden154  for reference