### PR TITLE
[lldb][windows] Remove LLDB_USE_LLDB_SERVER

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1365,7 +1365,6 @@ all = [
                         "LLDB_TEST_USER_ARGS"           : "--skip-category=lldb-dap",
                     },
                     env = {
-                        'LLDB_USE_LLDB_SERVER' : "1",
                         'CCACHE_DIR'    : util.Interpolate("%(prop:builddir)s/ccache-db"),
                         # TMP/TEMP within the build dir (to utilize a ramdisk).
                         'TMP'           : util.Interpolate("%(prop:builddir)s/build"),


### PR DESCRIPTION
`LLDB_USE_LLDB_SERVER` has no effect when running tests, the environment variable is not herited by the `lldb.exe` subprocess when running tests: https://github.com/llvm/llvm-project/pull/197660.

Furthermore, `lldb-server` on Windows does not work well and 100+ tests in `check-lldb` are failing when it's used.

This patch removes this `LLDB_USE_LLDB_SERVER` before merging https://github.com/llvm/llvm-project/pull/197660, as it will enable the `lldb-server` tests, which will fail. It's not tested at the moment.