### PR TITLE
[CI] Use unique staging table ids when uploading to BigQuery

### DIFF
--- a/premerge/ops-container/operational_metrics_lib.py
+++ b/premerge/ops-container/operational_metrics_lib.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import math
 from typing import Any, TypeAlias
+import uuid
 from google.cloud import bigquery
 import requests
 import retry
@@ -342,7 +343,11 @@ def upload_to_bigquery(
     return
 
   target_table_id = f"{bq_dataset}.{bq_table}"
-  staging_table_id = f"{target_table_id}_staging"
+
+  # Create a unique staging table ID to avoid conflict with concurrently running
+  # scripts.
+  unique_id = uuid.uuid4().hex
+  staging_table_id = f"{target_table_id}_staging_{unique_id}"
 
   records = [dataclasses.asdict(record) for record in llvm_data]
   fields = [field for field in records[0].keys()]

--- a/premerge/ops-container/operational_metrics_lib.py
+++ b/premerge/ops-container/operational_metrics_lib.py
@@ -346,8 +346,7 @@ def upload_to_bigquery(
 
   # Create a unique staging table ID to avoid conflict with concurrently running
   # scripts.
-  unique_id = uuid.uuid4().hex
-  staging_table_id = f"{target_table_id}_staging_{unique_id}"
+  staging_table_id = f"{target_table_id}_staging_{uuid.uuid4().hex}"
 
   records = [dataclasses.asdict(record) for record in llvm_data]
   fields = [field for field in records[0].keys()]

--- a/premerge/ops-container/operational_metrics_lib_test.py
+++ b/premerge/ops-container/operational_metrics_lib_test.py
@@ -106,8 +106,13 @@ class TestOperationalMetricsLib(unittest.TestCase):
 
     self.assertEqual(mock_post.call_count, 3)
 
-  def test_upload_to_bigquery(self):
+  @unittest.mock.patch('uuid.uuid4')
+  def test_upload_to_bigquery(self, mock_uuid4):
     """Test uploading commit data to BigQuery."""
+    mock_uuid4_instance = unittest.mock.MagicMock()
+    mock_uuid4_instance.hex = 'abc123'
+    mock_uuid4.return_value = mock_uuid4_instance
+
     mock_bq_client = unittest.mock.MagicMock()
     mock_bq_table = unittest.mock.MagicMock()
 
@@ -129,7 +134,7 @@ class TestOperationalMetricsLib(unittest.TestCase):
     mock_bq_client.load_table_from_json.assert_called_once()
     mock_bq_client.load_table_from_json.assert_called_once_with(
         json_rows=[expected_commit_record],
-        destination='mock_dataset.mock_table_staging',
+        destination='mock_dataset.mock_table_staging_abc123',
         job_config=unittest.mock.ANY,
     )
 
@@ -137,12 +142,14 @@ class TestOperationalMetricsLib(unittest.TestCase):
     mock_bq_client.query.assert_called_once()
     executed_query = mock_bq_client.query.call_args.args[0]
     self.assertIn('MERGE mock_dataset.mock_table', executed_query)
-    self.assertIn('USING mock_dataset.mock_table_staging', executed_query)
+    self.assertIn(
+        'USING mock_dataset.mock_table_staging_abc123', executed_query
+    )
     self.assertIn('ON dest.commit_sha = src.commit_sha', executed_query)
 
     # Cleanup
     mock_bq_client.delete_table.assert_called_once_with(
-        'mock_dataset.mock_table_staging',
+        'mock_dataset.mock_table_staging_abc123',
         not_found_ok=True,
     )
 


### PR DESCRIPTION
There are instances where scripts may be executing simultaneously and attempt to create/drop the same staging table, causing at least one of the scripts to fail. Appending a UUID to the staging table id for each upload removes any potential for conflicting upload attempts.