### PR TITLE
[google-integrate] Add notifier for release-noassertions-warnings

### DIFF
--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -680,6 +680,16 @@ def getReporters():
                     ],
                 )
             ]),
+        reporters.MailNotifier(
+            fromaddr = status_email_fromaddr,
+            SendToInterestedUsers = False,
+            extraRecipients = ["llvm-presubmit-infra@google.com"],
+            generators = [
+                utils.LLVMDefaultBuildStatusGenerator(
+                    builders = [
+                        "release-noassertions-warnings"])
+            ]
+        )
     ])
 
     return r


### PR DESCRIPTION
So that we get emails when things break just in case.