### PR TITLE
Add check-clang-unit, check-llvm-unit with LLVM_WINDOWS_PREFER_FORWARD_SLASH enabled on llvm-clang-x86_64-win-fast bot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -92,7 +92,17 @@ all = [
                     clean=True,
                     checks=[
                         "check-llvm-unit",
-                        "check-clang-unit"
+                        "check-clang-unit",
+                        {
+                            'target': 'check-llvm-unit',
+                            'env_override': {'LLVM_WINDOWS_PREFER_FORWARD_SLASH': '1'},
+                            'name_suffix': '-forward-slashes'
+                        },
+                        {
+                            'target': 'check-clang-unit',
+                            'env_override': {'LLVM_WINDOWS_PREFER_FORWARD_SLASH': '1'},
+                            'name_suffix': '-forward-slashes'
+                        }
                     ],
                     extra_configure_args=[
                         "-DLLVM_CCACHE_BUILD=ON",

--- a/zorg/buildbot/builders/UnifiedTreeBuilder.py
+++ b/zorg/buildbot/builders/UnifiedTreeBuilder.py
@@ -13,6 +13,7 @@ from zorg.buildbot.conditions.FileConditions import FileDoesNotExist
 from zorg.buildbot.process.factory import LLVMBuildFactory
 
 import zorg.buildbot.builders.Util as builders_util
+from zorg.buildbot.process.properties import MergedEnv
 
 def getLLVMBuildFactoryAndPrepareForSourcecodeSteps(
            depends_on_projects = None,
@@ -235,13 +236,28 @@ def addNinjaSteps(
 
     if checks:
         for check in checks:
-            f.addStep(LitTestCommand(name=trunc50("test-%s-%s" % (step_name, check)),
-                                    command=['ninja', check],
+            check_target = check
+            check_env_override = None
+            check_suffix = ""
+
+            if isinstance(check, dict):
+                check_target = check.get('target')
+                check_env_override = check.get('env_override')
+                check_suffix = check.get('name_suffix', "")
+
+            check_name = check_target + check_suffix
+
+            step_env = check_env
+            if check_env_override:
+                step_env = MergedEnv(check_env, check_env_override)
+
+            f.addStep(LitTestCommand(name=trunc50("test-%s-%s" % (step_name, check_name)),
+                                    command=['ninja', check_target],
                                     description=[
                                     "Test", "just", "built", "components", "for",
-                                    check,
+                                    check_name,
                                     ],
-                                    env=check_env,
+                                    env=step_env,
                                     workdir=obj_dir,
                                     **kwargs # Pass through all the extra arguments.
                                     ))

--- a/zorg/buildbot/process/properties.py
+++ b/zorg/buildbot/process/properties.py
@@ -59,3 +59,26 @@ class InterpolateToPosixPath(Interpolate):
             pass
 
         return p
+
+
+@implementer(IRenderable)
+class MergedEnv(object):
+    def __init__(self, base_env, overrides):
+        self.base_env = base_env
+        self.overrides = overrides
+
+    @defer.inlineCallbacks
+    def getRenderingFor(self, build):
+        if hasattr(build, 'render'):
+            base_env_rendered = yield build.render(self.base_env)
+        elif hasattr(build, 'properties') and hasattr(build.properties, 'render'):
+            base_env_rendered = yield build.properties.render(self.base_env)
+        else:
+            base_env_rendered = {}
+
+        if not isinstance(base_env_rendered, dict):
+            base_env_rendered = {}
+
+        merged = base_env_rendered.copy()
+        merged.update(self.overrides)
+        return merged


### PR DESCRIPTION
This PR enables running `check-clang-unit`, `check-llvm-unit` tests twice on `llvm-clang-x86_64-win-fast` bot: once with default settings (backslash path behavior), and once with the forward slash override enabled (`LLVM_WINDOWS_PREFER_FORWARD_SLASH=1`).

### Context & Rationale
There is no test coverage for LLVM_WINDOWS_PREFER_FORWARD_SLASH feature. Adding LLVM_WINDOWS_PREFER_FORWARD_SLASH enabled tests will improve the coverage, so that the change owners can notice test breakages.
It was also [discussed](https://discord.com/channels/636084430946959380/642340762620657675/1506736958611652658) to add tests with the flag to  an existing bot, rather than adding a new builder.

### Key Changes
*   `llvm-clang-x86_64-win-fast` will run the following tests:
    1.  `check-llvm-unit` (Default)
    2.  `check-clang-unit` (Default)
    3.  `check-llvm-unit-forward-slashes` (with `LLVM_WINDOWS_PREFER_FORWARD_SLASH=1` override)
    4.  `check-clang-unit-forward-slashes` (with `LLVM_WINDOWS_PREFER_FORWARD_SLASH=1` override)

* Introduces a new check type with `target`, `env_override`, `name_suffix` to support overriding an environment variable.

### Questions for reviewers
* Is there a better way than the `env_override` approach?
* Should `llvm-clang-x86_64-expensive-checks-win` also duplicate the checks, too?