### PR TITLE
[HIP] Rely on CMake cache for compiler-rt

### DIFF
--- a/zorg/buildbot/builders/annotated/hip-tpl.py
+++ b/zorg/buildbot/builders/annotated/hip-tpl.py
@@ -36,7 +36,7 @@ def main(argv):
         # Use Ninja as the generator.
         # The other important settings alrady come from the CMake CMake
         # cache file inside LLVM
-        cmake_args = ["-GNinja", "-C %s" % cmake_cache_file, "-DLLVM_ENABLE_RUNTIMES=compiler-rt"]
+        cmake_args = ["-GNinja", "-C %s" % cmake_cache_file]
 
         run_command(["cmake", os.path.join(source_dir, "llvm")] + cmake_args)
 


### PR DESCRIPTION
The script enabled the compiler-rt explicitly. However, it was/is already enabled in the CMake cache file and our other builders rely on the CMake cache alone.

Remove it as an explicit setting in this bot.