### PR TITLE
[HIP] Move bot to ScriptedBuilder

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1920,11 +1920,9 @@ all += [
     'tags'  : ["amdgpu", "offload", "openmp"],
     'workernames' : ["ext_buildbot_hw_05-hip-docker"],
     'builddir': "hip-third-party-libs-test",
-    'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
+    'factory' : ScriptedBuilder.getScriptedBuildFactory(
+                    "offload/ci/hip-tpl.py",
                     depends_on_projects=['llvm', 'clang', 'compiler-rt', 'lld', 'mlir', 'flang', 'openmp', 'offload', 'flang-rt'],
-                    script="hip-tpl.py",
-                    checkout_llvm_sources=True,
-                    script_interpreter=None
                 )},
 
     {'name' : "openmp-offload-libc-amdgpu-runtime",


### PR DESCRIPTION
The HIP TPL bot is currently failing as the result of picking up a previous CMakeCache.
I wanted to move that bot over to the ScriptedBuilder anyway. Let's do that now.