### PR TITLE
[BOLT][AArch64] Do not generate A53 veneers

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2937,6 +2937,9 @@ all += [
                     extra_configure_args=[
                         "-DCMAKE_C_COMPILER=gcc",
                         "-DCMAKE_CXX_COMPILER=g++",
+                        # Neoverse V1 does not need Cortex-A53 erratum veneers.
+                        "-DCMAKE_C_FLAGS=-mno-fix-cortex-a53-843419",
+                        "-DCMAKE_CXX_FLAGS=-mno-fix-cortex-a53-843419",
                         "-DLLVM_APPEND_VC_REV=OFF",
                         "-DCMAKE_C_COMPILER_LAUNCHER=ccache",
                         "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache",


### PR DESCRIPTION
GCC generates erratum 843419 veneers required for Cortex-A53.
`bolt-worker-aarch64` runs on Neoverse V1.