### PR TITLE
[AMD] Add `check-compiler-rt` to amdgcn bot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1906,7 +1906,7 @@ all += [
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_CFLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                             "-DTEST_SUITE_SOLLVEVV_OFFLOADING_LDLAGS=-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa",
                         ],
-                        add_lit_checks=["check-clang", "check-llvm", "check-lld", "check-libc-amdgcn-amd-amdhsa"],
+                        add_lit_checks=["check-clang", "check-llvm", "check-lld", "check-libc-amdgcn-amd-amdhsa", "check-compiler-rt-amdgcn-amd-amdhsa"],
                         add_openmp_lit_args=["--time-tests", "--timeout 100"],
                         )},
 


### PR DESCRIPTION
Summary:
These are lightweight tests that check the compiler builtins and ubsan
interface right now. This should prevent us from regressing on behavior
for these. They use the same infra as the existing libc tests.
