### PR TITLE
[Buildbot][AMDGPU] Remove old HIP bot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1922,16 +1922,6 @@ all += [
                     script_interpreter=None
                 )},
 
-    # This one has a longer turn-around time, so we cannot disallow collapsing requests
-    {'name' : "hip-third-party-libs-test",
-    'tags'  : ["amdgpu", "offload", "openmp"],
-    'workernames' : ["ext_buildbot_hw_05-hip-docker"],
-    'builddir': "hip-third-party-libs-test",
-    'factory' : ScriptedBuilder.getScriptedBuildFactory(
-                    "offload/ci/hip-tpl.py",
-                    depends_on_projects=['llvm', 'clang', 'compiler-rt', 'lld', 'mlir', 'flang', 'openmp', 'offload', 'flang-rt'],
-                )},
-
     {'name' : "openmp-offload-libc-amdgpu-runtime",
     'tags'  : ["openmp"],
     'workernames' : ["omp-vega20-1"],
@@ -2036,11 +2026,9 @@ all += [
     'tags'  : ["amdgpu", "offload", "openmp"],
     'workernames' : ["AMD-bb-w-03"],
     'builddir': "amdgpu-hip-tpl",
-    'factory' : AnnotatedBuilder.getAnnotatedBuildFactory(
+    'factory' : ScriptedBuilder.getScriptedBuildFactory(
+                    "offload/ci/hip-tpl.py",
                     depends_on_projects=['llvm', 'clang', 'compiler-rt', 'lld', 'mlir', 'flang', 'openmp', 'offload', 'flang-rt'],
-                    script="hip-tpl.py",
-                    checkout_llvm_sources=True,
-                    script_interpreter=None
                 )},
 
     {'name' : "amdgpu-clang-flang",

--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -506,7 +506,6 @@ def getReporters():
                 utils.LLVMDefaultBuildStatusGenerator(
                     builders = [
                         "clang-hip-vega20",
-                        "hip-third-party-libs-test",
                         "openmp-offload-amdgpu-runtime",
                         "openmp-offload-amdgpu-runtime-2",
                         "openmp-offload-libc-amdgpu-runtime",

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -377,7 +377,6 @@ def get_all():
         create_worker("intel-sycl-gpu-01", properties={'jobs': 192}, max_builds=1),
 
         # Containerized builder for third party libraries using HIP
-        create_worker("ext_buildbot_hw_05-hip-docker", properties={'jobs': 32}, max_builds=1),
         create_worker("AMD-bb-w-03", properties={'jobs': 32}, max_builds=1),
 
         # AMD ROCm support, Ubuntu 18.04.6, AMD Ryzen @ 1.5 GHz, MI200 GPU


### PR DESCRIPTION
This PR removed the old HIP bot for AMDGPU and applied the scripted builder to the new bot.