### PR TITLE
Removed deprecated code to be ready for buildbot 4.x

### DIFF
--- a/zorg/buildbot/builders/AnnotatedBuilder.py
+++ b/zorg/buildbot/builders/AnnotatedBuilder.py
@@ -1,5 +1,5 @@
 from buildbot.plugins import util
-from buildbot.steps.shell import SetProperty
+from buildbot.steps.shell import SetPropertyFromCommand
 from zorg.buildbot.commands.AnnotatedCommand import AnnotatedCommand
 from zorg.buildbot.process.factory import LLVMBuildFactory
 
@@ -51,7 +51,7 @@ def getAnnotatedBuildFactory(
         depends_on_projects=depends_on_projects)
 
     if clean:
-        f.addStep(SetProperty(property='clean', command='echo 1'))
+        f.addStep(SetPropertyFromCommand(property='clean', command='echo 1'))
 
     # We normally use the clean property to indicate that we want a
     # clean build, but AnnotatedCommand uses the clobber property
@@ -59,7 +59,7 @@ def getAnnotatedBuildFactory(
     # value.  This will cause AnnotatedCommand to set
     # BUILDBOT_CLOBBER=1 in the environment, which is how we
     # communicate to the script that we need a clean build.
-    f.addStep(SetProperty(
+    f.addStep(SetPropertyFromCommand(
         property='clobber',
         command='echo 1',
         doStepIf=lambda step: step.build.getProperty('clean', False)))

--- a/zorg/buildbot/builders/ClangBuilder.py
+++ b/zorg/buildbot/builders/ClangBuilder.py
@@ -2,7 +2,7 @@ import copy
 from datetime import datetime
 
 from buildbot.plugins import util
-from buildbot.steps.shell import ShellCommand, SetProperty
+from buildbot.steps.shell import ShellCommand, SetPropertyFromCommand
 from buildbot.steps.shell import WarningCountingShellCommand
 from buildbot.steps.transfer import StringDownload
 
@@ -44,7 +44,7 @@ def addGCSUploadSteps(f, package_name, install_prefix, gcs_directory, env,
             now=lambda _: datetime.utcnow().strftime(time_fmt))
 
     if gcs_url_property:
-        f.addStep(SetProperty(
+        f.addStep(SetPropertyFromCommand(
                       name="record GCS url for " + package_name,
                       command=['echo', gcs_url],
                       property=gcs_url_property))
@@ -337,7 +337,7 @@ def _getClangCMakeBuildFactory(
 
     # Set up VS environment, if appropriate.
     if vs and vs != "manual":
-        f.addStep(SetProperty(
+        f.addStep(SetPropertyFromCommand(
             command=builders_util.getVisualStudioEnvironment(vs, vs_target_arch),
             extract_fn=builders_util.extractVSEnvironment))
         assert not env, "Can't have custom builder env vars with VS"
@@ -593,7 +593,7 @@ def _getClangCMakeBuildFactory(
         # CC and CXX are needed as env for build-tools
         if vs and vs != "manual":
             # VS environment requires some extra care.
-            f.addStep(SetProperty(
+            f.addStep(SetPropertyFromCommand(
                 command=builders_util.getVisualStudioEnvironment(vs, vs_target_arch),
                 extract_fn=builders_util.extractVSEnvironment,
                 env={'CC'  : cc, 'CXX' : cxx}))

--- a/zorg/buildbot/builders/LLDBBuilder.py
+++ b/zorg/buildbot/builders/LLDBBuilder.py
@@ -1,4 +1,4 @@
-from buildbot.steps.shell import SetProperty
+from buildbot.steps.shell import SetPropertyFromCommand
 from buildbot.steps.shell import ShellCommand, WarningCountingShellCommand
 from buildbot.plugins import steps, util
 
@@ -36,7 +36,7 @@ def getLLDBCMakeBuildFactory(
 
     env = {}
     if vs and vs != 'manual':
-        f.addStep(SetProperty(
+        f.addStep(SetPropertyFromCommand(
             command=getVisualStudioEnvironment(vs, target_arch),
             extract_fn=extractVSEnvironment))
         env = Property('vs_env')

--- a/zorg/buildbot/conditions/FileConditions.py
+++ b/zorg/buildbot/conditions/FileConditions.py
@@ -1,5 +1,4 @@
 from buildbot.process.remotecommand import RemoteCommand
-from buildbot.interfaces import WorkerTooOldError
 import stat
 
 

--- a/zorg/buildbot/reporters/utils.py
+++ b/zorg/buildbot/reporters/utils.py
@@ -177,10 +177,9 @@ class LLVMInformativeMailGenerator(BuildStatusGenerator):
         super().__init__(mode=mode, message_formatter=message_formatter, **kwargs)
 
 class LLVMDefaultBuildStatusGenerator(BuildStatusGenerator):
-    def __init__(self, mode=("failing",),
-                 subject="Build Failure: {{ buildername }}", **kwargs):
+    def __init__(self, mode=("failing",), **kwargs):
         super().__init__(mode=mode,
-                         message_formatter=MessageFormatter(subject=subject),
+                         message_formatter=MessageFormatter(subject="Build Failure: {{ buildername }}"),
                          **kwargs)
 
 
@@ -191,7 +190,6 @@ class LLVMFailBuildGenerator(BuildStatusGenerator):
         builders=None,
         schedulers=None,
         branches=None,
-        add_logs=True,
         add_patch=False,
         message_formatter=LLVMInformativeComment,
         is_message_needed_filter=None,
@@ -202,8 +200,6 @@ class LLVMFailBuildGenerator(BuildStatusGenerator):
             builders=builders,
             schedulers=schedulers,
             branches=branches,
-            subject=None,
-            add_logs=add_logs,
             add_patch=add_patch,
         )
         self.formatter = message_formatter
@@ -371,6 +367,7 @@ class LLVMFailGitHubReporter(GitHubCommentPush):
         repo_name,
         sha,
         state,
+        props=None, # 4.x
         target_url=None,
         context=None,
         issue=None,
@@ -387,10 +384,11 @@ class LLVMFailGitHubReporter(GitHubCommentPush):
         url = "/".join(["/repos", repo_user, repo_name, "issues", issue, "comments"])
         log.msg(f"{self.name}.createStatus: INFO: http.post({url})")
 
-        # Never use debug=True in GitHubStatusPush and inherited classes.
-        # It will cause unexpected exceptions inside HTTP client service.
-
-        ret = yield self._http.post(url, json=payload)
+        if props:
+            headers = yield self._get_auth_header(props) # 4.x
+            ret = yield self._http.post(url, json=payload, headers=headers)
+        else:
+            ret = yield self._http.post(url, json=payload)
         return ret
 
 
@@ -430,6 +428,7 @@ class LLVMFailGitHubLabeler(LLVMFailGitHubReporter):
         repo_name,
         sha,
         state,
+        props=None, # 4.x
         target_url=None,
         context=None,
         issue=None,
@@ -451,8 +450,9 @@ class LLVMFailGitHubLabeler(LLVMFailGitHubReporter):
         url = "/".join(["/repos", repo_user, repo_name, "issues", issue, "labels"])
         log.msg(f"{self.name}.createStatus: INFO: http.post({url}), label={description}")
 
-        # Never use debug=True in GitHubStatusPush and inherited classes.
-        # It will cause unexpected exceptions inside HTTP client service.
-
-        ret = yield self._http.post(url, json=payload)
+        if props:
+            headers = yield self._get_auth_header(props) # 4.x
+            ret = yield self._http.post(url, json=payload, headers=headers)
+        else:
+            ret = yield self._http.post(url, json=payload)
         return ret


### PR DESCRIPTION
- buildbot.steps.shell.SetProperty has been renamed to SetPropertyFromCommand.
- buildbot.interfaces.WorkerTooOldError has been renamed to WorkerSetupError, but it is unused at all.
- BuildStatusGenerator subject parameter has been deprecated: please configure subject in the message formatter.
- LLVMFailBuildGenerator argument add_logs have been deprecated. Please use want_logs_content of the passed message formatter. 

Also GitHubStatusPush.createStatus() in 4.x contains the new parameter `props`. Add `props` to LLVMFailBuildGenerator.createStatus() and LLVMFailGitHubLabeler.createStatus() to avoid builtins.TypeError: LLVMFailGitHubReporter.createStatus() got an unexpected keyword argument 'props' on buildbot 4.x.