### PR TITLE
Remove flang-aarch64-debug-reverse-iteration

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2288,22 +2288,6 @@ all += [
                         "-DCMAKE_BUILD_TYPE=Release",
                     ])},
 
-    {'name' : "flang-aarch64-debug-reverse-iteration",
-    'tags'  : ["flang", "rev_iter"],
-    'workernames' : ["linaro-flang-aarch64-debug-reverse-iteration"],
-    'builddir': "flang-aarch64-debug-reverse-iteration",
-    'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
-                    clean=True,
-                    checks=['check-flang','check-flang-rt'],
-                    depends_on_projects=['llvm','mlir','clang','flang','flang-rt','openmp'],
-                    extra_configure_args=[
-                        "-DLLVM_TARGETS_TO_BUILD=AArch64",
-                        "-DCMAKE_BUILD_TYPE=Debug",
-                        "-DCMAKE_CXX_STANDARD=17",
-                        "-DLLVM_USE_LINKER=lld",
-                        "-DLLVM_REVERSE_ITERATION:BOOL=ON",
-                    ])},
-
     {'name' : "flang-aarch64-libcxx",
     'tags'  : ['flang'],
     'workernames' : ["linaro-flang-aarch64-libcxx"],

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -31,7 +31,6 @@ def get_all():
         create_worker("linaro-flang-aarch64-dylib", max_builds=1),
         create_worker("linaro-flang-aarch64-sharedlibs", max_builds=1),
         create_worker("linaro-flang-aarch64-out-of-tree", max_builds=1),
-        create_worker("linaro-flang-aarch64-debug-reverse-iteration", max_builds=1),
         create_worker("linaro-flang-aarch64-libcxx", max_builds=1),
         create_worker("linaro-flang-aarch64-release", max_builds=1),
         create_worker("linaro-flang-aarch64-rel-assert", max_builds=1),


### PR DESCRIPTION
It tests a very specific scenario and the worker is not being able to
keep up with the build requests.

The server that hosts it is also low on memory and disk space.
