### PR TITLE
[BazelBot] Multiple retries on failed push

### DIFF
--- a/google-bazel-bot/bazel-bot/bazelbot_server_main.py
+++ b/google-bazel-bot/bazel-bot/bazelbot_server_main.py
@@ -12,7 +12,7 @@ parser.add_argument(
 parser.add_argument("--poll_interval", type=int, help="Polling interval", default=120)
 parser.add_argument("--create_prs", action="store_true", help="Whether to create PRs.")
 parser.add_argument(
-    "--log_level", default="INFO", help="Set the logging level -- WARNING, INFO, DEBUG",
+    "--log_level", default="INFO", help="Set the logging level -- WARNING, INFO, DEBUG"
 )
 parser.add_argument(
     "--test_commits", type=str, help="File path containing commits to test."

--- a/google-bazel-bot/bazel-bot/bazelbot_server_main.py
+++ b/google-bazel-bot/bazel-bot/bazelbot_server_main.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 import sys
 
 import bazelbot_server
@@ -12,7 +13,9 @@ parser.add_argument(
 parser.add_argument("--poll_interval", type=int, help="Polling interval", default=120)
 parser.add_argument("--create_prs", action="store_true", help="Whether to create PRs.")
 parser.add_argument(
-    "--log_level", default="INFO", help="Set the logging level -- WARNING, INFO, DEBUG"
+    "--log_level",
+    default=os.environ.get("LOG_LEVEL", "INFO"),
+    help="Set the logging level -- WARNING, INFO, DEBUG",
 )
 parser.add_argument(
     "--test_commits", type=str, help="File path containing commits to test."

--- a/google-bazel-bot/bazel-bot/bazelbot_server_main.py
+++ b/google-bazel-bot/bazel-bot/bazelbot_server_main.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-import os
 import sys
 
 import bazelbot_server
@@ -13,9 +12,7 @@ parser.add_argument(
 parser.add_argument("--poll_interval", type=int, help="Polling interval", default=120)
 parser.add_argument("--create_prs", action="store_true", help="Whether to create PRs.")
 parser.add_argument(
-    "--log_level",
-    default=os.environ.get("LOG_LEVEL", "INFO"),
-    help="Set the logging level -- WARNING, INFO, DEBUG",
+    "--log_level", default="INFO", help="Set the logging level -- WARNING, INFO, DEBUG",
 )
 parser.add_argument(
     "--test_commits", type=str, help="File path containing commits to test."

--- a/google-bazel-bot/bazel-bot/bazelbot_server_test.py
+++ b/google-bazel-bot/bazel-bot/bazelbot_server_test.py
@@ -93,6 +93,66 @@ class TestBazelBotServer(unittest.TestCase):
         self.assertEqual(mock_prs[0].state, "closed")
         self.assertEqual(mock_prs[1].state, "closed")
 
+    @mock.patch("utils.git.Repo")
+    @mock.patch("utils.github.GithubIntegration")
+    @mock.patch("utils.github.Auth")
+    @mock.patch("os.path.exists")
+    @mock.patch("utils.time.sleep")
+    def test_local_git_repo_push_retry(
+        self, mock_sleep, mock_exists, github_mock, auth_mock, mock_repo
+    ):
+        mock_exists.return_value = False
+        creds = mock.MagicMock()
+        creds.gh_fork_repo_name = "fork/repo"
+        creds.gh_pr_repo_name = "pr/repo"
+        creds.gh_app_id = "app_id"
+        creds.gh_app_private_key = "app_private_key"
+
+        repo = utils.LocalGitRepo("/path/to/repo", creds, can_create_pr=True)
+        repo_instance = mock_repo.return_value
+
+        # Setup mocks for getting open PRs.
+        class MockPullRequest:
+            def __init__(self):
+                setattr(self, "state", "open")
+
+            def edit(self, state: str) -> None:
+                setattr(self, "state", state)
+
+            @property
+            def url(self) -> str:
+                return "PullRequestMockObjectURL"
+
+        mock_prs = [MockPullRequest()]
+        repo.gh_pr_repo.get_issues = mock.MagicMock()
+        repo.gh_pr_repo.get_issues.return_value = mock_prs
+
+        # Scenario 1: Push fails always, should retry 3 times and return False
+        repo_instance.git.push.side_effect = Exception("Push failed")
+
+        result = repo.push_fix(utils.BuildInfo("commit_hash"), True)
+
+        self.assertFalse(result)
+        self.assertEqual(repo_instance.git.push.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+        repo.gh_pr_repo.create_pull.assert_not_called()
+
+        # Reset mocks for next scenario
+        repo_instance.git.push.reset_mock()
+        mock_sleep.reset_mock()
+        repo.gh_pr_repo.create_pull.reset_mock()
+        repo_instance.git.push.side_effect = None
+
+        # Scenario 2: Push fails first time, succeeds second time
+        repo_instance.git.push.side_effect = [Exception("Push failed"), None]
+
+        result = repo.push_fix(utils.BuildInfo("commit_hash"), True)
+
+        self.assertTrue(result)
+        self.assertEqual(repo_instance.git.push.call_count, 2)
+        self.assertEqual(mock_sleep.call_count, 1)
+        repo.gh_pr_repo.create_pull.assert_called_once()
+
     def test_local_build_processor(self):
         cmd_processor = mock.MagicMock()
         git_repo = mock.MagicMock()

--- a/google-bazel-bot/bazel-bot/bazelbot_server_test.py
+++ b/google-bazel-bot/bazel-bot/bazelbot_server_test.py
@@ -128,7 +128,9 @@ class TestBazelBotServer(unittest.TestCase):
         repo.gh_pr_repo.get_issues.return_value = mock_prs
 
         # Scenario 1: Push fails always, should retry 3 times and return False
-        repo_instance.git.push.side_effect = Exception("Push failed")
+        repo_instance.git.push.side_effect = utils.git.GitCommandError(
+            "git push", 1, "Push failed"
+        )
 
         result = repo.push_fix(utils.BuildInfo("commit_hash"), True)
 
@@ -144,7 +146,10 @@ class TestBazelBotServer(unittest.TestCase):
         repo_instance.git.push.side_effect = None
 
         # Scenario 2: Push fails first time, succeeds second time
-        repo_instance.git.push.side_effect = [Exception("Push failed"), None]
+        repo_instance.git.push.side_effect = [
+            utils.git.GitCommandError("git push", 1, "Push failed"),
+            None,
+        ]
 
         result = repo.push_fix(utils.BuildInfo("commit_hash"), True)
 

--- a/google-bazel-bot/bazel-bot/utils.py
+++ b/google-bazel-bot/bazel-bot/utils.py
@@ -279,7 +279,7 @@ class LocalGitRepo:
                 )
                 try:
                     self.repo.delete_remote(self.remote_name)
-                except Exception as e:
+                except git.GitCommandError as e:
                     logger.debug(f"Failed to delete remote (might not exist): {e}")
 
                 access_token = self.fork_github_integration.get_access_token(
@@ -324,7 +324,7 @@ class LocalGitRepo:
                 )
                 logger.info(f"Pull Request Created: {pr.html_url}")
                 return True
-            except Exception as e:
+            except (git.GitCommandError, github.GithubException) as e:
                 logger.warning(f"Attempt {attempt + 1} to push fix failed: {e}")
                 if attempt < max_retries - 1:
                     logger.info(f"Retrying in {delay} seconds...")

--- a/google-bazel-bot/bazel-bot/utils.py
+++ b/google-bazel-bot/bazel-bot/utils.py
@@ -268,56 +268,71 @@ class LocalGitRepo:
             create_pr = self.can_create_pr
         commit_hash = build_data.commit
         branch_name = self.get_branch_name(commit_hash)
-        try:
-            logger.info(f"Pushing branch {branch_name} to remote...")
-            self.repo.delete_remote(self.remote_name)
-            access_token = self.fork_github_integration.get_access_token(
-                self.gh_fork_installation.id
-            ).token
-            self.repo.create_remote(
-                self.remote_name,
-                f"https://x-access-token:{access_token}@github.com/{self.creds.gh_fork_repo_name}.git",
-            )
-            if not self.repo.git.push(
-                "--set-upstream", self.remote_name, f"HEAD:{branch_name}", "-f"
-            ):
-                logger.error("Failed to push branch.")
-                return False
 
-            if not create_pr:
-                logger.info("PR creation disabled. Skipping PR creation.")
+        max_retries = 3
+        delay = 10
+
+        for attempt in range(max_retries):
+            try:
                 logger.info(
-                    f"Pull request can be created at: https://github.com/llvm/llvm-project/compare/main...{self.creds.gh_fork_user}:llvm-project:{branch_name}?expand=1"
+                    f"Pushing branch {branch_name} to remote (attempt {attempt + 1}/{max_retries})..."
                 )
+                try:
+                    self.repo.delete_remote(self.remote_name)
+                except Exception as e:
+                    logger.debug(f"Failed to delete remote (might not exist): {e}")
+
+                access_token = self.fork_github_integration.get_access_token(
+                    self.gh_fork_installation.id
+                ).token
+                self.repo.create_remote(
+                    self.remote_name,
+                    f"https://x-access-token:{access_token}@github.com/{self.creds.gh_fork_repo_name}.git",
+                )
+                logger.debug(f"New remote {self.remote_name} created.")
+                self.repo.git.push(
+                    "--set-upstream", self.remote_name, f"HEAD:{branch_name}", "-f"
+                )
+
+                if not create_pr:
+                    logger.info("PR creation disabled. Skipping PR creation.")
+                    logger.info(
+                        f"Pull request can be created at: https://github.com/llvm/llvm-project/compare/main...{self.creds.gh_fork_user}:llvm-project:{branch_name}?expand=1"
+                    )
+                    return True
+
+                # Close any leftover PRs from previous fixes that were never merged.
+                self.close_existing_prs()
+
+                # This requires the Github app installation used for authentication
+                # to have pull-request:write access.
+                logger.info(
+                    f"Creating Pull Request for branch {branch_name} from {self.creds.gh_fork_repo_name} to {self.creds.gh_pr_repo_name}..."
+                )
+                buildkite_url = build_data.buildkite_url
+                pr_body = (
+                    f"This fixes {commit_hash}.\n\n"
+                    f"Buildkite error link: {buildkite_url}\n"
+                )
+
+                pr = self.gh_pr_repo.create_pull(
+                    title=f"[Bazel] Fixes {commit_hash[:7]}",
+                    body=pr_body,
+                    head=f"{self.creds.gh_fork_user}:{branch_name}",
+                    base=self.main_branch,
+                    maintainer_can_modify=False,
+                )
+                logger.info(f"Pull Request Created: {pr.html_url}")
                 return True
-
-            # Close any leftover PRs from previous fixes that were never merged.
-            self.close_existing_prs()
-
-            # This requires the Github app installation used for authentication
-            # to have pull-request:write access.
-            logger.info(
-                f"Creating Pull Request for branch {branch_name} from {self.creds.gh_fork_repo_name} to {self.creds.gh_pr_repo_name}..."
-            )
-            buildkite_url = build_data.buildkite_url
-            pr_body = (
-                f"This fixes {commit_hash}.\n\n"
-                f"Buildkite error link: {buildkite_url}\n"
-            )
-
-            pr = self.gh_pr_repo.create_pull(
-                title=f"[Bazel] Fixes {commit_hash[:7]}",
-                body=pr_body,
-                head=f"{self.creds.gh_fork_user}:{branch_name}",
-                base=self.main_branch,
-                maintainer_can_modify=False,
-            )
-            logger.info(f"Pull Request Created: {pr.html_url}")
-        except Exception as e:
-            logger.error(f"Failed to push or create PR: {e}")
-            return False
-
-        return True
+            except Exception as e:
+                logger.warning(f"Attempt {attempt + 1} to push fix failed: {e}")
+                if attempt < max_retries - 1:
+                    logger.info(f"Retrying in {delay} seconds...")
+                    time.sleep(delay)
+                else:
+                    logger.error("All attempts to push fix failed.")
+                    return False
+        return False
 
 
 class BuildState(enum.Enum):
@@ -340,7 +355,6 @@ class BuildInfo:
         if self.build_number is not None:
             return f"https://buildkite.com/llvm-project/upstream-bazel/builds/{self.build_number}"
         return f"https://buildkite.com/llvm-project/upstream-bazel/builds?commit={self.commit}"
-
 
 
 class BuildProcessor(abc.ABC):


### PR DESCRIPTION
We are encountering GitHub 403 errors intermittently when pushing fixes to the branch. It may be GitHub server hiccup. Implement multiple retries with delay in such scenarios.