### PR TITLE
Remove cross-project-tests from x86 darwin bot

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -1083,12 +1083,12 @@ all = [
                         "-DLLVM_ENABLE_WERROR=OFF"])},
 
     {'name': "llvm-clang-x86_64-darwin",
-    'tags'  : ["llvm", "clang", "clang-tools-extra", "lld", "cross-project-tests"],
+    'tags'  : ["llvm", "clang", "clang-tools-extra", "lld"],
     'workernames': ["doug-worker-3"],
     'builddir': "x86_64-darwin",
     'factory': UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
-                    depends_on_projects=['llvm','clang','clang-tools-extra','lld','cross-project-tests'],
+                    depends_on_projects=['llvm','clang','clang-tools-extra','lld'],
                     extra_configure_args=[
                         "-DCMAKE_C_COMPILER=clang",
                         "-DCMAKE_CXX_COMPILER=clang++",


### PR DESCRIPTION
Recently the x86 darwin bot has been showing random failures on the cross-project test `debuginfo-tests/llgdb-tests/nrvo-string.cpp` which is making the bot very noisy. I don't have time to debug the issue so I'm just going to remove it from the tests run by the bot.