### PR TITLE
Update email for release-no-assertions-warnings bot

### DIFF
--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -684,7 +684,7 @@ def getReporters():
         reporters.MailNotifier(
             fromaddr = status_email_fromaddr,
             sendToInterestedUsers=False,
-            extraRecipients = ["llvm-presubmit-infra@google.com"],
+            extraRecipients = ["google-integrate-buildbot@google.com"],
             generators = [
                 utils.LLVMDefaultBuildStatusGenerator(
                     builders = [


### PR DESCRIPTION
Use a more specific group rather than the more generic one so that notifications go to the right people.