### PR TITLE
[BazelBot] Allow reaping zombie processes

### DIFF
--- a/google-bazel-bot/bazel-fixer-bot.yaml
+++ b/google-bazel-bot/bazel-fixer-bot.yaml
@@ -8,6 +8,7 @@ spec:
   selector:
     matchLabels:
       app: bazel-fixer-bot
+  shareProcessNamespace: true
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/google-bazel-bot/bazel-fixer-bot.yaml
+++ b/google-bazel-bot/bazel-fixer-bot.yaml
@@ -8,6 +8,7 @@ spec:
   selector:
     matchLabels:
       app: bazel-fixer-bot
+  # Allow reaping zombies to restart Bazel Java server
   shareProcessNamespace: true
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
The java server that Bazel starts can sometimes become zombie. Since PID 1 here is bazel_server_main.py which doesn't have any capability to reap zombie processes, the java server process remains alive. Subsequent Bazel builds then keep waiting for this to die and we are stuck in an infinite loop with bazelbot not doing anything useful.

shareProcessNamespace makes /pause as PID 1 which allows reaping zombie processes.