### PR TITLE
[Zorg] Mark factory "always clean build" if requested for `UnifiedTreeBuilder.getCmakeExBuildFactory `.

### DIFF
--- a/zorg/buildbot/builders/UnifiedTreeBuilder.py
+++ b/zorg/buildbot/builders/UnifiedTreeBuilder.py
@@ -928,6 +928,8 @@ def getCmakeExBuildFactory(
             src_to_build_dir    = src_to_build_dir,
             obj_dir             = obj_dir,
             install_dir         = install_dir,
+            # mark factory as "always does clean build" if requested
+            clean               = clean,
         )
 
     f.addSteps([


### PR DESCRIPTION

To allow a correct buildrequest collapse for the generated builders, properly mark the factory with "always does clean build" attribute as it requested.