### PR TITLE
Add notification recepients for `llvm-clang-ubuntu-x-aarch64-pauthtest` builder.

### DIFF
--- a/buildbot/osuosl/master/config/status.py
+++ b/buildbot/osuosl/master/config/status.py
@@ -325,7 +325,8 @@ def getReporters():
                         "llvm-nvptx-nvidia-win", "llvm-nvptx64-nvidia-win",
                         "lldb-remote-linux-ubuntu", "lldb-remote-linux-win",
                         "lldb-x86_64-win",
-                        "llvm-clang-ubuntu-x-aarch64-pac-ret"])
+                        "llvm-clang-ubuntu-x-aarch64-pac-ret",
+                        "llvm-clang-ubuntu-x-aarch64-pauthtest"])
             ]),
         reporters.MailNotifier(
             fromaddr = status_email_fromaddr,
@@ -355,7 +356,8 @@ def getReporters():
             generators = [
                 utils.LLVMDefaultBuildStatusGenerator(
                     builders = [
-                        "llvm-clang-ubuntu-x-aarch64-pac-ret"])
+                        "llvm-clang-ubuntu-x-aarch64-pac-ret",
+                        "llvm-clang-ubuntu-x-aarch64-pauthtest"])
             ]),
         reporters.MailNotifier(
             fromaddr = status_email_fromaddr,


### PR DESCRIPTION
Provide build failure notifications for the builder.