### PR TITLE
[Buildbot][z/OS] Add z/OS s390x builder and worker (zos-s390x-1)

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -835,6 +835,33 @@ all = [
                         "-DLLVM_CCACHE_BUILD=ON",
                         "-DLLVM_ENABLE_ASSERTIONS=ON"])},
 
+    {'name' : "llvm-s390x-zos",
+    'collapseRequests' : False,
+    'tags'  : ["llvm", "zos", "s390x"],
+    'workernames' : ["zos-s390x-1"],
+    'builddir': "llvm-s390x-zos",
+    'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                    depends_on_projects=['llvm'],
+                    checks=['check-llvm'],
+                    clean=True,
+                    extra_configure_args=[
+                        '-DCMAKE_BUILD_TYPE=Release',
+                        '-DLLVM_COMPILER_CHECKED=1',
+                        '-DHAVE_CXX_ATOMICS_WITHOUT_LIB=ON',
+                        '-DHAVE_CXX_ATOMICS64_WITHOUT_LIB=ON',
+                        '-DLLVM_ENABLE_ASSERTIONS=ON',
+                        '-DLLVM_APPEND_VC_REV=OFF',
+                        '-DLLVM_TOOL_GOLD_BUILD=OFF',
+                        '-DLLVM_ENABLE_WERROR=ON',
+                        '-DCMAKE_AR=/VERSYSB/bin/ar',
+                        '-DLLVM_TARGETS_TO_BUILD=SystemZ',
+                    ],
+                    env={
+                        'CC': '/usr/lpp/IBM/cnw/v2r2/openxl/bin/ibm-clang64',
+                        'CXX': '/usr/lpp/IBM/cnw/v2r2/openxl/bin/ibm-clang++64',
+                        'TMPDIR': '/data/devuser/tmp/',
+                    })},
+
     {'name' : 'clang-sparc64-linux',
     'tags'  : ['clang'],
     'workernames' : ['debian-stadler-sparc64'],

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -120,6 +120,9 @@ def get_all():
         # IBM z13 (s390x), Ubuntu 16.04.2
         create_worker("systemz-1", properties={'jobs': 4, 'vcs_protocol': 'https'}, max_builds=4),
 
+        # IBM z15, z/OS 3.1
+        create_worker("zos-s390x-1", properties={'jobs': 4, 'vcs_protocol': 'https'}, max_builds=1),
+
         # Windows Server 2012 x86_64 16-core GCE instance
         create_worker("sanitizer-windows", properties={'jobs': 16}, max_builds=1),
 


### PR DESCRIPTION
This is a PR adding a new buildbot worker and builder for z/OS on s390x.

## Worker (`workers.py`)
- Name: `zos-s390x-1`
- OS: z/OS 3.1 (OS/390 29.00) s390x
- Hardware: IBM z15 (Machine Type 8561)
- Compiler: IBM Open XL C/C++ 2.2 for z/OS, version 2.2.0.0, clang version 21.1.1
- CMake: 3.27.8

## Builder (`builders.py`)
- Name: `llvm-s390x-zos`
- Builds: `llvm` with `check-llvm`
- Build type: Release with Assertions
- Target: SystemZ
- `collapseRequests: False`