### PR TITLE
[zorg] Add Arm-managed worker for clang-aarch64-quick

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -418,7 +418,7 @@ all = [
     ## AArch64 check-all
     {'name' : "clang-aarch64-quick",
     'tags'  : ["clang"],
-    'workernames' : ["linaro-clang-aarch64-quick"],
+    'workernames' : ["linaro-clang-aarch64-quick", "arm-bbot-clang-aarch64-quick"],
     'builddir': "clang-aarch64-quick",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=False,

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -584,4 +584,6 @@ def get_all():
                 "nvhpc-devops@nvidia.com"
             ],
         ),
+        # Arm-managed buildbot
+        create_worker("arm-bbot-clang-aarch64-quick", max_builds=1),
         ]


### PR DESCRIPTION
We are migrating the clang-aarch64-quick builder from Linaro-hosted infrastructure to Arm-hosted infrastructure.

Add the new Arm-managed worker to the existing clang-aarch64-quick builder. Reusing the existing builder avoids introducing a duplicate builder during the transition and keeps the builder name unchanged.

The new worker will initially connect to the silent Buildbot master for validation. Once the existing Linaro worker has been taken offline, the Arm worker can be connected to the normal master.

The Linaro worker configuration can be removed separately, once the migration is complete.

We intend to migrate more bots in the similar fashion, once this one is successful.