### PR TITLE
Add Intel Windows GPU machine

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2083,7 +2083,6 @@ all += [
                         "-DRUNTIMES_spirv64-unknown-unknown_LLVM_ENABLE_RUNTIMES=compiler-rt",
                         "-DRUNTIMES_spirv64-unknown-unknown_COMPILER_RT_INCLUDE_TESTS=OFF",
                         "-DOFFLOAD_INCLUDE_TESTS=ON",
-
                     ])},
 
     {'name' : "intel-sycl-gpu-win",

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2082,6 +2082,8 @@ all += [
                         "-DRUNTIMES_spirv64-intel_LLVM_ENABLE_RUNTIMES=openmp",
                         "-DRUNTIMES_spirv64-unknown-unknown_LLVM_ENABLE_RUNTIMES=compiler-rt",
                         "-DRUNTIMES_spirv64-unknown-unknown_COMPILER_RT_INCLUDE_TESTS=OFF",
+                        "-DOFFLOAD_INCLUDE_TESTS=ON",
+
                     ])},
 
     {'name' : "intel-sycl-gpu-win",
@@ -2107,6 +2109,7 @@ all += [
                         "-DLIBOMPTARGET_PLUGINS_TO_BUILD=level_zero",
                         "-DLIBOMPTARGET_DLOPEN_PLUGINS=level_zero",
                         "-DLIBOMPTARGET_ENABLE_DEBUG=ON",
+                        "-DOFFLOAD_INCLUDE_TESTS=ON",
                     ])},
 
 # Whole-toolchain builders.

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2087,7 +2087,7 @@ all += [
     {'name' : "intel-sycl-gpu-win",
     'tags'  : ["sycl"],
     'collapseRequests': False,
-    'workernames' : ["intel-sycl-gpu-win-01"],
+    'workernames' : ["intel-win-bmg-01"],
     'builddir': "intel-sycl-gpu-win",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,

--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -2061,7 +2061,7 @@ all += [
 
     {'name' : "intel-sycl-gpu",
     'tags'  : ["sycl"],
-    'collapseRequests': False,     
+    'collapseRequests': False,
     'workernames' : ["intel-sycl-gpu-01"],
     'builddir': "intel-sycl-gpu",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
@@ -2084,6 +2084,30 @@ all += [
                         "-DRUNTIMES_spirv64-unknown-unknown_COMPILER_RT_INCLUDE_TESTS=OFF",
                     ])},
 
+    {'name' : "intel-sycl-gpu-win",
+    'tags'  : ["sycl"],
+    'collapseRequests': False,
+    'workernames' : ["intel-sycl-gpu-win-01"],
+    'builddir': "intel-sycl-gpu-win",
+    'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
+                    clean=True,
+                    checks=['check-offload'],
+                    enable_runtimes=['offload'],
+                    depends_on_projects=['llvm', 'clang', 'offload'],
+                    extra_configure_args=[
+                        "-DCMAKE_C_COMPILER=clang-cl",
+                        "-DCMAKE_CXX_COMPILER=clang-cl",
+                        "-DCMAKE_LINKER=lld-link",
+                        "-DCMAKE_RC_COMPILER=llvm-rc",
+                        "-DCMAKE_MT=llvm-mt",
+                        "-DLLVM_CCACHE_BUILD=ON",
+                        "-DLLVM_TARGETS_TO_BUILD=host;SPIRV",
+                        "-DLLVM_ENABLE_ASSERTIONS=ON",
+                        "-DLLVM_INSTALL_UTILS=ON",
+                        "-DLIBOMPTARGET_PLUGINS_TO_BUILD=level_zero",
+                        "-DLIBOMPTARGET_DLOPEN_PLUGINS=level_zero",
+                        "-DLIBOMPTARGET_ENABLE_DEBUG=ON",
+                    ])},
 
 # Whole-toolchain builders.
 

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -376,6 +376,7 @@ def get_all():
 
         # SYCL GPU
         create_worker("intel-sycl-gpu-01", properties={'jobs': 192}, max_builds=1),
+        create_worker("intel-sycl-gpu-win-01", properties={'jobs': 128}, max_builds=1),
 
         # Containerized builder for third party libraries using HIP
         create_worker("AMD-bb-w-03", properties={'jobs': 32}, max_builds=1),

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -376,7 +376,7 @@ def get_all():
 
         # SYCL GPU
         create_worker("intel-sycl-gpu-01", properties={'jobs': 192}, max_builds=1),
-        create_worker("intel-sycl-gpu-win-01", properties={'jobs': 128}, max_builds=1),
+        create_worker("intel-win-bmg-01", properties={'jobs': 128}, max_builds=1),
 
         # Containerized builder for third party libraries using HIP
         create_worker("AMD-bb-w-03", properties={'jobs': 32}, max_builds=1),


### PR DESCRIPTION
Manually tested this config on the actual machine and the builds complete in ~3 min which should allow us to keep up with traffic.

Once `libsycl` can be compiled/tested for Windows I will add support for that, but for now, just test `liboffload`.