### PR TITLE
[zorg] Add Arm-managed workers for AArch64 SVE/SVE2 builders

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -524,7 +524,7 @@ all = [
     # AArch64 Clang+LLVM+RT+LLD check-all + flang + test-suite 2-stage w/SVE-Vector-Length-Agnostic
     {'name' : "clang-aarch64-sve-vla-2stage",
     'tags'  : ["clang"],
-    'workernames' : ["linaro-g3-01", "linaro-g3-02", "linaro-g3-03", "linaro-g3-04"],
+    'workernames' : ["linaro-g3-01", "linaro-g3-02", "linaro-g3-03", "linaro-g3-04", "arm-bbot-clang-aarch64-sve-vla-2stage"],
     'builddir': "clang-aarch64-sve-vla-2stage",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=True,
@@ -572,7 +572,7 @@ all = [
     # AArch64 Clang+LLVM+RT+LLD check-all + flang + test-suite 2-stage w/SVE-Vector-Length-Specific
     {'name' : "clang-aarch64-sve-vls-2stage",
     'tags'  : ["clang"],
-    'workernames' : ["linaro-g3-01", "linaro-g3-02", "linaro-g3-03", "linaro-g3-04"],
+    'workernames' : ["linaro-g3-01", "linaro-g3-02", "linaro-g3-03", "linaro-g3-04", "arm-bbot-clang-aarch64-sve-vls-2stage"],
     'builddir': "clang-aarch64-sve-vls-2stage",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=True,
@@ -600,7 +600,7 @@ all = [
 
     {'name' : "clang-aarch64-sve2-vla",
     'tags'  : ["clang"],
-    'workernames' : ["linaro-g4-01", "linaro-g4-02"],
+    'workernames' : ["linaro-g4-01", "linaro-g4-02", "arm-bbot-clang-aarch64-sve2-vla"],
     'builddir': "clang-aarch64-sve2-vla",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=False,
@@ -624,7 +624,7 @@ all = [
     # (not just SVE) Vector Length Agnostic codegen.
     {'name' : "clang-aarch64-sve2-vla-2stage",
     'tags'  : ["clang"],
-    'workernames' : ["linaro-g4-01", "linaro-g4-02"],
+    'workernames' : ["linaro-g4-01", "linaro-g4-02", "arm-bbot-clang-aarch64-sve2-vla-2stage"],
     'builddir': "clang-aarch64-sve2-vla-2stage",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=True,

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -587,4 +587,8 @@ def get_all():
         ),
         # Arm-managed buildbot
         create_worker("arm-bbot-clang-aarch64-quick", max_builds=1),
+        create_worker("arm-bbot-clang-aarch64-sve-vla-2stage", max_builds=1),
+        create_worker("arm-bbot-clang-aarch64-sve-vls-2stage", max_builds=1),
+        create_worker("arm-bbot-clang-aarch64-sve2-vla", max_builds=1),
+        create_worker("arm-bbot-clang-aarch64-sve2-vla-2stage", max_builds=1),
         ]


### PR DESCRIPTION
We are migrating the AArch64 SVE builders from Linaro-hosted infrastructure to Arm-hosted infrastructure.

Add the new Arm-managed workers to the existing AArch64 SVE/SVE2 builders. Reusing the existing builders avoids introducing duplicate builders during the transition and keeps the builder names unchanged.

The new workers will initially connect to the silent Buildbot master for validation. Once the existing Linaro workers have been taken offline, the Arm workers can be connected to the normal master.

The Linaro worker configuration can be removed separately, once the migration is complete.