### PR TITLE
[Premerge] Switch to regional cluster

### DIFF
--- a/premerge/main.tf
+++ b/premerge/main.tf
@@ -58,7 +58,7 @@ locals {
 module "premerge_cluster_us_central" {
   source                                               = "./gke_cluster"
   cluster_name                                         = "llvm-premerge-cluster-us-central"
-  region                                               = "us-central1-a"
+  region                                               = "us-central1"
   libcxx_machine_type                                  = "n2d-standard-32"
   linux_machine_type                                   = "n2-standard-64"
   windows_machine_type                                 = "n2-standard-32"


### PR DESCRIPTION
Use us-central1 (the whole region) rather than us-central1-a (just the zone) given we are running into GCE resource exhaustion issues when limiting ourselves to the individual zone. This also better matches what we are doing for us-west.