### PR TITLE
[zorg] Add Arm-managed workers for AArch64 Flang, LLDB and GlobalISel

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -461,7 +461,7 @@ all = [
     ## AArch64 run test-suite at -O0 (GlobalISel is now default).
     {'name' : "clang-aarch64-global-isel",
     'tags'  : ["clang"],
-    'workernames' : ["linaro-clang-aarch64-global-isel"],
+    'workernames' : ["linaro-clang-aarch64-global-isel", "arm-bbot-clang-aarch64-global-isel"],
     'builddir': "clang-aarch64-global-isel",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=False,
@@ -1333,7 +1333,7 @@ all = [
 
     {'name' : "lldb-aarch64-ubuntu",
     'tags'  : ["lldb"],
-    'workernames' : ["linaro-lldb-aarch64-ubuntu"],
+    'workernames' : ["linaro-lldb-aarch64-ubuntu", "arm-bbot-lldb-aarch64-ubuntu"],
     'builddir': "lldb-aarch64-ubuntu",
     'factory' : LLDBBuilder.getLLDBCMakeBuildFactory(
                     test=True,
@@ -2346,7 +2346,7 @@ all += [
 
     {'name' : "flang-aarch64-libcxx",
     'tags'  : ['flang'],
-    'workernames' : ["linaro-flang-aarch64-libcxx"],
+    'workernames' : ["linaro-flang-aarch64-libcxx", "arm-bbot-flang-aarch64-libcxx"],
     'builddir': "flang-aarch64-libcxx",
     'factory' : FlangBuilder.getFlangOutOfTreeBuildFactory(
                     checks=['check-flang'],
@@ -2387,7 +2387,7 @@ all += [
 
     {'name' : "flang-aarch64-rel-assert",
     'tags'  : ["flang"],
-    'workernames' : ["linaro-flang-aarch64-rel-assert"],
+    'workernames' : ["linaro-flang-aarch64-rel-assert", "arm-bbot-flang-aarch64-rel-assert"],
     'builddir': "flang-aarch64-rel-assert",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,
@@ -2403,7 +2403,7 @@ all += [
 
     {'name' : "flang-aarch64-latest-gcc",
     'tags'  : ['flang'],
-    'workernames' : ["linaro-flang-aarch64-latest-gcc"],
+    'workernames' : ["linaro-flang-aarch64-latest-gcc", "arm-bbot-flang-aarch64-latest-gcc"],
     'builddir': "flang-aarch64-latest-gcc",
     'factory' : UnifiedTreeBuilder.getCmakeWithNinjaBuildFactory(
                     clean=True,

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -591,4 +591,9 @@ def get_all():
         create_worker("arm-bbot-clang-aarch64-sve-vls-2stage", max_builds=1),
         create_worker("arm-bbot-clang-aarch64-sve2-vla", max_builds=1),
         create_worker("arm-bbot-clang-aarch64-sve2-vla-2stage", max_builds=1),
+        create_worker("arm-bbot-clang-aarch64-global-isel", max_builds=1),
+        create_worker("arm-bbot-lldb-aarch64-ubuntu", max_builds=1),
+        create_worker("arm-bbot-flang-aarch64-latest-gcc", max_builds=1),
+        create_worker("arm-bbot-flang-aarch64-libcxx", max_builds=1),
+        create_worker("arm-bbot-flang-aarch64-rel-assert", max_builds=1),
         ]


### PR DESCRIPTION
We are migrating the AArch64 Flang, LLDB and GlobalISel builders from Linaro-hosted infrastructure to Arm-hosted infrastructure.

Add the new Arm-managed workers to the existing AArch64 Flang, LLDB and GlobalISel builders. Reusing the existing builders avoids introducing duplicate builders during the transition and keeps the builder names unchanged.

The new workers will initially connect to the silent Buildbot master for validation. Once the existing Linaro workers have been taken offline, the Arm workers can be connected to the normal master.

The Linaro worker configuration can be removed separately, once the migration is complete.