### PR TITLE
[CI] Use zonal node pool for us-central linux service

### DIFF
--- a/premerge/main.tf
+++ b/premerge/main.tf
@@ -62,6 +62,7 @@ module "premerge_cluster_us_central" {
   libcxx_machine_type                                  = "n2d-standard-32"
   linux_machine_type                                   = "n2-standard-64"
   windows_machine_type                                 = "n2-standard-32"
+  service_node_pool_locations                          = ["us-central1-a"]
   gcs_bucket_location                                  = "us-central1"
   linux_runners_namespace_name                         = local.linux_runners_namespace_name
   linux_runners_kubernetes_service_account_name        = local.linux_runners_kubernetes_service_account_name


### PR DESCRIPTION
Otherwise we end up with 3 nodes per zone for a total of 9 when we actually only want 3 in total.