### PR TITLE
Complete depends_on_projects for the bot flang-runtime-cuda-gcc

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3208,8 +3208,7 @@ all += [
     'workernames' : ["as-builder-7"],
     'builddir': "flang-runtime-cuda-gcc",
     'factory' : UnifiedTreeBuilder.getCmakeExBuildFactory(
-                    depends_on_projects = ["llvm", "clang", "mlir", "flang"],
-                    enable_runtimes = ["flang-rt", "openmp"],
+                    depends_on_projects = ["llvm", "clang", "mlir", "flang", "flang-rt", "openmp"],
                     clean = True,
                     checks = [],
                     targets = ["flang-rt"],


### PR DESCRIPTION
Note the parameter `enable_runtimes="auto"` by default in UnifiedTreeBuilder.getCmakeExBuildFactory(). So `enable_runtimes` will be constructed automatically from the list `depends_on_projects`:
```
self.enable_runtimes = self.depends_on_projects.intersection(_all_runtimes)
```
where `_all_runtimes = ["compiler-rt", "flang-rt", "libc", "libcxx", "libcxxabi", "libunwind", "openmp"]`