### PR TITLE
[lldb] Add TSan-ified LLDB job to Jenkins

### DIFF
--- a/zorg/jenkins/build.py
+++ b/zorg/jenkins/build.py
@@ -517,6 +517,21 @@ def parse_settings_from_output(working_dir, cmd):
         os.chdir(old_dir)
 
 
+def tsan_lit_filter():
+    """Build a LIT_FILTER regex from the explicit list of tests in
+    lldb-tsan-tests.txt, one test name/path per line."""
+    tests = []
+    with open(os.path.join(here, "lldb-tsan-tests.txt")) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            tests.append(line)
+    if not tests:
+        return None
+    return "|".join(re.escape(test) for test in tests)
+
+
 def lldb_cmake_builder(target, variant=None):
     """Do a CMake build of lldb."""
 
@@ -539,7 +554,7 @@ def lldb_cmake_builder(target, variant=None):
                 '--xunit-xml-output={}'.format(results_file), '-v']
     if conf.max_parallel_tests:
         lit_args.extend(['-j', conf.max_parallel_tests])
-    if variant == 'sanitized':
+    if variant in ('sanitized', 'tsan'):
         lit_args.extend(['--timeout 1200'])
 
     # Construct CMake invocation.
@@ -569,7 +584,11 @@ def lldb_cmake_builder(target, variant=None):
 
     if variant == 'sanitized':
         cmake_cmd.append('-DLLVM_USE_SANITIZER=Address;Undefined')
-        # There is no need to compile the lldb tests with an asanified compiler
+    elif variant == 'tsan':
+        cmake_cmd.append('-DLLVM_USE_SANITIZER=Thread')
+
+    if variant in ('sanitized', 'tsan'):
+        # There is no need to compile the lldb tests with a sanitized compiler
         # if we have a host compiler available.
         if conf.CC():
             cmake_cmd.extend([
@@ -589,7 +608,7 @@ def lldb_cmake_builder(target, variant=None):
 
     cmake_cmd.extend(conf.cmake_flags)
 
-    if variant == "sanitized":
+    if variant in ("sanitized", "tsan"):
         # On macOS, we need to use bootstrapped sanitizer runtimes for sanitized libLTO
         # to be loadable in ld
         def bootstrap_option(x):
@@ -626,7 +645,7 @@ def lldb_cmake_builder(target, variant=None):
 
     if target == 'all' or target == 'build':
         header("Build")
-        run_cmd(conf.lldbbuilddir(), [NINJA, '-v'] + (["stage2"] if variant == 'sanitized' else []))
+        run_cmd(conf.lldbbuilddir(), [NINJA, '-v'] + (["stage2"] if variant in ('sanitized', 'tsan') else []))
         footer()
 
     if target == 'all' or target == 'install':
@@ -639,11 +658,16 @@ def lldb_cmake_builder(target, variant=None):
         check_target = "check-lldb"
         if variant == "debuginfo":
             check_target = "check-debuginfo"
-        elif variant == "sanitized":
+        elif variant in ("sanitized", "tsan"):
             check_target = "stage2-check-lldb"
 
         test_command = ["/usr/bin/env", "TERM=vt100", NINJA, "-v", check_target]
-        run_cmd(conf.lldbbuilddir(), test_command)
+        test_env = {}
+        if variant == "tsan":
+            lit_filter = tsan_lit_filter()
+            if lit_filter:
+                test_env["LIT_FILTER"] = lit_filter
+        run_cmd(conf.lldbbuilddir(), test_command, env=test_env)
         footer()
 
     for test_target in conf.cmake_test_targets:
@@ -953,6 +977,7 @@ KNOWN_BUILDS = [
     'lldb-cmake-debuginfo',
     'lldb-cmake-xcode',
     'lldb-cmake-sanitized',
+    'lldb-cmake-tsan',
     'lldb-cmake-matrix',
     'fetch',
     'artifact',
@@ -1127,6 +1152,8 @@ def main():
             lldb_cmake_builder(args.build_target, 'debuginfo')
         elif args.build_type == 'lldb-cmake-sanitized':
             lldb_cmake_builder(args.build_target, 'sanitized')
+        elif args.build_type == 'lldb-cmake-tsan':
+            lldb_cmake_builder(args.build_target, 'tsan')
         elif args.build_type == 'lldb-cmake-matrix':
             lldb_cmake_builder(args.build_target, 'matrix')
         elif args.build_type == 'lldb-cmake-standalone':

--- a/zorg/jenkins/jobs/jobs/lldb-cmake-tsan
+++ b/zorg/jenkins/jobs/jobs/lldb-cmake-tsan
@@ -1,0 +1,168 @@
+#!/usr/bin/env groovy
+pipeline {
+    options {
+        disableConcurrentBuilds()
+    }
+
+    parameters {
+        string(name: 'LABEL', defaultValue: params.LABEL ?: 'macos-arm64', description: 'Node label to run on')
+
+        string(name: 'GIT_SHA', defaultValue: params.GIT_REVISION ?: '*/main', description: 'Git commit to build.')
+
+        string(name: 'BUILD_TYPE', defaultValue: params.BUILD_TYPE ?: 'Release', description: 'Default CMake build type; one of: Release, Debug, ...')
+
+        booleanParam(name: 'CLEAN', defaultValue: params.CLEAN ?: false, description: 'Wipe the build directory?')
+    }
+
+    agent {
+        node {
+            label params.LABEL
+        }
+    }
+    stages {
+        stage('Print Machine Info') {
+            environment {
+               PATH="/opt/homebrew/bin/:$PATH:/usr/bin:/usr/local/bin"
+            }
+            steps {
+                sh '''
+                arch
+                sw_vers
+                xcodebuild -version
+                cmake --version
+                python3 --version
+                '''
+            }
+        }
+        stage('Checkout') {
+            steps {
+                timeout(30) {
+                    dir('llvm-project') {
+                        checkout([$class: 'GitSCM', branches: [
+                            [name: params.GIT_SHA]
+                        ], userRemoteConfigs: [
+                            [url: 'https://github.com/llvm/llvm-project.git']
+                        ], extensions: [
+                            [$class: 'CloneOption',
+                            noTags: true, timeout: 30]
+                        ]])
+                    }
+                    dir('llvm-zorg') {
+                        checkout([$class: 'GitSCM', branches: [
+                            [name: '*/main']
+                        ], userRemoteConfigs: [
+                            [url: 'https://github.com/llvm/llvm-zorg.git']
+                        ], extensions: [
+                            [$class: 'CloneOption',
+                            reference: '/Users/Shared/llvm-zorg.git']
+                        ]])
+                    }
+                }
+            }
+        }
+        stage('Setup Venv') {
+            environment {
+               PATH="/opt/homebrew/bin/:$PATH:/usr/bin:/usr/local/bin"
+            }
+            steps {
+                sh '''
+                   # Non-incremental, so always delete just in case.
+                   rm -rf lldb-build clang-install host-compiler *.tar.gz
+                   rm -rf venv
+                   python3 -m venv venv
+                   set +u
+                   source ./venv/bin/activate
+                   pip install -r ./llvm-zorg/zorg/jenkins/jobs/requirements.txt
+                   set -u
+               '''
+            }
+        }
+        stage('Build') {
+            environment {
+               PATH="/opt/homebrew/bin/:$PATH:/usr/bin:/usr/local/bin"
+            }
+            steps {
+                timeout(240) {
+                    sh '''
+                    set -u
+                    rm -rf build.properties
+                    source ./venv/bin/activate
+
+                    cd llvm-project
+                    git tag -a -m "First Commit" first_commit 97724f18c79c7cc81ced24239eb5e883bf1398ef || true
+
+                    git_desc=$(git describe --match "first_commit")
+
+                    export GIT_DISTANCE=$(echo ${git_desc} | cut -f 2 -d "-")
+
+                    sha=$(echo ${git_desc} | cut -f 3 -d "-")
+                    export GIT_SHA=${sha:1}
+
+                    cd -
+
+                    export PYTHON_HOME=$(python3 -c "import sys; print(sys.base_prefix)")
+
+                    rm -rf lldb-build/bin/debugserver
+                    # Running too many sanitized threads is too stressful for the kernel and we get >90% system time.
+                    export MAX_PARALLEL_TESTS=1
+
+                    python3 llvm-zorg/zorg/jenkins/monorepo_build.py lldb-cmake-tsan build \
+                      --assertions \
+                      --projects="clang;lld;lldb"  \
+                      --runtimes="libcxx;libcxxabi;libunwind" \
+                      --cmake-type=Release \
+                      --cmake-flag="-DLLDB_USE_SYSTEM_DEBUGSERVER=ON" \
+                      --cmake-flag="-DPython3_EXECUTABLE=$(which python)"
+                    '''
+                }
+            }
+        }
+        stage('Clean Test Results') {
+            environment {
+                PATH="/opt/homebrew/bin/:$PATH:/usr/bin:/usr/local/bin"
+            }
+            steps {
+                timeout(10) {
+                    sh '''
+                    set -u
+
+                    rm -rf test/results.xml
+                    '''
+                }
+            }
+        }
+        stage('Test') {
+            environment {
+               PATH="/opt/homebrew/bin/:$PATH:/usr/bin:/usr/local/bin"
+            }
+            steps {
+                timeout(240) {
+                    sh '''
+                    set -u
+
+                    source ./venv/bin/activate
+
+                    export PYTHON_HOME=$(python3 -c "import sys; print(sys.base_prefix)")
+
+                    rm -rf test/results.xml
+
+                    python3 llvm-zorg/zorg/jenkins/monorepo_build.py lldb-cmake-tsan test --cmake-flag="-DPython3_EXECUTABLE=$(which python)"
+                    '''
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            // ToDo: Restore issue scanner
+            // scanForIssues tool: clang()
+            script {
+                def Junit = new org.swift.Junit()
+                Junit.safeJunit([
+                    testResults: 'test/results.xml'
+                ])
+            }
+        }
+    }
+}

--- a/zorg/jenkins/lldb-tsan-tests.txt
+++ b/zorg/jenkins/lldb-tsan-tests.txt
@@ -1,0 +1,19 @@
+# Explicit list of LLDB tests to run under the lldb-cmake-tsan builder.
+#
+# The expected foramt is one test name per line, matched as a regex against the
+# lit test name.
+
+# Take random tests from different languages/functionality.
+lang/c/enum_types/TestEnumTypes.py
+lang/objc/bitfield_ivars/TestBitfieldIvars.py
+lang/cpp/multiple-inheritance/TestCppMultipleInheritance.py
+functionalities/load_unload/TestLoadUnload.py
+tools/lldb-dap/server/TestDAP_server.py
+
+# related to past TSan issues.
+python_api/was_interrupted/TestDebuggerInterruption.py
+python_api/process/cancel_attach/TestCancelAttach.py
+functionalities/scripted_frame_provider/runlock_reentrant_deadlock/TestRunLockReentrantDeadlock.py
+
+# Those are actually multithreaded tests.
+api/multithreaded

--- a/zorg/jenkins/tsan-tests.txt
+++ b/zorg/jenkins/tsan-tests.txt
@@ -1,0 +1,4 @@
+# Explicit list of LLDB tests to run under the lldb-cmake-tsan builder.
+#
+# The expected foramt is one test name per line, matched as a regex against the
+# lit test name.


### PR DESCRIPTION
* lldb-cmake-tsan is the same contents as the other jobs except that it passes the tsan build mode to build.py

* tsan-tests.txt is a list of LLDB tests that are executed. We don't run the whole test suite as that takes far too long with TSan's overhead. Also, many tests fail right now, so there is anyway no point in running them all. The current small list of tests runs for about 10 minutes on my new machine.