### PR TITLE
[zorg] Add Arm-hosted workers for 32-bit Arm builders

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -355,7 +355,7 @@ all = [
     ## ARMv8 check-all
     {'name' : "clang-armv8-quick",
     'tags'  : ["clang"],
-    'workernames':["linaro-clang-armv8-quick"],
+    'workernames':["linaro-clang-armv8-quick", "arm-bbot-clang-armv8-quick"],
     'builddir':"clang-armv8-quick",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=False,
@@ -403,7 +403,7 @@ all = [
     ## ARMv7 VFPv3 check-all 2-stage
     {'name' : "clang-armv7-vfpv3-2stage",
     'tags'  : ["clang"],
-    'workernames' : ["linaro-clang-armv7-vfpv3-2stage"],
+    'workernames' : ["linaro-clang-armv7-vfpv3-2stage", "arm-bbot-clang-armv7-vfpv3-2stage"],
     'builddir': "clang-armv7-vfpv3-2stage",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=True,
@@ -476,7 +476,7 @@ all = [
     # Sanitizers build disabled due to PR38690
     {'name' : "clang-armv8-lld-2stage",
     'tags'  : ["lld"],
-    'workernames' : ["linaro-clang-armv8-lld-2stage"],
+    'workernames' : ["linaro-clang-armv8-lld-2stage", "arm-bbot-clang-armv8-lld-2stage"],
     'builddir': "clang-armv8-lld-2stage",
     'factory' : ClangBuilder.getClangCMakeBuildFactory(
                     clean=True,
@@ -1345,7 +1345,7 @@ all = [
 
     {'name' : "lldb-arm-ubuntu",
     'tags'  : ["lldb"],
-    'workernames' : ["linaro-lldb-arm-ubuntu"],
+    'workernames' : ["linaro-lldb-arm-ubuntu", "arm-bbot-lldb-arm-ubuntu"],
     'builddir': "lldb-arm-ubuntu",
     'factory' : LLDBBuilder.getLLDBCMakeBuildFactory(
                     test=True,

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -596,4 +596,8 @@ def get_all():
         create_worker("arm-bbot-flang-aarch64-latest-gcc", max_builds=1),
         create_worker("arm-bbot-flang-aarch64-libcxx", max_builds=1),
         create_worker("arm-bbot-flang-aarch64-rel-assert", max_builds=1),
+        create_worker("arm-bbot-clang-armv7-vfpv3-2stage", max_builds=1),
+        create_worker("arm-bbot-clang-armv8-quick", max_builds=1),
+        create_worker("arm-bbot-lldb-arm-ubuntu", max_builds=1),
+        create_worker("arm-bbot-clang-armv8-lld-2stage", max_builds=1),
         ]


### PR DESCRIPTION
As part of the migration from Linaro infrastructure to Arm infrastructure, add new Arm-managed workers for the 32-bit Arm Clang and LLDB builders to the OSUOSL Buildbot configuration.

Add the new Arm-managed workers to the existing ARMv7/ARMv8 Clang and LLDB builders. Reusing the existing builders avoids introducing duplicate builders during the transition and keeps the builder names unchanged.

The new workers will initially connect to the silent Buildbot master for validation. Once the existing Linaro workers have been taken offline, the Arm workers can be connected to the normal master.

The Linaro worker configuration can be removed separately once the migration is complete.