### PR TITLE
[Buildbot][z/OS] Disable threads for z/OS builder and reduce jobs for worker

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -855,6 +855,7 @@ all = [
                         '-DLLVM_ENABLE_WERROR=ON',
                         '-DCMAKE_AR=/VERSYSB/bin/ar',
                         '-DLLVM_TARGETS_TO_BUILD=SystemZ',
+                        '-DLLVM_ENABLE_THREADS=OFF',
                     ],
                     env={
                         'CC': '/usr/lpp/IBM/cnw/v2r2/openxl/bin/ibm-clang64',

--- a/buildbot/osuosl/master/config/workers.py
+++ b/buildbot/osuosl/master/config/workers.py
@@ -121,7 +121,7 @@ def get_all():
         create_worker("systemz-1", properties={'jobs': 4, 'vcs_protocol': 'https'}, max_builds=4),
 
         # IBM z15, z/OS 3.1
-        create_worker("zos-s390x-1", properties={'jobs': 4, 'vcs_protocol': 'https'}, max_builds=1),
+        create_worker("zos-s390x-1", properties={'jobs': 1, 'vcs_protocol': 'https'}, max_builds=1),
 
         # Windows Server 2012 x86_64 16-core GCE instance
         create_worker("sanitizer-windows", properties={'jobs': 16}, max_builds=1),


### PR DESCRIPTION
This PR disables threads for the z/OS builder `llvm-s390x-zos` and reduces the jobs from 4 to 1 for the `zos-s390x-1` worker.