### PR TITLE
Revert "Fix max parallel tests to 1 in LLDB sanitized bots"

### DIFF
--- a/zorg/jenkins/jobs/jobs/lldb-cmake-sanitized
+++ b/zorg/jenkins/jobs/jobs/lldb-cmake-sanitized
@@ -104,7 +104,7 @@ pipeline {
 
                     rm -rf lldb-build/bin/debugserver
                     # Running too many asanified threads is too stressful for the kernel and we get >90% system time.
-                    export MAX_PARALLEL_TESTS=1
+                    export MAX_PARALLEL_TESTS=$(sysctl hw.physicalcpu |awk '{print int(($2+1)/2)}')
 
                     python3 llvm-zorg/zorg/jenkins/monorepo_build.py lldb-cmake-sanitized build \
                       --assertions \


### PR DESCRIPTION
This reverts commit fb01b8d610bf06d1fb51a55c53bf159185b83897.

We now have a better mitigation for this problem in LLDB's LIT runner.