### PR TITLE
The builder configuration adjustment for 'nvhpc-offload-nvgpu-x86_64-linux'.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3251,6 +3251,8 @@ all += [
     'builddir': "nvhpc-offload-nvgpu-x86_64-linux",
     'factory' : UnifiedTreeBuilder.getCmakeExBuildFactory(
                     depends_on_projects = ["llvm", "clang", "mlir", "flang", "lld", "flang-rt", "openmp", "offload", "compiler-rt", "libcxx", "libcxxabi", "libc"],
+                    enable_projects = ["clang", "mlir", "flang", "lld"],
+                    enable_runtimes = ["flang-rt", "openmp", "offload"],
                     clean = True,
                     checks = ["check-offload"],
                     targets = [],


### PR DESCRIPTION
Explicitly specify the lists of the enabled projects (`enable_projects`) and the enabled runtimes (`enable_runtimes`) for the builder. We should not use `auto` for them as we use the `depends_on_projects` parameter to pass all dependencies for all stages.

Ref: #929 