### PR TITLE
The builder configuration adjustment for 'nvhpc-offload-nvgpu-x86_64-linux'.

### DIFF
--- a/buildbot/osuosl/master/config/builders.py
+++ b/buildbot/osuosl/master/config/builders.py
@@ -3255,7 +3255,6 @@ all += [
                     enable_runtimes = ["flang-rt", "openmp", "offload"],
                     clean = True,
                     checks = ["check-offload"],
-                    targets = [],
                     cmake_definitions = {
                         "CMAKE_BUILD_TYPE"              : "Release",
                         "CMAKE_EXPORT_COMPILE_COMMANDS" : "ON",


### PR DESCRIPTION
Use the default build targets for the builder.

ref #929 